### PR TITLE
add a startShutdownManager and ShutdownSender interface to trigger shutdown from the Runnables

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ type ReloadSender interface {
 
 ## Advanced Usage
 
-### Implementing Reloadable Services
+### Implementing a Reloadable Service
 
 ```go
 type ConfigurableService struct {
@@ -164,63 +164,6 @@ func (s *ConfigurableService) Reload() {
     s.config = newConfig
     
     fmt.Printf("%s: Configuration reloaded\n", s.name)
-}
-```
-
-### Implementing Stateable Services
-
-```go
-type StatefulService struct {
-    MyService
-    state     string
-    stateChan chan string
-    mu        sync.Mutex
-}
-
-// Interface guards, ensuring that StatefulService implements Runnable and Stateable
-var _ supervisor.Runnable = (*StatefulService)(nil)
-var _ supervisor.Stateable = (*StatefulService)(nil)
-
-func NewStatefulService(name string) *StatefulService {
-    return &StatefulService{
-        MyService: MyService{name: name, done: make(chan struct{})},
-        state:     "initialized",
-        stateChan: make(chan string, 10),
-    }
-}
-
-func (s *StatefulService) GetState() string {
-    s.mu.Lock()
-    defer s.mu.Unlock()
-    return s.state
-}
-
-func (s *StatefulService) GetStateChan(ctx context.Context) <-chan string {
-    return s.stateChan
-}
-
-func (s *StatefulService) setState(state string) {
-    s.mu.Lock()
-    s.state = state
-    s.mu.Unlock()
-    
-    // Non-blocking send to state channel
-    select {
-    case s.stateChan <- state:
-    default:
-    }
-}
-
-func (s *StatefulService) Run(ctx context.Context) error {
-    s.setState("running")
-    // Run implementation
-    return nil
-}
-
-func (s *StatefulService) Stop() {
-    s.setState("stopping")
-    // Stop implementation
-    s.setState("stopped")
 }
 ```
 

--- a/runnables/mocks/mocks.go
+++ b/runnables/mocks/mocks.go
@@ -150,3 +150,22 @@ func NewMockRunnableWithReloadSender() *MockRunnableWithReloadSender {
 		Runnable: NewMockRunnable(),
 	}
 }
+
+// MockRunnableWithShutdownSender extends Runnable to also implement the ShutdownSender interface.
+type MockRunnableWithShutdownSender struct {
+	*Runnable
+}
+
+// ShutdownSender mocks implementation of the ShutdownSender interface.
+// It returns a receive-only channel that emits signals when a shutdown is requested.
+func (m *MockRunnableWithShutdownSender) GetShutdownTrigger() <-chan struct{} {
+	args := m.Called()
+	return args.Get(0).(chan struct{})
+}
+
+// NewMockRunnableWithShutdown creates a new MockRunnableWithReload with default delays.
+func NewMockRunnableWithShutdownSender() *MockRunnableWithShutdownSender {
+	return &MockRunnableWithShutdownSender{
+		Runnable: NewMockRunnable(),
+	}
+}

--- a/supervisor/interfaces.go
+++ b/supervisor/interfaces.go
@@ -54,3 +54,9 @@ type ReloadSender interface {
 	// GetReloadTrigger returns a channel that emits signals when a reload is requested.
 	GetReloadTrigger() <-chan struct{}
 }
+
+// ShutdownSender represents a service that can trigger system shutdown.
+type ShutdownSender interface {
+	// GetShutdownTrigger returns a channel that emits signals when a shutdown is requested.
+	GetShutdownTrigger() <-chan struct{}
+}

