### PR TITLE
add fmt.Stringer to the Runnable interface, and adjust mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ and manage them accordingly.
 ```go
 // Runnable represents a service that can be run and stopped
 type Runnable interface {
+    fmt.Stringer
     Run(ctx context.Context) error
     Stop()
 }

--- a/runnables/httpserver/mocks_test.go
+++ b/runnables/httpserver/mocks_test.go
@@ -95,6 +95,15 @@ func (r *MockRunner) configCallback() (*Config, error) {
 	return r.callback()
 }
 
+// String returns a string representation of the MockRunner
+func (r *MockRunner) String() string {
+	config := r.getConfig()
+	if config == nil {
+		return "MockRunner<nil>"
+	}
+	return fmt.Sprintf("MockRunner{listening: %s}", config.ListenAddr)
+}
+
 // reloadConfig implementation similar to Runner's reloadConfig
 func (r *MockRunner) reloadConfig() error {
 	newConfig, err := r.configCallback()

--- a/runnables/mocks/mocks_test.go
+++ b/runnables/mocks/mocks_test.go
@@ -15,19 +15,23 @@ import (
 func TestInterfaceGuards(t *testing.T) {
 	// Create mock instances
 	mockRunnable := mocks.NewMockRunnable()
-	mockRunnableWithReload := mocks.NewMockRunnableWithReload()
+	mockRunnableWithState := mocks.NewMockRunnableWithStatable()
+	mockRunnableWithReload := mocks.NewMockRunnableWithReloadSender()
 
 	// Type assertions to verify mock types implement required interfaces
 	var (
-		// Basic Runnable should implement all three base interfaces
+		// Basic Runnable should implement the base Runnable interface
 		_ supervisor.Runnable   = mockRunnable
 		_ supervisor.Reloadable = mockRunnable
-		_ supervisor.Stateable  = mockRunnable
 
-		// MockRunnableWithReload should implement all interfaces including ReloadSender
+		// MockRunnableWithState should implement the base Runnable interface + Stateable
+		_ supervisor.Runnable   = mockRunnableWithState
+		_ supervisor.Reloadable = mockRunnableWithState
+		_ supervisor.Stateable  = mockRunnableWithState
+
+		// MockRunnableWithReload should implement the base Runnable interface + ReloadSender
 		_ supervisor.Runnable     = mockRunnableWithReload
 		_ supervisor.Reloadable   = mockRunnableWithReload
-		_ supervisor.Stateable    = mockRunnableWithReload
 		_ supervisor.ReloadSender = mockRunnableWithReload
 	)
 

--- a/runnables/mocks/mocks_test.go
+++ b/runnables/mocks/mocks_test.go
@@ -4,21 +4,24 @@ Package mocks_test provides tests to ensure mocks correctly implement all superv
 package mocks_test
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/robbyt/go-supervisor/runnables/mocks"
 	"github.com/robbyt/go-supervisor/supervisor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
-// TestInterfaceGuards uses compile-time type assertions to ensure that mock implementations
-// correctly implement their respective interfaces.
 func TestInterfaceGuards(t *testing.T) {
 	// Create mock instances
 	mockRunnable := mocks.NewMockRunnable()
 	mockRunnableWithState := mocks.NewMockRunnableWithStatable()
 	mockRunnableWithReload := mocks.NewMockRunnableWithReloadSender()
 
-	// Type assertions to verify mock types implement required interfaces
+	// Type assertions to verify mock types implement the correct interfaces
 	var (
 		// Basic Runnable should implement the base Runnable interface
 		_ supervisor.Runnable   = mockRunnable
@@ -34,7 +37,250 @@ func TestInterfaceGuards(t *testing.T) {
 		_ supervisor.Reloadable   = mockRunnableWithReload
 		_ supervisor.ReloadSender = mockRunnableWithReload
 	)
+}
 
-	// This test has no runtime assertions - it just needs to compile successfully.
-	// If the mocks don't properly implement the interfaces, this test will fail to compile.
+// TestMockRunnable tests the basic Runnable implementation
+func TestMockRunnable(t *testing.T) {
+	t.Run("Run method", func(t *testing.T) {
+		// Create a mock with a shorter delay for testing
+		mockRunnable := mocks.NewMockRunnable()
+		mockRunnable.DelayRun = 5 * time.Millisecond
+
+		// Set up expectations
+		expectedErr := errors.New("test error")
+		mockRunnable.On("Run", mock.Anything).Return(expectedErr)
+
+		// Call the method
+		start := time.Now()
+		err := mockRunnable.Run(context.Background())
+		elapsed := time.Since(start)
+
+		// Verify behavior
+		assert.Equal(t, expectedErr, err)
+		assert.GreaterOrEqual(
+			t,
+			elapsed, 5*time.Millisecond,
+			"Run should delay by at least DelayRun duration",
+		)
+		mockRunnable.AssertExpectations(t)
+	})
+
+	t.Run("Stop method", func(t *testing.T) {
+		// Create a mock with a shorter delay for testing
+		mockRunnable := mocks.NewMockRunnable()
+		mockRunnable.DelayStop = 5 * time.Millisecond
+
+		// Set up expectations
+		mockRunnable.On("Stop").Return()
+
+		// Call the method
+		start := time.Now()
+		mockRunnable.Stop()
+		elapsed := time.Since(start)
+
+		// Verify behavior
+		assert.GreaterOrEqual(
+			t,
+			elapsed, 5*time.Millisecond,
+			"Stop should delay by at least DelayStop duration",
+		)
+		mockRunnable.AssertExpectations(t)
+	})
+
+	t.Run("Reload method", func(t *testing.T) {
+		// Create a mock with a shorter delay for testing
+		mockRunnable := mocks.NewMockRunnable()
+		mockRunnable.DelayReload = 5 * time.Millisecond
+
+		// Set up expectations
+		mockRunnable.On("Reload").Return()
+
+		// Call the method
+		start := time.Now()
+		mockRunnable.Reload()
+		elapsed := time.Since(start)
+
+		// Verify behavior
+		assert.GreaterOrEqual(
+			t,
+			elapsed, 5*time.Millisecond,
+			"Reload should delay by at least DelayReload duration",
+		)
+		mockRunnable.AssertExpectations(t)
+	})
+
+	t.Run("String method with mock expectation", func(t *testing.T) {
+		// Create a mock
+		mockRunnable := mocks.NewMockRunnable()
+
+		// Set up expectations
+		mockRunnable.On("String").Return("CustomRunnable")
+
+		// Call the method
+		result := mockRunnable.String()
+
+		// Verify behavior
+		assert.Equal(t, "CustomRunnable", result)
+		mockRunnable.AssertExpectations(t)
+	})
+
+	t.Run("String method default value", func(t *testing.T) {
+		// Create a mock
+		mockRunnable := mocks.NewMockRunnable()
+
+		// Set up expectations to return nil
+		mockRunnable.On("String").Return(nil)
+
+		// Call the method
+		result := mockRunnable.String()
+
+		// Verify default is returned
+		assert.Equal(t, "Runnable", result)
+		mockRunnable.AssertExpectations(t)
+	})
+}
+
+// TestMockRunnableWithStatable tests the MockRunnableWithStatable implementation
+func TestMockRunnableWithStatable(t *testing.T) {
+	t.Run("GetState method", func(t *testing.T) {
+		// Create a mock with a shorter delay for testing
+		mockRunnable := mocks.NewMockRunnableWithStatable()
+		mockRunnable.DelayGetState = 5 * time.Millisecond
+
+		// Set up expectations
+		mockRunnable.On("GetState").Return("running")
+
+		// Call the method
+		start := time.Now()
+		state := mockRunnable.GetState()
+		elapsed := time.Since(start)
+
+		// Verify behavior
+		assert.Equal(t, "running", state)
+		assert.GreaterOrEqual(
+			t,
+			elapsed, 5*time.Millisecond,
+			"GetState should delay by at least DelayGetState duration",
+		)
+		mockRunnable.AssertExpectations(t)
+	})
+
+	t.Run("GetStateChan method", func(t *testing.T) {
+		// Create a mock
+		mockRunnable := mocks.NewMockRunnableWithStatable()
+
+		// Create a test channel
+		testChan := make(chan string, 1)
+		testChan <- "running"
+
+		// Set up expectations
+		mockRunnable.On("GetStateChan", mock.Anything).Return(testChan)
+
+		// Call the method
+		resultChan := mockRunnable.GetStateChan(context.Background())
+
+		// Verify behavior - we should receive the state from the channel
+		state := <-resultChan
+		assert.Equal(t, "running", state)
+		mockRunnable.AssertExpectations(t)
+	})
+
+	t.Run("inherits from base Runnable", func(t *testing.T) {
+		// Create a mock
+		mockRunnable := mocks.NewMockRunnableWithStatable()
+
+		// Set up expectations for base methods
+		mockRunnable.On("Run", mock.Anything).Return(nil)
+		mockRunnable.On("Stop").Return()
+		mockRunnable.On("Reload").Return()
+		mockRunnable.On("String").Return("StatefulService")
+
+		// Call and verify all the inherited methods
+		err := mockRunnable.Run(context.Background())
+		assert.NoError(t, err)
+
+		mockRunnable.Stop()
+		mockRunnable.Reload()
+
+		name := mockRunnable.String()
+		assert.Equal(t, "StatefulService", name)
+
+		mockRunnable.AssertExpectations(t)
+	})
+}
+
+// TestMockRunnableWithReloadSender tests the MockRunnableWithReloadSender implementation
+func TestMockRunnableWithReloadSender(t *testing.T) {
+	t.Run("GetReloadTrigger method", func(t *testing.T) {
+		// Create a mock
+		mockRunnable := mocks.NewMockRunnableWithReloadSender()
+
+		// Create a test channel
+		testChan := make(chan struct{}, 1)
+		testChan <- struct{}{}
+
+		// Set up expectations
+		mockRunnable.On("GetReloadTrigger").Return(testChan)
+
+		// Call the method
+		resultChan := mockRunnable.GetReloadTrigger()
+
+		// Verify behavior - we should receive a signal from the channel
+		select {
+		case <-resultChan:
+			// Success - we received a signal
+		case <-time.After(50 * time.Millisecond):
+			t.Fatal("Did not receive expected signal from reload channel")
+		}
+
+		mockRunnable.AssertExpectations(t)
+	})
+
+	t.Run("inherits from base Runnable", func(t *testing.T) {
+		// Create a mock
+		mockRunnable := mocks.NewMockRunnableWithReloadSender()
+
+		// Set up expectations for base methods
+		mockRunnable.On("Run", mock.Anything).Return(nil)
+		mockRunnable.On("Stop").Return()
+		mockRunnable.On("Reload").Return()
+		mockRunnable.On("String").Return("ReloadingService")
+
+		// Call and verify all the inherited methods
+		err := mockRunnable.Run(context.Background())
+		assert.NoError(t, err)
+
+		mockRunnable.Stop()
+		mockRunnable.Reload()
+
+		name := mockRunnable.String()
+		assert.Equal(t, "ReloadingService", name)
+
+		mockRunnable.AssertExpectations(t)
+	})
+}
+
+// TestFactoryMethods tests the constructor functions for all mock types
+func TestFactoryMethods(t *testing.T) {
+	t.Run("NewMockRunnable creates with default delays", func(t *testing.T) {
+		mock := mocks.NewMockRunnable()
+		assert.Equal(t, 1*time.Millisecond, mock.DelayRun)
+		assert.Equal(t, 1*time.Millisecond, mock.DelayStop)
+		assert.Equal(t, 1*time.Millisecond, mock.DelayReload)
+	})
+
+	t.Run("NewMockRunnableWithStatable creates with default delays", func(t *testing.T) {
+		mock := mocks.NewMockRunnableWithStatable()
+		assert.Equal(t, 1*time.Millisecond, mock.DelayRun)
+		assert.Equal(t, 1*time.Millisecond, mock.DelayStop)
+		assert.Equal(t, 1*time.Millisecond, mock.DelayReload)
+		assert.Equal(t, 1*time.Millisecond, mock.DelayGetState)
+	})
+
+	t.Run("NewMockRunnableWithReloadSender creates with default delays", func(t *testing.T) {
+		mock := mocks.NewMockRunnableWithReloadSender()
+		assert.Equal(t, 1*time.Millisecond, mock.DelayRun)
+		assert.Equal(t, 1*time.Millisecond, mock.DelayStop)
+		assert.Equal(t, 1*time.Millisecond, mock.DelayReload)
+	})
 }

--- a/supervisor/interfaces.go
+++ b/supervisor/interfaces.go
@@ -23,7 +23,7 @@ import (
 
 // Runnable represents a service that can be run and stopped.
 type Runnable interface {
-	fmt.Stringer
+	fmt.Stringer // Runnables needs a String() method to be identifiable in logs
 
 	// Run starts the service with the given context and returns an error if it fails.
 	// Run must be a blocking call that runs the work unit until it is stopped.

--- a/supervisor/interfaces.go
+++ b/supervisor/interfaces.go
@@ -18,10 +18,13 @@ package supervisor
 
 import (
 	"context"
+	"fmt"
 )
 
 // Runnable represents a service that can be run and stopped.
 type Runnable interface {
+	fmt.Stringer
+
 	// Run starts the service with the given context and returns an error if it fails.
 	// Run must be a blocking call that runs the work unit until it is stopped.
 	Run(ctx context.Context) error

--- a/supervisor/reload_test.go
+++ b/supervisor/reload_test.go
@@ -14,7 +14,7 @@ import (
 func TestPIDZero_ReloadManager(t *testing.T) {
 	t.Run("handles reload notifications", func(t *testing.T) {
 		// Setup mock
-		sender := mocks.NewMockRunnableWithReload()
+		sender := mocks.NewMockRunnableWithReloadSender()
 		reloadTrigger := make(chan struct{})
 		stateChan := make(chan string)
 
@@ -52,8 +52,8 @@ func TestPIDZero_ReloadManager(t *testing.T) {
 	})
 
 	t.Run("handles multiple reloads", func(t *testing.T) {
-		sender1 := mocks.NewMockRunnableWithReload()
-		sender2 := mocks.NewMockRunnableWithReload()
+		sender1 := mocks.NewMockRunnableWithReloadSender()
+		sender2 := mocks.NewMockRunnableWithReloadSender()
 
 		reloadTrigger1 := make(chan struct{})
 		reloadTrigger2 := make(chan struct{})
@@ -107,7 +107,7 @@ func TestPIDZero_ReloadManager(t *testing.T) {
 	t.Run("graceful shutdown", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
-		sender := mocks.NewMockRunnableWithReload()
+		sender := mocks.NewMockRunnableWithReloadSender()
 		reloadTrigger := make(chan struct{})
 		stateChan := make(chan string)
 
@@ -147,8 +147,8 @@ func TestPIDZero_ReloadManager(t *testing.T) {
 		mockService1 := mocks.NewMockRunnable()
 		mockService2 := mocks.NewMockRunnable()
 
-		stateChan1 := make(chan string)
-		stateChan2 := make(chan string)
+		mockService1.On("String").Return("ReloadableService1").Maybe()
+		mockService2.On("String").Return("ReloadableService2").Maybe()
 
 		mockService1.On("Reload").Once()
 		mockService2.On("Reload").Once()
@@ -158,11 +158,6 @@ func TestPIDZero_ReloadManager(t *testing.T) {
 
 		mockService1.On("Stop").Once()
 		mockService2.On("Stop").Once()
-
-		mockService1.On("GetState").Return("idle").Maybe()
-		mockService2.On("GetState").Return("idle").Maybe()
-		mockService1.On("GetStateChan", mock.Anything).Return(stateChan1).Maybe()
-		mockService2.On("GetStateChan", mock.Anything).Return(stateChan2).Maybe()
 
 		// Create supervisor with both services
 		ctx, cancel := context.WithCancel(context.Background())

--- a/supervisor/state.go
+++ b/supervisor/state.go
@@ -18,7 +18,6 @@ package supervisor
 
 import (
 	"context"
-	"fmt"
 )
 
 // StateMap is a map of runnable string representation to its current state
@@ -53,7 +52,7 @@ func (p *PIDZero) GetStateMap() StateMap {
 	p.stateMap.Range(func(key, value any) bool {
 		r := key.(Runnable)
 		state := value.(string)
-		stateMap[fmt.Sprintf("%s", r)] = state
+		stateMap[r.String()] = state
 		return true
 	})
 


### PR DESCRIPTION
By adding `fmt.Stringer` to the `Runnable` interface, we can make sure that every Runnable instance can always be logged correctly.

This change also includes some minor cleanup to the mocks and tests that use the mocks.