### PR TITLE
improve supervisor startup by expanding the statable interface with IsRunning

### DIFF
--- a/runnables/composite/state.go
+++ b/runnables/composite/state.go
@@ -17,6 +17,11 @@ func (r *Runner[T]) GetStateChan(ctx context.Context) <-chan string {
 	return r.fsm.GetStateChan(ctx)
 }
 
+// IsRunning returns true if the CompositeRunner is currently running.
+func (r *Runner[T]) IsRunning() bool {
+	return r.fsm.GetState() == finitestate.StatusRunning
+}
+
 // setStateError marks the FSM as being in the error state.
 func (r *Runner[T]) setStateError() {
 	err := r.fsm.SetState(finitestate.StatusError)

--- a/runnables/httpserver/state.go
+++ b/runnables/httpserver/state.go
@@ -36,3 +36,8 @@ func (r *Runner) GetState() string {
 func (r *Runner) GetStateChan(ctx context.Context) <-chan string {
 	return r.fsm.GetStateChan(ctx)
 }
+
+// IsRunning returns true if the HTTP server is currently running.
+func (r *Runner) IsRunning() bool {
+	return r.fsm.GetState() == finitestate.StatusRunning
+}

--- a/runnables/mocks/mocks.go
+++ b/runnables/mocks/mocks.go
@@ -124,6 +124,13 @@ func (m *MockRunnableWithStatable) GetStateChan(ctx context.Context) <-chan stri
 	return args.Get(0).(chan string)
 }
 
+// IsRunning mocks the IsRunning method of the Stateable interface.
+// It returns true if the service is currently running, as configured in test expectations.
+func (m *MockRunnableWithStatable) IsRunning() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
 // NewMockRunnableWithStatable creates a new MockRunnableWithStatable with default delays.
 func NewMockRunnableWithStatable() *MockRunnableWithStatable {
 	return &MockRunnableWithStatable{

--- a/runnables/mocks/mocks_test.go
+++ b/runnables/mocks/mocks_test.go
@@ -246,6 +246,15 @@ func TestMockRunnableWithStatable(t *testing.T) {
 		mockRunnable.AssertExpectations(t)
 	})
 
+	t.Run("IsRunning method", func(t *testing.T) {
+		// Create a mock
+		mockRunnable := mocks.NewMockRunnableWithStatable()
+		mockRunnable.On("IsRunning", mock.Anything).Return(true)
+		r := mockRunnable.IsRunning()
+		assert.True(t, r)
+		mockRunnable.AssertExpectations(t)
+	})
+
 	t.Run("inherits from base Runnable", func(t *testing.T) {
 		testHelperInheritedMethods(t, mocks.NewMockRunnableWithStatable(), "StatefulService")
 	})

--- a/supervisor/interfaces.go
+++ b/supervisor/interfaces.go
@@ -47,6 +47,9 @@ type Stateable interface {
 
 	// GetStateChan returns a channel that will receive the current state of the service.
 	GetStateChan(context.Context) <-chan string
+
+	// IsRunning returns true if the service is currently running.
+	IsRunning() bool
 }
 
 // ReloadSender represents a service that can trigger reloads.


### PR DESCRIPTION
Prior to this, the Supervisor would start all `Runnable`s async, because there wasn't a good and universal way to introspect when the `Runnable`s were ready.

This extends the `Statable` interface signature by adding a `IsRunning` method, and then changes the `Run` considerably by adding a `blockUntilRunnableReady` method to wait (with an exponential back-off) for the Runnable startup. It also adds an optional timeout to the Supervisor that can be set with `WithStartupTimeout`.