--- a/supervisor/shutdown.go
+++ b/supervisor/shutdown.go
@@ -1,0 +1,42 @@
+package supervisor
+
+import "sync"
+
+// startShutdownManager starts goroutines to listen for shutdown notifications
+// from any runnables that implement ShutdownSender. It blocks until the context is done.
+func (p *PIDZero) startShutdownManager() {
+	defer p.wg.Done()
+	p.logger.Debug("Starting shutdown manager...")
+
+	var shutdownWg sync.WaitGroup
+
+	// Find all runnables that can send shutdown signals and start listeners
+	for _, r := range p.runnables {
+		if sdSender, ok := r.(ShutdownSender); ok {
+			shutdownWg.Add(1)
+			// Pass both Runnable 'r' and ShutdownSender 's' for clarity
+			go func(r Runnable, s ShutdownSender) {
+				defer shutdownWg.Done()
+				triggerChan := s.GetShutdownTrigger()
+				for {
+					select {
+					case <-p.ctx.Done():
+						return
+					case <-triggerChan:
+						p.logger.Info("Shutdown requested by runnable", "runnable", r)
+						p.Shutdown() // Trigger supervisor shutdown
+						return       // Exit this goroutine after triggering shutdown
+					}
+				}
+			}(r, sdSender) // Pass both variables
+		}
+	}
+
+	// Block until context is done, then wait for listener goroutines to finish
+	<-p.ctx.Done()
+	p.logger.Debug(
+		"Shutdown manager received context done signal, waiting for listeners to exit...",
+	)
+	shutdownWg.Wait()
+	p.logger.Debug("Shutdown manager complete.")
+}

