### PR TITLE
change the behavior of the composite.Runnable to handle empty Entries

### DIFF
--- a/runnables/composite/errors.go
+++ b/runnables/composite/errors.go
@@ -12,9 +12,6 @@ var (
 	// ErrConfigMissing is returned when the config is missing
 	ErrConfigMissing = errors.New("config is missing")
 
-	// ErrNoRunnables is returned when there are no runnables to manage
-	ErrNoRunnables = errors.New("no runnables to manage")
-
 	// ErrOldConfig is returned when the config hasn't changed during a reload
 	ErrOldConfig = errors.New("configuration unchanged")
 )


### PR DESCRIPTION
When sent a config via callback with empty `[]Entries`, the composite.Runnable `.boot()` should noop, waiting for a future `Reload()` that may provide things for this composite Runnable to do.