### PR TITLE
fix race condition in example worker

### DIFF
--- a/examples/composite/worker.go
+++ b/examples/composite/worker.go
@@ -266,9 +266,8 @@ func (w *Worker) processReload(newConfig *WorkerConfig) {
 	}
 	logger.Info(
 		"Interval changed, resetting ticker",
-		"name", newConfig.JobName,
-		"oldInterval", oldCfg.Interval,
-		"newInterval", newConfig.Interval,
+		"old", oldCfg,
+		"new", newConfig,
 	)
 	w.mu.Lock()
 	runCtx := w.ctx

--- a/examples/composite/worker.go
+++ b/examples/composite/worker.go
@@ -45,16 +45,16 @@ func (wc WorkerConfig) validate() error {
 // Worker is a simplified example of a runnable that does background work
 type Worker struct {
 	name       string
-	mu         sync.RWMutex      // Use RWMutex for better read performance
-	config     WorkerConfig      // Current running config
-	nextConfig chan WorkerConfig // Channel for pending config updates from ReloadWithConfig
+	mu         sync.Mutex
+	config     WorkerConfig
+	nextConfig chan WorkerConfig
 
-	tickCount atomic.Int64  // Counter for processed ticks
-	tickChan  chan struct{} // Channel for tick notifications
+	tickCount atomic.Int64
+	tickChan  chan struct{}
 
 	ctx          context.Context
-	cancel       context.CancelFunc // Function to cancel the Run context
-	tickerCancel context.CancelFunc // Function to cancel the ticker goroutine
+	cancel       context.CancelFunc
+	tickerCancel context.CancelFunc
 	logger       *slog.Logger
 }
 
@@ -93,76 +93,87 @@ func (w *Worker) Run(ctx context.Context) error {
 	w.mu.Lock()
 	runCtx, cancel := context.WithCancel(ctx)
 	w.ctx = runCtx
-	w.cancel = cancel // Store cancel function for Stop()
+	w.cancel = cancel
 	w.mu.Unlock()
 
 	cfg := w.getConfig()
-	logger.Info("Starting worker", "cfg", cfg.JobName)
+	logger = logger.With("name", cfg.JobName)
+	logger.Info("Starting worker")
 
 	w.startTicker(runCtx, cfg.Interval)
 	defer func() {
-		if w.tickerCancel != nil {
-			w.tickerCancel() // Stop the goroutine started in `startTicker`
+		if tc := w.tickerCancel; tc != nil {
+			tc()
 		}
-		logger.Info("Worker stopped", "name", w.getConfig().JobName)
+		logger.Info("Worker stopped")
 	}()
 
 	for {
 		select {
 		case <-runCtx.Done():
-			logger.Debug("Worker context cancelled, shutting down", "name", w.getConfig().JobName)
-			return nil // Normal exit
-
+			logger.Debug("Worker context cancelled, shutting down")
+			return nil
 		case <-w.tickChan:
 			w.processTick()
-
 		case newConfig := <-w.nextConfig:
 			w.processReload(&newConfig)
+			cfg = w.getConfig()
+			logger = logger.With("name", cfg.JobName)
 		}
 	}
 }
 
 // Stop signals the worker to gracefully shut down by cancelling its context.
 func (w *Worker) Stop() {
-	w.logger.WithGroup("Stop").Info("Stopping worker...", "name", w.getConfig().JobName)
-	if w.cancel != nil {
-		w.cancel() // Signal the Run loop to exit via context cancellation
+	logger := w.logger.WithGroup("Stop")
+	currentName := w.getConfig().JobName
+	logger.Info("Stopping worker...", "name", currentName)
+	if c := w.cancel; c != nil {
+		w.cancel = nil
+		c()
 	}
 	w.tickCount.Store(0)
 }
 
 // startTicker starts a new ticker goroutine that sends tick notifications to the worker.
 func (w *Worker) startTicker(ctx context.Context, interval time.Duration) {
-	tickCtx, tickCancel := context.WithCancel(ctx)
-	w.tickerCancel = tickCancel
 	logger := w.logger.WithGroup("startTicker")
+	w.mu.Lock()
+	oldTickerCancel := w.tickerCancel
+	w.tickerCancel = nil
+	w.mu.Unlock()
+	if oldTickerCancel != nil {
+		logger.Debug("Cancelling previous ticker goroutine")
+		oldTickerCancel()
+	}
+	tickCtx, newTickerCancel := context.WithCancel(ctx)
+	w.mu.Lock()
+	w.tickerCancel = newTickerCancel
+	w.mu.Unlock()
 	ticker := time.NewTicker(interval)
-
-	// Start a goroutine to push ticks to the worker's tick channel
 	go func() {
 		defer ticker.Stop()
+		defer logger.Debug("Ticker stopped")
+		logger.Debug("Ticker started")
 		for {
 			select {
 			case <-tickCtx.Done():
-				// Ticker goroutine context was cancelled
 				logger.Debug("Ticker context cancelled, stopping ticker")
 				return
 			case <-ticker.C:
 				select {
 				case w.tickChan <- struct{}{}:
-					// tick sent successfully
 				default:
-					// Tick channel is full, log a warning
-					logger.Warn("Tick notification dropped (tick channel full)")
+					logger.Warn("Tick notification dropped (tick channel full or closed)")
 				}
 			}
 		}
 	}()
-	logger.Debug("Ticker started", "interval", interval)
+	logger.Debug("Ticker setup complete", "interval", interval)
 }
 
 // ReloadWithConfig receives a new config from the composite Runnable, and sends it to the Run
-// loop via a channel. It handles potential backpressure by replacing a pending config with the
+// loop via a channel. It handles potential back-pressure by replacing a pending config with the
 // latest received if the channel is full.
 func (w *Worker) ReloadWithConfig(config any) {
 	logger := w.logger.WithGroup("ReloadWithConfig")
@@ -213,8 +224,8 @@ func (w *Worker) ReloadWithConfig(config any) {
 
 // getConfig returns the worker's current configuration safely.
 func (w *Worker) getConfig() WorkerConfig {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.config
 }
 
@@ -223,19 +234,18 @@ func (w *Worker) getConfig() WorkerConfig {
 func (w *Worker) setConfig(newConfig WorkerConfig) (oldCfg WorkerConfig) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-
 	oldCfg = w.config
 	w.config = newConfig
-	w.name = newConfig.JobName
-
-	w.logger.Debug("Updated config",
-		"old", oldCfg, "new", newConfig)
+	if w.name != newConfig.JobName {
+		w.name = newConfig.JobName
+	}
+	w.logger.Debug("Updated config", "old", oldCfg, "new", newConfig)
 	return oldCfg
 }
 
 // processReload is a helper function to process the new configuration.
 func (w *Worker) processReload(newConfig *WorkerConfig) {
-	logger := w.logger.WithGroup("handleReload").With("newConfig", newConfig)
+	logger := w.logger.WithGroup("processReload").With("newConfig", newConfig)
 	currentCfg := w.getConfig()
 	if err := newConfig.validate(); err != nil {
 		logger.Error(
@@ -246,41 +256,43 @@ func (w *Worker) processReload(newConfig *WorkerConfig) {
 		)
 		return
 	}
-
-	// Apply the new configuration and get the *previous* config
 	oldCfg := w.setConfig(*newConfig)
 	if oldCfg.Interval == newConfig.Interval {
-		logger.Debug("Interval unchanged, skipping update", "name", currentCfg.JobName)
+		logger.Debug(
+			"Interval unchanged, skipping ticker restart",
+			"name", newConfig.JobName,
+		)
 		return
 	}
-
 	logger.Info(
 		"Interval changed, resetting ticker",
-		"old", oldCfg,
-		"new", newConfig,
+		"name", newConfig.JobName,
+		"oldInterval", oldCfg.Interval,
+		"newInterval", newConfig.Interval,
 	)
-	if w.tickerCancel != nil {
-		w.tickerCancel()
+	w.mu.Lock()
+	runCtx := w.ctx
+	w.mu.Unlock()
+	if runCtx == nil {
+		logger.Error(
+			"Cannot restart ticker, run context is nil",
+			"name", newConfig.JobName,
+		)
+		return
 	}
-	w.startTicker(w.ctx, newConfig.Interval)
-	w.tickCount.Store(0) // Reset tick count on ticker reset reload
+	w.startTicker(runCtx, newConfig.Interval)
+	w.tickCount.Store(0)
 }
 
 // processTick performs the actual work on each tick.
 func (w *Worker) processTick() {
-	w.mu.RLock()
-	cfg := w.config
-	currentName := w.name
-	w.mu.RUnlock()
-
-	// Simulate work - Replace with your actual task
+	cfg := w.getConfig()
 	time.Sleep(1 * time.Millisecond)
 	count := w.tickCount.Add(1)
-
 	w.logger.Info(
 		"Performing work",
 		"interval", cfg.Interval,
-		"name", currentName,
+		"name", cfg.JobName,
 		"tick_count", count,
 	)
 	// --- Add your actual worker logic here ---

--- a/examples/composite/worker_test.go
+++ b/examples/composite/worker_test.go
@@ -41,15 +41,15 @@ func testLogger(t *testing.T, capture bool) (*slog.Logger, *bytes.Buffer) { //no
 
 // readWorkerConfig safely reads the current config from the worker.
 func readWorkerConfig(w *Worker) WorkerConfig {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.config // Return a copy
 }
 
 // readWorkerName safely reads the current name from the worker.
 func readWorkerName(w *Worker) string {
-	w.mu.RLock()
-	defer w.mu.RUnlock()
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.name
 }
 
@@ -652,9 +652,9 @@ func TestWorker_ProcessReload_UnchangedInterval(t *testing.T) {
 	)
 
 	// Verify config was updated by checking the name property directly
-	worker.mu.RLock()
+	worker.mu.Lock()
 	assert.Equal(t, "updated-job", worker.name, "Worker name should be updated")
-	worker.mu.RUnlock()
+	worker.mu.Unlock()
 }
 
 // TestWorker_ProcessReload_InvalidConfig tests handling of invalid config in processReload
@@ -686,14 +686,14 @@ func TestWorker_ProcessReload_InvalidConfig(t *testing.T) {
 	assert.Equal(t, initialState, currentConfig, "Config should not change after invalid config")
 
 	// Verify the worker name wasn't updated
-	worker.mu.RLock()
+	worker.mu.Lock()
 	assert.Equal(
 		t,
 		initialConfig.JobName,
 		worker.name,
 		"Worker name should not be updated with invalid config",
 	)
-	worker.mu.RUnlock()
+	worker.mu.Unlock()
 }
 
 // TestWorker_NewWorker_NilLogger tests worker creation with nil logger


### PR DESCRIPTION
While testing another unrelated change (#20), I received a very intermittent race condition failure, so I decided to simplify and just some of the locking in the Worker example code.

Test failure, for reference.
```bash
go test -timeout 3m -race -cover github.com/robbyt/go-supervisor/examples/composite github.com/robbyt/go-supervisor/examples/http github.com/robbyt/go-supervisor/internal/finitestate github.com/robbyt/go-supervisor/runnables/composite github.com/robbyt/go-supervisor/runnables/httpserver github.com/robbyt/go-supervisor/runnables/httpserver/middleware github.com/robbyt/go-supervisor/runnables/mocks github.com/robbyt/go-supervisor/supervisor
TestWorker Stop called for ID: worker1
TestWorker Stop called for ID: worker2
==================
WARNING: DATA RACE
Write at 0x00c0000bc3f0 by goroutine 18:
  github.com/robbyt/go-supervisor/examples/composite.(*Worker).startTicker()
      /home/runner/work/go-supervisor/go-supervisor/examples/composite/worker.go:137 +0xcf
  github.com/robbyt/go-supervisor/examples/composite.(*Worker).Run()
      /home/runner/work/go-supervisor/go-supervisor/examples/composite/worker.go:102 +0x2e8
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).startRunnable()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/runner.go:206 +0x259
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).startRunnable()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/runner.go:206 +0x259
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).startRunnable()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/runner.go:200 +0x1c5
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).boot.func1()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/runner.go:190 +0x9b

Previous read at 0x00c0000bc3f0 by goroutine 11:
  github.com/robbyt/go-supervisor/examples/composite.(*Worker).Run.func1()
      /home/runner/work/go-supervisor/go-supervisor/examples/composite/worker.go:105 +0x85
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.24.2/x64/src/runtime/panic.go:610 +0x5d
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).startRunnable()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/runner.go:206 +0x259
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).startRunnable()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/runner.go:206 +0x259
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).startRunnable()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/runner.go:200 +0x1c5
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).boot.func1()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/runner.go:190 +0x9b

Goroutine 18 (running) created at:
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).boot()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/runner.go:188 +0x4ee
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).reloadMembershipChanged()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/reload.go:93 +0x184
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).Reload()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/reload.go:59 +0x3c4
  github.com/robbyt/go-supervisor/runnables/composite.hasMembershipChanged[go.shape.*uint8]()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/reload.go:138 +0x272
  github.com/robbyt/go-supervisor/runnables/composite.hasMembershipChanged[go.shape.*uint8]()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/reload.go:133 +0x1ae
  github.com/robbyt/go-supervisor/runnables/composite.hasMembershipChanged[go.shape.*uint8]()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/reload.go:133 +0x1ae
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).Reload()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/reload.go:55 +0x350
  github.com/robbyt/go-supervisor/examples/composite.TestMembershipChangesBasic()
      /home/runner/work/go-supervisor/go-supervisor/examples/composite/reload_membership_test.go:183 +0xc3a
  testing.tRunner()
      /opt/hostedtoolcache/go/1.24.2/x64/src/testing/testing.go:1792 +0x225
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.24.2/x64/src/testing/testing.go:1851 +0x44

Goroutine 11 (running) created at:
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).boot()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/runner.go:188 +0x4ee
  github.com/robbyt/go-supervisor/runnables/composite.(*Runner[go.shape.*uint8]).Run()
      /home/runner/work/go-supervisor/go-supervisor/runnables/composite/runner.go:109 +0x295
  github.com/robbyt/go-supervisor/examples/composite.TestMembershipChangesBasic.func3()
      /home/runner/work/go-supervisor/go-supervisor/examples/composite/reload_membership_test.go:156 +0x56
==================
TestWorker Stop called for ID: worker3
TestWorker Stop called for ID: worker2
--- FAIL: TestMembershipChangesBasic (0.27s)
    reload_membership_test.go:182: Triggering reload to remove worker1 and add worker3
    reload_membership_test.go:107: Worker stopped: worker1
    reload_membership_test.go:107: Worker stopped: worker2
    reload_membership_test.go:193: Cancelling context to stop all workers
    reload_membership_test.go:107: Worker stopped: worker3
    reload_membership_test.go:107: Worker stopped: worker2
    reload_membership_test.go:216: Final stopped workers: map[worker1:true worker2:true worker3:true]
    testing.go:1490: race detected during execution of test
FAIL
coverage: 72.4% of statements
FAIL	github.com/robbyt/go-supervisor/examples/composite	2.482s
ok  	github.com/robbyt/go-supervisor/examples/http	1.219s	coverage: 51.0% of statements
ok  	github.com/robbyt/go-supervisor/internal/finitestate	1.013s	coverage: 100.0% of statements
ok  	github.com/robbyt/go-supervisor/runnables/composite	1.626s	coverage: 90.9% of statements
ok  	github.com/robbyt/go-supervisor/runnables/httpserver	3.554s	coverage: 86.5% of statements
ok  	github.com/robbyt/go-supervisor/runnables/httpserver/middleware	1.015s	coverage: 100.0% of statements
ok  	github.com/robbyt/go-supervisor/runnables/mocks	1.045s	coverage: 100.0% of statements
ok  	github.com/robbyt/go-supervisor/supervisor	2.021s	coverage: 84.8% of statements
FAIL
```