--- a/supervisor/shutdown_test.go
+++ b/supervisor/shutdown_test.go
@@ -1,0 +1,156 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// TestPIDZero_StartShutdownManager_TriggersShutdown verifies that receiving a signal
+// on a ShutdownSender's trigger channel calls the supervisor's Shutdown method.
+func TestPIDZero_StartShutdownManager_TriggersShutdown(t *testing.T) {
+	t.Parallel()
+
+	// Create a context with cancel for cleanup and monitoring
+	// Use a background context for the supervisor initially
+	supervisorCtx, supervisorCancel := context.WithCancel(context.Background())
+	defer supervisorCancel() // Ensure cleanup
+
+	// Create mock service that implements ShutdownSender
+	mockService := mocks.NewMockRunnableWithShutdownSender()
+	shutdownChan := make(chan struct{}, 1) // Buffered to prevent blocking sender
+
+	mockService.On("GetShutdownTrigger").Return(shutdownChan).Once()
+	mockService.On("String").Return("mockShutdownService").Maybe()
+	mockService.On("Stop").Return().Maybe()
+
+	// Create a supervisor with the mock runnable
+	// Pass the specific context so we can monitor its cancellation
+	pidZero, err := New(WithContext(supervisorCtx), WithRunnables(mockService))
+	assert.NoError(t, err)
+
+	// Start the shutdown manager in a goroutine
+	pidZero.wg.Add(1)
+	go pidZero.startShutdownManager()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Send a shutdown signal from the mock runnable
+	shutdownChan <- struct{}{}
+
+	// Wait for the supervisor's context to be cancelled, which indicates
+	// that p.Shutdown() was called by the manager.
+	select {
+	case <-pidZero.ctx.Done():
+		// Context was cancelled as expected, Shutdown() was called.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Supervisor context was not cancelled, Shutdown() likely not called")
+	}
+
+	// Bypass waiting for the WaitGroup - we've already confirmed
+	// the Shutdown() was triggered which is the key test assertion
+
+	// Verify expectations on the mock
+	mockService.AssertExpectations(t)
+}
+
+// TestPIDZero_StartShutdownManager_ContextCancel verifies that the manager
+// cleans up its listener goroutines when the main context is cancelled.
+func TestPIDZero_StartShutdownManager_ContextCancel(t *testing.T) {
+	t.Parallel()
+
+	// Create a context with cancel for cleanup
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // Ensure cleanup
+
+	// Create mock service that implements ShutdownSender
+	mockService := mocks.NewMockRunnableWithShutdownSender()
+	shutdownChan := make(chan struct{}) // Unbuffered is fine, won't be used
+
+	// Expect GetShutdownTrigger to be called, but no signal sent
+	mockService.On("GetShutdownTrigger").Return(shutdownChan).Once()
+	mockService.On("String").Return("mockShutdownService").Maybe()
+	mockService.On("Stop").Return().Maybe()
+
+	// Create a supervisor with the mock runnable
+	pidZero, err := New(WithContext(ctx), WithRunnables(mockService))
+	assert.NoError(t, err)
+
+	// Start the shutdown manager in a goroutine
+	pidZero.wg.Add(1)
+	go pidZero.startShutdownManager()
+
+	// Give the manager a moment to start its internal listener goroutine
+	time.Sleep(100 * time.Millisecond) // Increased sleep duration
+
+	// Cancel the main context
+	cancel()
+
+	// Wait for the startShutdownManager goroutine (and its listeners) to finish
+	waitChan := make(chan struct{})
+	go func() {
+		pidZero.wg.Wait()
+		close(waitChan)
+	}()
+
+	select {
+	case <-waitChan:
+		// WaitGroup finished cleanly, indicating proper cleanup
+	case <-time.After(1 * time.Second):
+		t.Fatal("WaitGroup did not finish within the timeout after context cancellation")
+	}
+
+	// Verify expectations on the mock
+	mockService.AssertExpectations(t)
+}
+
+// TestPIDZero_StartShutdownManager_NoSenders verifies that the manager
+// starts and stops cleanly even if no runnables implement ShutdownSender.
+func TestPIDZero_StartShutdownManager_NoSenders(t *testing.T) {
+	t.Parallel()
+
+	// Create a context with cancel for cleanup
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // Ensure cleanup
+
+	// Create a mock service that does *not* implement ShutdownSender
+	nonSenderRunnable := mocks.NewMockRunnable()
+	nonSenderRunnable.On("Run", mock.Anything).Return(nil).Maybe()
+	nonSenderRunnable.On("Stop").Maybe()
+	nonSenderRunnable.On("String").Return("simpleRunnable").Maybe()
+
+	// Create a supervisor with the non-sender runnable
+	pidZero, err := New(WithContext(ctx), WithRunnables(nonSenderRunnable))
+	assert.NoError(t, err)
+
+	// Start the shutdown manager in a goroutine
+	pidZero.wg.Add(1)
+	go pidZero.startShutdownManager()
+
+	// Give the manager a moment to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel the main context
+	cancel()
+
+	// Wait for the startShutdownManager goroutine to finish
+	waitChan := make(chan struct{})
+	go func() {
+		pidZero.wg.Wait()
+		close(waitChan)
+	}()
+
+	select {
+	case <-waitChan:
+		// WaitGroup finished cleanly
+	case <-time.After(1 * time.Second):
+		t.Fatal("WaitGroup did not finish within the timeout when no senders were present")
+	}
+
+	// No ShutdownSender specific mock expectations to verify
+	nonSenderRunnable.AssertExpectations(t) // Assert expectations for Run/Stop/String if set
+}

--- a/supervisor/state.go
+++ b/supervisor/state.go
@@ -18,6 +18,7 @@ package supervisor
 
 import (
 	"context"
+	"sync"
 )
 
 // StateMap is a map of runnable string representation to its current state
