### PR TITLE
make it easier for external middleware implementations

### DIFF
--- a/runnables/httpserver/middleware/logger.go
+++ b/runnables/httpserver/middleware/logger.go
@@ -18,7 +18,7 @@ func Logger(logger *slog.Logger) Middleware {
 			start := time.Now()
 
 			// Create a response writer wrapper to capture status code
-			rw := &responseWriter{
+			rw := &ResponseWriter{
 				ResponseWriter: w,
 				statusCode:     http.StatusOK, // Default status code
 			}

--- a/runnables/httpserver/middleware/metrics.go
+++ b/runnables/httpserver/middleware/metrics.go
@@ -15,7 +15,7 @@ func MetricCollector() Middleware {
 			start := time.Now()
 
 			// Create a response writer wrapper to capture status code
-			rw := &responseWriter{
+			rw := &ResponseWriter{
 				ResponseWriter: w,
 				statusCode:     http.StatusOK, // Default status code
 			}

--- a/runnables/httpserver/middleware/metrics_test.go
+++ b/runnables/httpserver/middleware/metrics_test.go
@@ -63,7 +63,7 @@ func TestMetricCollector(t *testing.T) {
 	t.Run("captures status code in responseWriter", func(t *testing.T) {
 		// Setup direct responseWriter (without middleware)
 		rec := httptest.NewRecorder()
-		rw := &responseWriter{
+		rw := &ResponseWriter{
 			ResponseWriter: rec,
 			statusCode:     http.StatusOK, // Default
 		}

--- a/runnables/httpserver/middleware/middleware.go
+++ b/runnables/httpserver/middleware/middleware.go
@@ -1,3 +1,4 @@
+// Package middleware provides HTTP middleware utilities for wrapping http.HandlerFunc with additional functionality such as logging, metrics, and response inspection.
 package middleware
 
 import (
@@ -5,27 +6,41 @@ import (
 )
 
 // Middleware is a function that takes an http.HandlerFunc and returns a new http.HandlerFunc
-// which may execute code before and/or after calling the original handler.
+// which may execute code before and/or after calling the original handler. It is commonly used
+// for cross-cutting concerns such as logging, authentication, and metrics.
 type Middleware func(http.HandlerFunc) http.HandlerFunc
 
-// responseWriter is a wrapper for http.ResponseWriter that captures the status code.
-type responseWriter struct {
+// ResponseWriter is a wrapper for http.ResponseWriter that captures the status code and the number of bytes written.
+// It is useful in middleware for logging, metrics, and conditional logic based on the response.
+type ResponseWriter struct {
 	http.ResponseWriter
-	statusCode int
-	written    bool
+	statusCode   int
+	written      bool
+	bytesWritten int
 }
 
 // WriteHeader captures the status code and calls the underlying WriteHeader.
-func (rw *responseWriter) WriteHeader(statusCode int) {
-	rw.statusCode = statusCode
+func (rw *ResponseWriter) WriteHeader(statusCode int) {
 	rw.written = true
+	rw.statusCode = statusCode
 	rw.ResponseWriter.WriteHeader(statusCode)
 }
 
-// Write captures that a response has been written and calls the underlying Write.
-func (rw *responseWriter) Write(b []byte) (int, error) {
-	if !rw.written {
-		rw.written = true
-	}
-	return rw.ResponseWriter.Write(b)
+// Write captures that a response has been written, counts the bytes, and calls the underlying Write.
+func (rw *ResponseWriter) Write(b []byte) (int, error) {
+	rw.written = true
+	n, err := rw.ResponseWriter.Write(b)
+	rw.bytesWritten += n
+	return n, err
+}
+
+// Status returns the HTTP status code that was written to the response.
+// If no status code was explicitly set, it returns 0.
+func (rw *ResponseWriter) Status() int {
+	return rw.statusCode
+}
+
+// BytesWritten returns the total number of bytes written to the response body.
+func (rw *ResponseWriter) BytesWritten() int {
+	return rw.bytesWritten
 }


### PR DESCRIPTION
Previously, the `ResponseWriter` was private and limited. This expands the type with some additional metadata collection, useful for external middleware implementations.