### PR TITLE
fix 'make bench' race condition tester

### DIFF
--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -409,9 +409,13 @@ func (r *Runner) startServers(
 
 		// Wait for server to be ready
 		if !r.waitForIsRunning(ctx, r.deadlineServerStart, runner) {
-			logger.Error("Server failed to become ready")
+			logger.Error("Server failed to become ready",
+				"timeout", r.deadlineServerStart,
+				"state", runner.GetState())
 			// Cancel the server context to clean up
 			serverCancel()
+			// Stop the runner explicitly to ensure cleanup
+			runner.Stop()
 			// Remove entry completely since server failed to start
 			current = current.removeEntry(id)
 			continue


### PR DESCRIPTION
Previously, the 0 restart delay was causing occasional `make bench` failures while rebinding. This splits out the 0 delay test into a second benchmark, and also stops the server instance if there's an error after creating it.