@@ -149,74 +150,97 @@ func (p *PIDZero) broadcastState() {
 // 4. Updates the internal stateMap when states change
 // 5. Broadcasts state changes to all subscribers
 //
-// The stateMap serves multiple critical functions:
+// The many purposes of the stateMap:
 //   - Provides a thread-safe cache of the latest state for each runnable
 //   - Enables state change deduplication (avoiding duplicate broadcasts of identical states)
-//   - Serves as the single source of truth for runnable states within the supervisor
+//   - Represents the supervisor's "truth" for the state of current runnables
 //   - Allows state querying without directly accessing runnables (e.g. for APIs or UIs)
 //
 // State deduplication works by comparing incoming states against the previously recorded state.
 // Only when a state differs from the previous one is it stored and broadcast, preventing
 // unnecessary broadcasts and reducing system load when runnables emit frequent duplicate states.
+// startStateMonitor initiates background goroutines to monitor state changes for each
+// Stateable runnable. It blocks until the context is done, coordinating state updates
+// from all state-emitting services.
 func (p *PIDZero) startStateMonitor() {
-	for _, r := range p.runnables {
-		if stateable, ok := r.(Stateable); ok {
-			r := r // capture loop variable
-			go func() {
-				stateChan := stateable.GetStateChan(p.ctx)
+	defer p.wg.Done()
+	p.logger.Debug("Starting state monitor...")
+
+	// Create a WaitGroup to track state monitoring goroutines
+	var stateWg sync.WaitGroup
+
+	// Start a goroutine for each Stateable runnable
+	for _, run := range p.runnables {
+		if stateable, ok := run.(Stateable); ok {
+			stateWg.Add(1)
+			go func(r Runnable, s Stateable) {
+				defer stateWg.Done()
+				stateChan := s.GetStateChan(p.ctx)
 
 				// Read the first state and discard it - it's the initial state
 				// that we've already captured and stored manually in startRunnable
 				select {
+				case <-p.ctx.Done():
+					return
 				case state, ok := <-stateChan:
 					if !ok {
-						p.logger.Debug("State channel closed during initialization", "runnable", r)
 						return
 					}
 					// First state discarded to avoid duplicate broadcast
 					p.logger.Debug("Discarded initial state", "runnable", r, "state", state)
-				case <-p.ctx.Done():
-					return
 				}
 
 				// Keep track of the last state to avoid duplicate broadcasts
 				var lastState string
-				if currentState, loaded := p.stateMap.Load(r); loaded {
+				if currentState, ok := p.stateMap.Load(r); ok {
 					lastState = currentState.(string)
 				}
 
+				// Process state changes until context is done
 				for {
 					select {
 					case <-p.ctx.Done():
 						return
 					case state, ok := <-stateChan:
 						if !ok {
-							p.logger.Debug("State channel closed", "runnable", r)
 							return
 						}
 
-						// Only broadcast if the state has actually changed from the last known state
-						if state != lastState {
-							p.stateMap.Store(r, state)
+						if state == lastState {
 							p.logger.Debug(
-								"State changed",
+								"Received duplicate state (ignoring)",
 								"runnable",
 								r,
-								"oldState",
-								lastState,
-								"newState",
+								"state",
 								state,
 							)
-							lastState = state
-
-							// Broadcast state change to all subscribers
-							p.broadcastState()
-						} else {
-							p.logger.Debug("Received duplicate state (ignoring)", "runnable", r, "state", state)
+							continue
 						}
+
+						prev, loaded := p.stateMap.Swap(s, state)
+						if !loaded {
+							p.logger.Debug(
+								"State map entry created",
+								"runnable", r,
+								"state", state)
+						} else {
+							p.logger.Debug(
+								"State map entry updated",
+								"runnable", r,
+								"oldState", prev,
+								"state", state)
+						}
+						lastState = state  // enable local state deduplication
+						p.broadcastState() // Broadcast state change to all subscribers
 					}
 				}
-			}()
+			}(run, stateable)
 		}
 	}
+
+	// Block here until context is done, then wait for all monitoring goroutines to finish
+	<-p.ctx.Done()
+	p.logger.Debug("State monitor received context done signal, waiting for monitors to exit...")
+	stateWg.Wait()
+	p.logger.Debug("State monitor complete.")
 }

--- a/supervisor/state.go
+++ b/supervisor/state.go
@@ -209,18 +209,16 @@ func (p *PIDZero) startStateMonitor() {
 						if state == lastState {
 							p.logger.Debug(
 								"Received duplicate state (ignoring)",
-								"runnable",
-								r,
-								"state",
-								state,
-							)
+								"runnable", r,
+								"state", state)
 							continue
 						}
 
-						prev, loaded := p.stateMap.Swap(s, state)
+						prev, loaded := p.stateMap.Swap(r, state)
 						if !loaded {
-							p.logger.Debug(
-								"State map entry created",
+							// The state map entry for this runnable should have been created elsewhere
+							p.logger.Warn(
+								"Unexpected State map entry created",
 								"runnable", r,
 								"state", state)
 						} else {

--- a/supervisor/state_test.go
+++ b/supervisor/state_test.go
@@ -128,7 +128,8 @@ func TestPIDZero_StartStateMonitor(t *testing.T) {
 	pidZero.stateMap.Store(mockService, "initial")
 
 	// Start the state monitor
-	pidZero.startStateMonitor()
+	pidZero.wg.Add(1)
+	go pidZero.startStateMonitor()
 
 	// Send an initial state that will be discarded
 	stateChan <- "initial"
@@ -206,7 +207,8 @@ func TestPIDZero_SubscribeStateChanges(t *testing.T) {
 	pidZero.stateMap.Store(mockService2, "initial2")
 
 	// Start the state monitor
-	pidZero.startStateMonitor()
+	pidZero.wg.Add(1)
+	go pidZero.startStateMonitor()
 
 	// Subscribe to state changes
 	stateMapChan := pidZero.SubscribeStateChanges(ctx)

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -138,7 +138,7 @@ func (p *PIDZero) Run() error {
 	}()
 	p.listenForSignals()
 
-	// Start the reload manager if any runnables support reloading
+	// Start a single reload manager if any runnable is reloadable
 	for _, r := range p.runnables {
 		if _, ok := r.(Reloadable); ok {
 			p.wg.Add(1)
@@ -147,7 +147,7 @@ func (p *PIDZero) Run() error {
 		}
 	}
 
-	// Start the shutdown manager if any runnables support the Stateable interface
+	// Start a single state monitor if any runnable reports state
 	for _, r := range p.runnables {
 		if _, ok := r.(Stateable); ok {
 			p.wg.Add(1)
@@ -156,7 +156,7 @@ func (p *PIDZero) Run() error {
 		}
 	}
 
-	// Start the shutdown manager if any runnables support the ShutdownSender interface
+	// Start a single shutdown manager if any runnable can trigger shutdown
 	for _, r := range p.runnables {
 		if _, ok := r.(ShutdownSender); ok {
 			p.wg.Add(1)

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -138,16 +138,37 @@ func (p *PIDZero) Run() error {
 	}()
 	p.listenForSignals()
 
-	p.wg.Add(1) // wait for reload manager upon exit
-	go p.startReloadManager()
+	// Start the reload manager if any runnables support reloading
+	for _, r := range p.runnables {
+		if _, ok := r.(Reloadable); ok {
+			p.wg.Add(1)
+			go p.startReloadManager()
+			break
+		}
+	}
 
-	// log state changes for all runnables that are "stateable"
-	p.startStateMonitor()
+	// Start the shutdown manager if any runnables support the Stateable interface
+	for _, r := range p.runnables {
+		if _, ok := r.(Stateable); ok {
+			p.wg.Add(1)
+			go p.startStateMonitor()
+			break
+		}
+	}
+
+	// Start the shutdown manager if any runnables support the ShutdownSender interface
+	for _, r := range p.runnables {
+		if _, ok := r.(ShutdownSender); ok {
+			p.wg.Add(1)
+			go p.startShutdownManager()
+			break
+		}
+	}
 
 	// Start each service in sequence
 	for _, r := range p.runnables {
+		p.wg.Add(1)
 		go p.startRunnable(r)
-		p.wg.Add(1) // wait for each runnable upon exit
 	}
 
 	// Begin reaping process

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -208,8 +208,7 @@ func TestPIDZero_Reap_HandleSIGTERM(t *testing.T) {
 	mockRunnable.On("GetState").Return("running").Maybe()
 	mockRunnable.On("GetStateChan", mock.Anything).Return(stateChan).Maybe()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	pid0, err := New(WithContext(ctx), WithRunnables(mockRunnable))
 	assert.NoError(t, err)


### PR DESCRIPTION
This also updates the behavior of the `startStateMonitor` to block and make sure it's closed correctly.