### PR TITLE
adjust the format and location of the functional options on the included Runnables

### DIFF
--- a/examples/composite/main.go
+++ b/examples/composite/main.go
@@ -76,8 +76,8 @@ func main() {
 
 	// Create composite runner
 	runner, err := composite.NewRunner(
+		configCallback,
 		composite.WithContext[*Worker](ctx),
-		composite.WithConfigCallback(configCallback),
 	)
 	if err != nil {
 		logger.Error("Failed to create composite runner", "error", err)

--- a/examples/composite/reload_membership_test.go
+++ b/examples/composite/reload_membership_test.go
@@ -144,8 +144,8 @@ func TestMembershipChangesBasic(t *testing.T) {
 	defer cancel()
 
 	runner, err := composite.NewRunner[*TestWorker](
+		configCallback,
 		composite.WithContext[*TestWorker](ctx),
-		composite.WithConfigCallback[*TestWorker](configCallback),
 		composite.WithLogHandler[*TestWorker](logger.Handler()),
 	)
 	require.NoError(t, err)

--- a/runnables/composite/options.go
+++ b/runnables/composite/options.go
@@ -22,15 +22,7 @@ func WithLogHandler[T runnable](handler slog.Handler) Option[T] {
 func WithContext[T runnable](ctx context.Context) Option[T] {
 	return func(c *Runner[T]) {
 		if ctx != nil {
-			c.parentCtx, c.cancel = context.WithCancel(ctx)
+			c.parentCtx, c.parentCancel = context.WithCancel(ctx)
 		}
-	}
-}
-
-// WithConfigCallback sets the function that will be called to load or reload configuration.
-// This option is required when creating a new CompositeRunner.
-func WithConfigCallback[T runnable](callback func() (*Config[T], error)) Option[T] {
-	return func(c *Runner[T]) {
-		c.configCallback = callback
 	}
 }

--- a/runnables/composite/options_test.go
+++ b/runnables/composite/options_test.go
@@ -44,15 +44,15 @@ func TestWithContext(t *testing.T) {
 
 	originalCtx := context.Background()
 	runner := &Runner[*mockRunnable]{
-		parentCtx: nil,
-		cancel:    nil,
+		parentCtx:    nil,
+		parentCancel: nil,
 	}
 
 	WithContext[*mockRunnable](originalCtx)(runner)
 
 	// Verify the context and cancel function are set
 	require.NotNil(t, runner.parentCtx, "Context should be set")
-	require.NotNil(t, runner.cancel, "Cancel function should be set")
+	require.NotNil(t, runner.parentCancel, "Cancel function should be set")
 
 	// Test that the contexts are related (child can access parent values)
 	originalCtx = context.WithValue(context.Background(), testContextKey, "value")
@@ -67,8 +67,8 @@ func TestWithContext(t *testing.T) {
 	// Test with empty context - we should get a new cancellable context
 	// but still be able to verify it's connected to the background context
 	runner = &Runner[*mockRunnable]{
-		parentCtx: nil,
-		cancel:    nil,
+		parentCtx:    nil,
+		parentCancel: nil,
 	}
 	// Use context.Background() instead of nil
 	WithContext[*mockRunnable](context.Background())(runner)
@@ -78,39 +78,14 @@ func TestWithContext(t *testing.T) {
 	// 2. The cancel function is not nil
 	// 3. The context is derived from Background() (it will be a cancel context)
 	require.NotNil(t, runner.parentCtx, "Context should be set with Background()")
-	require.NotNil(t, runner.cancel, "Cancel function should be set with Background()")
+	require.NotNil(t, runner.parentCancel, "Cancel function should be set with Background()")
 
 	// Verify it's a cancel context by calling the cancel function and checking if Done channel closes
-	runner.cancel()
+	runner.parentCancel()
 	select {
 	case <-runner.parentCtx.Done():
 		// This is what we want - the context was canceled
 	default:
 		t.Error("Context should be cancellable when created with Background()")
 	}
-}
-
-func TestWithConfigCallback(t *testing.T) {
-	t.Parallel()
-
-	// Create a test callback function
-	testCallback := func() (*Config[*mockRunnable], error) {
-		return &Config[*mockRunnable]{Name: "test"}, nil
-	}
-
-	// Create a runner
-	runner := &Runner[*mockRunnable]{
-		configCallback: nil,
-	}
-
-	// Apply the option
-	WithConfigCallback(testCallback)(runner)
-
-	// Verify the callback was set
-	require.NotNil(t, runner.configCallback, "Config callback should be set")
-
-	// Test that the callback works and returns the expected value
-	config, err := runner.configCallback()
-	assert.NoError(t, err)
-	assert.Equal(t, "test", config.Name, "Config callback should return the expected value")
 }

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -103,7 +103,7 @@ func TestCompositeRunner_Reload(t *testing.T) {
 
 		ctx := context.Background()
 		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
+			configCallback,
 			WithContext[*mocks.Runnable](ctx),
 			WithLogHandler[*mocks.Runnable](handler),
 		)
@@ -191,7 +191,7 @@ func TestCompositeRunner_Reload(t *testing.T) {
 		// Create runner and set state to Running
 		ctx := t.Context()
 		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
+			configCallback,
 			WithContext[*mocks.Runnable](ctx),
 		)
 		require.NoError(t, err)
@@ -288,7 +288,7 @@ func TestCompositeRunner_Reload(t *testing.T) {
 		// Create runner and set state to Running
 		ctx := t.Context()
 		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
+			configCallback,
 			WithContext[*mocks.Runnable](ctx),
 		)
 		require.NoError(t, err)
@@ -400,7 +400,7 @@ func TestCompositeRunner_Reload(t *testing.T) {
 		// Create runner
 		ctx := t.Context()
 		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
+			configCallback,
 			WithContext[*mocks.Runnable](ctx),
 		)
 		require.NoError(t, err)
@@ -493,7 +493,7 @@ func TestCompositeRunner_Reload(t *testing.T) {
 		// Create runner with proper context
 		ctx := t.Context()
 		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
+			configCallback,
 			WithContext[*MockReloadableWithConfig](ctx),
 		)
 		require.NoError(t, err)
@@ -597,9 +597,7 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Replace FSM with our mock that will fail transition
@@ -630,9 +628,7 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Replace FSM with our mock
@@ -665,9 +661,7 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Replace FSM with our mock
@@ -712,9 +706,7 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Manually set current config (skipping initial load)
@@ -799,9 +791,7 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Manually set current config (skipping initial load)
@@ -865,9 +855,7 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Manually set current config (skipping initial load)
@@ -910,9 +898,7 @@ func TestGetConfig_NilCase(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Clear the config cache
@@ -930,9 +916,7 @@ func TestGetConfig_NilCase(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Clear the config cache
@@ -954,11 +938,11 @@ func TestSetStateError(t *testing.T) {
 		mockFSM.On("SetState", finitestate.StatusError).Return(nil)
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(func() (*Config[*mocks.Runnable], error) {
-				return NewConfig("test", []RunnableEntry[*mocks.Runnable]{})
-			}),
-		)
+		configCallback := func() (*Config[*mocks.Runnable], error) {
+			return NewConfig("test", []RunnableEntry[*mocks.Runnable]{})
+		}
+
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Replace FSM with our mock
@@ -977,11 +961,10 @@ func TestSetStateError(t *testing.T) {
 		mockFSM.On("SetState", finitestate.StatusError).Return(errors.New("set state error"))
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(func() (*Config[*mocks.Runnable], error) {
-				return NewConfig("test", []RunnableEntry[*mocks.Runnable]{})
-			}),
-		)
+		configCallback := func() (*Config[*mocks.Runnable], error) {
+			return NewConfig("test", []RunnableEntry[*mocks.Runnable]{})
+		}
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Replace FSM with our mock
@@ -1006,9 +989,7 @@ func TestGetChildStates(t *testing.T) {
 			return nil, errors.New("config error")
 		}
 
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Call GetChildStates
@@ -1044,11 +1025,11 @@ func TestReloadConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(func() (*Config[*mocks.Runnable], error) {
-				return config, nil
-			}),
-		)
+		configCallback := func() (*Config[*mocks.Runnable], error) {
+			return config, nil
+		}
+
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Call reloadConfig directly
@@ -1085,13 +1066,10 @@ func TestReloadConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(
-				func() (*Config[*MockReloadableWithConfig], error) {
-					return config, nil
-				},
-			),
-		)
+		configCallback := func() (*Config[*MockReloadableWithConfig], error) {
+			return config, nil
+		}
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Call reloadConfig directly
@@ -1131,18 +1109,16 @@ func TestReloadConfig(t *testing.T) {
 
 		// Create runners
 		runner1, err := NewRunner(
-			WithConfigCallback(func() (*Config[*mocks.Runnable], error) {
+			func() (*Config[*mocks.Runnable], error) {
 				return config1, nil
-			}),
+			},
 		)
 		require.NoError(t, err)
 
 		runner2, err := NewRunner(
-			WithConfigCallback(
-				func() (*Config[*MockReloadableWithConfig], error) {
-					return config2, nil
-				},
-			),
+			func() (*Config[*MockReloadableWithConfig], error) {
+				return config2, nil
+			},
 		)
 		require.NoError(t, err)
 
@@ -1214,10 +1190,7 @@ func TestReloadMembershipChanged(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-			WithContext[*mocks.Runnable](ctx),
-		)
+		runner, err := NewRunner(configCallback, WithContext[*mocks.Runnable](ctx))
 		require.NoError(t, err)
 
 		// Make sure initial config is loaded
@@ -1253,9 +1226,9 @@ func TestReloadMembershipChanged(t *testing.T) {
 	t.Run("handles stopRunnables error", func(t *testing.T) {
 		// Setup a runner with no initial config
 		runner, err := NewRunner(
-			WithConfigCallback(func() (*Config[*mocks.Runnable], error) {
+			func() (*Config[*mocks.Runnable], error) {
 				return nil, nil
-			}),
+			},
 		)
 		require.NoError(t, err)
 
@@ -1307,8 +1280,7 @@ func TestReloadMembershipChanged(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
+		runner, err := NewRunner(configCallback,
 			WithContext[*mocks.Runnable](ctx),
 		)
 		require.NoError(t, err)
@@ -1478,8 +1450,7 @@ func TestHasMembershipChanged(t *testing.T) {
 		}
 
 		ctx := context.Background() // Use a clean context instead of t.Context()
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
+		runner, err := NewRunner(configCallback,
 			WithContext[*mocks.Runnable](ctx),
 		)
 		require.NoError(t, err)

--- a/runnables/composite/runner.go
+++ b/runnables/composite/runner.go
@@ -31,7 +31,12 @@ type Runner[T runnable] struct {
 	logger       *slog.Logger
 }
 
-// NewRunner creates a new CompositeRunner instance with the provided options.
+// NewRunner creates a new CompositeRunner instance with the provided configuration callback and options.
+// Parameters:
+//   - configCallback: Required. A function that returns the initial configuration and is called during any reload operations.
+//   - opts: Optional. A variadic list of Option functions to customize the Runner behavior.
+//
+// The configCallback must not be nil and will be invoked by Run() to load the initial configuration.
 func NewRunner[T runnable](
 	configCallback ConfigCallback[T],
 	opts ...Option[T],
@@ -58,7 +63,7 @@ func NewRunner[T runnable](
 	// Validate requirements
 	if r.configCallback == nil {
 		return nil, fmt.Errorf(
-			"%w: config callback is required (use WithConfigCallback)",
+			"%w: config callback is required",
 			ErrCompositeRunnable,
 		)
 	}

--- a/runnables/composite/runner_run_test.go
+++ b/runnables/composite/runner_run_test.go
@@ -44,9 +44,7 @@ func TestCompositeRunner_Run_AdditionalScenarios(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Replace FSM with our mock
@@ -88,7 +86,7 @@ func TestCompositeRunner_Run_AdditionalScenarios(t *testing.T) {
 		defer parentCancel()
 
 		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
+			configCallback,
 			WithContext[*mocks.Runnable](parentCtx),
 		)
 		require.NoError(t, err)
@@ -150,9 +148,7 @@ func TestCompositeRunner_Run_AdditionalScenarios(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Run in goroutine with a context we can cancel
@@ -201,9 +197,7 @@ func TestCompositeRunner_Run_AdditionalScenarios(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Replace FSM with our mock
@@ -251,9 +245,7 @@ func TestCompositeRunner_Run_AdditionalScenarios(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Replace FSM with our mock
@@ -301,9 +293,7 @@ func TestCompositeRunner_Run_AdditionalScenarios(t *testing.T) {
 		}
 
 		// Create runner
-		runner, err := NewRunner(
-			WithConfigCallback(configCallback),
-		)
+		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
 		// Replace FSM with our mock

--- a/runnables/composite/state_test.go
+++ b/runnables/composite/state_test.go
@@ -36,9 +36,7 @@ func TestCompositeRunner_GetChildStates(t *testing.T) {
 	}
 
 	// Create runner with the supervisor.Runnable interface type
-	runner, err := NewRunner(
-		WithConfigCallback(configCallback),
-	)
+	runner, err := NewRunner(configCallback)
 	require.NoError(t, err)
 
 	// Get child states
@@ -68,9 +66,7 @@ func TestCompositeRunner_GetStateChan(t *testing.T) {
 	}
 
 	// Create runner
-	runner, err := NewRunner(
-		WithConfigCallback(configCallback),
-	)
+	runner, err := NewRunner(configCallback)
 	require.NoError(t, err)
 
 	// Create context with cancel
@@ -113,13 +109,11 @@ func TestGetState_PassThrough(t *testing.T) {
 	mockFSM := new(MockStateMachine)
 	mockFSM.On("GetState").Return(finitestate.StatusRunning)
 
-	// Create a runner
-	runner, err := NewRunner(
-		WithConfigCallback[*mocks.Runnable](func() (*Config[*mocks.Runnable], error) {
-			entries := []RunnableEntry[*mocks.Runnable]{}
-			return NewConfig("test", entries)
-		}),
-	)
+	// Create a runner with callback
+	cb := func() (*Config[*mocks.Runnable], error) {
+		return NewConfig("test", []RunnableEntry[*mocks.Runnable]{})
+	}
+	runner, err := NewRunner(cb)
 	require.NoError(t, err)
 
 	// Replace the FSM with our mock
@@ -146,12 +140,11 @@ func TestGetStateChan_PassThrough(t *testing.T) {
 	mockFSM.On("GetStateChan", mock.Anything).Return(stateCh)
 
 	// Create a runner
-	runner, err := NewRunner(
-		WithConfigCallback[*mocks.Runnable](func() (*Config[*mocks.Runnable], error) {
-			entries := []RunnableEntry[*mocks.Runnable]{}
-			return NewConfig("test", entries)
-		}),
-	)
+	cb := func() (*Config[*mocks.Runnable], error) {
+		return NewConfig("test", []RunnableEntry[*mocks.Runnable]{})
+	}
+
+	runner, err := NewRunner(cb)
 	require.NoError(t, err)
 
 	// Replace the FSM with our mock
@@ -199,9 +192,7 @@ func TestGetChildStates_WithStateables(t *testing.T) {
 	}
 
 	// Create runner
-	runner, err := NewRunner(
-		WithConfigCallback(configCallback),
-	)
+	runner, err := NewRunner(configCallback)
 	require.NoError(t, err)
 
 	// Call GetChildStates
@@ -240,9 +231,7 @@ func TestCompositeRunner_GetStringWithConfig(t *testing.T) {
 	}
 
 	// Create runner
-	runner, err := NewRunner(
-		WithConfigCallback(configCallback),
-	)
+	runner, err := NewRunner(configCallback)
 	require.NoError(t, err)
 
 	// Get string representation
@@ -263,9 +252,7 @@ func TestCompositeRunner_GetStringWithNilConfig(t *testing.T) {
 	}
 
 	// Create runner
-	runner, err := NewRunner(
-		WithConfigCallback(configCallback),
-	)
+	runner, err := NewRunner(configCallback)
 	require.NoError(t, err)
 
 	// Clear any cached config

--- a/runnables/httpserver/README.md
+++ b/runnables/httpserver/README.md
@@ -48,9 +48,11 @@ func main() {
         return httpserver.NewConfig(":8080", 5*time.Second, routes)
     }
     
-    // Create HTTP server runner
-    ctx := context.Background()
-    runner, _ := httpserver.NewRunner(ctx, configCallback)
+    // Create HTTP server runner (use functional options pattern)
+    runner, _ := httpserver.NewRunner(
+        httpserver.WithContext(context.Background()),
+        httpserver.WithConfigCallback(configCallback),
+    )
     
     // Add to supervisor
     super := supervisor.New([]supervisor.Runnable{runner})
@@ -125,7 +127,7 @@ func MyAdvancedMiddleware(next http.HandlerFunc) http.HandlerFunc {
         statusCode := rw.Status()
         bytesWritten := rw.BytesWritten()
         
-        // Use this information as needed
+        // ...
     }
 }
 ```
@@ -162,6 +164,25 @@ go func() {
 }()
 ```
 
+## Configuration Options
+
+The HTTP server runner uses a functional options pattern - see godoc for complete documentation of each option. Common usage patterns:
+
+```go
+// Dynamic configuration with a callback function (supports hot reloading)
+runner, _ := httpserver.NewRunner(
+    httpserver.WithContext(context.Background()),
+    httpserver.WithConfigCallback(configCallback),
+)
+
+// Static configuration (simpler when hot reloading isn't needed)
+config, _ := httpserver.NewConfig(":8080", 5*time.Second, routes)
+runner, _ := httpserver.NewRunner(
+    httpserver.WithContext(context.Background()),
+    httpserver.WithConfig(config),
+)
+```
+
 ## Full Example
 
-See `examples/http/main.go` for a complete example including middleware and metrics endpoints.
+See `examples/http/main.go` for a complete example.

--- a/runnables/httpserver/README.md
+++ b/runnables/httpserver/README.md
@@ -48,18 +48,24 @@ func main() {
         return httpserver.NewConfig(":8080", 5*time.Second, routes)
     }
     
-    // Create HTTP server runner (use functional options pattern)
-    runner, _ := httpserver.NewRunner(
-        httpserver.WithContext(context.Background()),
+    // Create HTTP server runner
+    hRunner, _ := httpserver.NewRunner(
         httpserver.WithConfigCallback(configCallback),
     )
     
-    // Add to supervisor
-    super := supervisor.New([]supervisor.Runnable{runner})
+    // create a supervisor instance and add the runner
+    ctx, cancel := context.WithCancel(context.Background())
+    defer cancel()
+    super, _ := supervisor.New(
+        supervisor.WithRunnables(hRunner), // Remove the spread operator '...'
+        supervisor.WithContext(ctx),
+    )
     
-    // Boot and run
-    super.Boot()
-    super.Exec()
+    // blocks until the supervisor receives a signal
+    if err := super.Run(); err != nil {
+        // Handle error appropriately
+        panic(err)
+    }
 }
 ```
 
@@ -134,7 +140,15 @@ func MyAdvancedMiddleware(next http.HandlerFunc) http.HandlerFunc {
 
 ## Configuration Reloading
 
-The HTTP server supports hot reloading of configuration, allowing you to update routes without restarting:
+The HTTP server runnable implements the `supervisor.Reloadable` interface. The `go-supervisor`
+instance managing this runnable will automatically trigger its `Reload()` method when the
+supervisor receives a `SIGHUP` signal.
+
+When `Reload()` is called (either by the supervisor via a HUP signal or programmatically), the
+runner calls the configuration callback function to fetch the latest configuration. If the
+configuration has changed, the underlying HTTP server may be gracefully shut down if ports changed,
+or the routes will be reloaded if the configuration is the same.
+
 
 ```go
 // Trigger a reload

--- a/runnables/httpserver/options.go
+++ b/runnables/httpserver/options.go
@@ -1,0 +1,61 @@
+package httpserver
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Option represents a functional option for configuring Runner.
+type Option func(*Runner)
+
+// WithLogHandler sets a custom slog handler for the Runner instance.
+// For example, to use a custom JSON handler with debug level:
+//
+//	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
+//	runner, err := httpserver.NewRunner(ctx, httpserver.WithConfigCallback(configCallback), httpserver.WithLogHandler(handler))
+func WithLogHandler(handler slog.Handler) Option {
+	return func(r *Runner) {
+		if handler != nil {
+			r.logger = slog.New(handler.WithGroup("httpserver.Runner"))
+		}
+	}
+}
+
+// WithContext sets a custom context for the Runner instance.
+// This allows for more granular control over cancellation and timeouts.
+func WithContext(ctx context.Context) Option {
+	return func(r *Runner) {
+		if ctx != nil {
+			r.ctx, r.cancel = context.WithCancel(ctx)
+		}
+	}
+}
+
+// WithConfigCallback sets the function that will be called to load or reload configuration. Using
+// this option or WithConfig is required to initialize the Runner instance, because it provides the
+// configuration for the HTTP server managed by the Runner.
+func WithConfigCallback(callback ConfigCallback) Option {
+	return func(r *Runner) {
+		r.configCallback = callback
+	}
+}
+
+// WithConfig sets the initial configuration for the Runner instance.
+// This option is a simple wrapper for the WithConfigCallback option, allowing you to pass a Config
+// instance directly instead of a callback function. This is useful when you have a static
+// configuration that doesn't require dynamic loading or reloading.
+func WithConfig(cfg *Config) Option {
+	return func(r *Runner) {
+		callback := func() (*Config, error) {
+			return cfg, nil
+		}
+		r.configCallback = callback
+	}
+}
+
+// WithName sets the name of the Runner instance.
+func WithName(name string) Option {
+	return func(r *Runner) {
+		r.name = name
+	}
+}

--- a/runnables/httpserver/options_test.go
+++ b/runnables/httpserver/options_test.go
@@ -1,0 +1,132 @@
+package httpserver
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Define a custom type for context keys to avoid string collision
+type contextKey string
+
+// TestWithContext verifies the WithContext option works correctly
+func TestWithContext(t *testing.T) {
+	t.Parallel()
+
+	// Create a custom context with a value using the type-safe key
+	testKey := contextKey("test-key")
+	customCtx := context.WithValue(context.Background(), testKey, "test-value")
+
+	// Create a server with the custom context
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	route, err := NewRoute("v1", "/", handler)
+	require.NoError(t, err)
+	hConfig := Routes{*route}
+
+	cfgCallback := func() (*Config, error) {
+		return NewConfig(":0", 1*time.Second, hConfig)
+	}
+
+	server, err := NewRunner(WithContext(context.Background()),
+		WithConfigCallback(cfgCallback),
+		WithContext(customCtx))
+	require.NoError(t, err)
+
+	// Verify the custom context was applied
+	actualValue := server.ctx.Value(testKey)
+	assert.Equal(t, "test-value", actualValue, "Context value should be preserved")
+
+	// Verify cancellation works through server.Stop()
+	done := make(chan struct{})
+	go func() {
+		<-server.ctx.Done()
+		close(done)
+	}()
+
+	// Call Stop to cancel the internal context
+	server.Stop()
+
+	// Wait for the server context to be canceled or timeout
+	select {
+	case <-done:
+		// Success, context was canceled
+	case <-time.After(1 * time.Second):
+		t.Fatal("Context cancellation not propagated")
+	}
+}
+
+func TestWithLogHandler(t *testing.T) {
+	t.Parallel()
+
+	// Create a custom logger with a buffer for testing output
+	var logBuffer strings.Builder
+	customHandler := slog.NewTextHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+	// Create required route and config callback for Runner
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	route, err := NewRoute("v1", "/", handler)
+	require.NoError(t, err)
+	hConfig := Routes{*route}
+
+	cfgCallback := func() (*Config, error) {
+		return NewConfig(":0", 1*time.Second, hConfig)
+	}
+
+	// Create a server with the custom logger
+	server, err := NewRunner(
+		WithContext(context.Background()),
+		WithConfigCallback(cfgCallback),
+		WithLogHandler(customHandler),
+	)
+	require.NoError(t, err)
+
+	// Verify the custom logger was applied by checking that it's not the default logger
+	assert.NotSame(t, slog.Default(), server.logger, "Server should use custom logger")
+
+	// Log something and check if it appears in our buffer
+	server.logger.Info("test message")
+	logOutput := logBuffer.String()
+	assert.Contains(t, logOutput, "test message", "Logger should write to our buffer")
+	assert.Contains(t, logOutput, "httpserver.Runner", "Log should contain the correct group name")
+}
+
+func TestWithConfig(t *testing.T) {
+	t.Parallel()
+
+	// Create a test server config
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	route, err := NewRoute("v1", "/test-route", handler)
+	require.NoError(t, err)
+	hConfig := Routes{*route}
+
+	testAddr := ":8765" // Use a specific port for identification
+	staticConfig, err := NewConfig(testAddr, 2*time.Second, hConfig)
+	require.NoError(t, err)
+
+	// Create a server with the static config
+	server, err := NewRunner(
+		WithContext(context.Background()),
+		WithConfig(staticConfig),
+	)
+	require.NoError(t, err)
+
+	// Verify the config callback was created and returns the correct config
+	config, err := server.configCallback()
+	require.NoError(t, err)
+	assert.NotNil(t, config)
+
+	// Verify config values match what we provided
+	assert.Equal(t, testAddr, config.ListenAddr, "Config address should match")
+	assert.Equal(t, 2*time.Second, config.DrainTimeout, "Config drain timeout should match")
+	assert.Equal(t, "/test-route", config.Routes[0].Path, "Config route path should match")
+	assert.Equal(t, "v1", config.Routes[0].name, "Config route name should match")
+
+	// Verify we get the same config instance (not a copy)
+	assert.Same(t, staticConfig, config, "Should return the exact same config instance")
+}

--- a/runnables/httpserver/runner.go
+++ b/runnables/httpserver/runner.go
@@ -15,46 +15,8 @@ import (
 	"github.com/robbyt/go-supervisor/supervisor"
 )
 
-// Option represents a functional option for configuring Runner.
-type Option func(*Runner)
-
-// WithLogHandler sets a custom slog handler for the Runner instance.
-// For example, to use a custom JSON handler with debug level:
-//
-//	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
-//	runner, err := httpserver.NewRunner(ctx, httpserver.WithConfigCallback(configCallback), httpserver.WithLogHandler(handler))
-func WithLogHandler(handler slog.Handler) Option {
-	return func(r *Runner) {
-		if handler != nil {
-			r.logger = slog.New(handler.WithGroup("httpserver.Runner"))
-		}
-	}
-}
-
-// WithContext sets a custom context for the Runner instance.
-// This allows for more granular control over cancellation and timeouts.
-func WithContext(ctx context.Context) Option {
-	return func(r *Runner) {
-		if ctx != nil {
-			r.ctx, r.cancel = context.WithCancel(ctx)
-		}
-	}
-}
-
-// WithConfigCallback sets the function that will be called to load or reload configuration.
-// This option is required when creating a new Runner.
-func WithConfigCallback(callback func() (*Config, error)) Option {
-	return func(r *Runner) {
-		r.configCallback = callback
-	}
-}
-
-// WithName sets the name of the Runner instance.
-func WithName(name string) Option {
-	return func(r *Runner) {
-		r.name = name
-	}
-}
+// ConfigCallback is the function type signature for the callback used to load initial config, and new config during Reload()
+type ConfigCallback func() (*Config, error)
 
 // Runner implements a configurable HTTP server that supports graceful shutdown,
 // dynamic reconfiguration, and state monitoring. It meets the Runnable, Reloadable,
@@ -62,7 +24,7 @@ func WithName(name string) Option {
 type Runner struct {
 	name           string
 	config         atomic.Pointer[Config]
-	configCallback func() (*Config, error)
+	configCallback ConfigCallback
 	bootLock       sync.Mutex
 	server         *http.Server
 	serverRunning  atomic.Bool


### PR DESCRIPTION
This updates the params for the `composite.Runnable` to **require** the config callback as a first param for the constructor. It's better to rely on compiler checks instead of runtime checks to confirm this was provided.

Also, in `httpserver.Runnable` this change splits out the options to a dedicated file, and corrects many comments and docs.