### PR TITLE
Wire Reload(ctx) through composite and httpserver internals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ help: Makefile
 test:
 	go test -timeout 3m -race -cover ./...
 
+## test-norace: Run tests WITHOUT race detector and with multiple iterations (mimics CI; catches goroutine ordering races that -race masks)
+.PHONY: test-norace
+test-norace:
+	go test -timeout 3m -count=10 ./...
+
 ## bench: Run performance benchmarks
 .PHONY: bench
 bench:

--- a/runnables/composite/errors.go
+++ b/runnables/composite/errors.go
@@ -14,4 +14,19 @@ var (
 
 	// ErrOldConfig is returned when the config hasn't changed during a reload
 	ErrOldConfig = errors.New("configuration unchanged")
+
+	// ErrReloadAborted is returned when a Reload(ctx) call did not run to
+	// completion as the result of normal control flow — caller's ctx
+	// cancellation, runner shutting down, or the consumer observing the
+	// caller's abandonment signal before starting work. Callers can use
+	// errors.Is to distinguish this from real reload failures (config
+	// callback errors, child stop/boot failures).
+	//
+	// IMPORTANT: only the dispatch layer (dispatchMembershipReload) and the
+	// consumer abandonment path (reloadRequest.RunReload) may wrap this
+	// sentinel. Operational failures from reloadWithRestart, boot, or
+	// stopAllRunnables MUST return errors that do NOT wrap ErrReloadAborted —
+	// otherwise Reload's triage will silently treat them as normal control
+	// flow and skip setStateError().
+	ErrReloadAborted = errors.New("reload aborted")
 )

--- a/runnables/composite/integration_race_test.go
+++ b/runnables/composite/integration_race_test.go
@@ -87,8 +87,6 @@ func testCompositeRaceCondition(t *testing.T) {
 			runErr <- runner.Run(ctx)
 		}()
 
-		// Advance virtual clock past the mock's default 1ms Run delay
-		time.Sleep(10 * time.Millisecond)
 		synctest.Wait()
 
 		assert.True(t, runner.IsRunning(), "Composite should report as running")
@@ -172,8 +170,6 @@ func TestIntegration_CompositeFullLifecycle(t *testing.T) {
 			runErr <- runner.Run(ctx)
 		}()
 
-		// Advance virtual clock past the mock's default 1ms Run delay
-		time.Sleep(10 * time.Millisecond)
 		synctest.Wait()
 
 		assert.True(t, runner.IsRunning(), "Should be Running")

--- a/runnables/composite/reload.go
+++ b/runnables/composite/reload.go
@@ -24,21 +24,44 @@ func (r *Runner[T]) Reload(ctx context.Context) {
 	logger := r.logger.WithGroup("Reload")
 
 	if err := r.fsm.Transition(finitestate.StatusReloading); err != nil {
-		logger.Error("Failed to transition to Reloading", "error", err)
-		r.setStateError()
+		// Common reason: runner is in Stopping/Stopped/Booting/Error — not a
+		// failure of the reload itself, so don't move the FSM to Error.
+		logger.Debug("Cannot reload — runner not in Running state",
+			"current", r.fsm.GetState(), "error", err)
 		return
 	}
 
-	if err := r.doReload(ctx); err != nil {
+	err := r.doReload(ctx)
+	switch {
+	case err == nil:
+		if transErr := r.fsm.Transition(finitestate.StatusRunning); transErr != nil {
+			logger.Error("Failed to transition to Running", "error", transErr)
+			r.setStateError()
+		}
+	case errors.Is(err, ErrReloadAborted):
+		// Normal control flow — caller cancelled or runner is shutting down.
+		logger.Debug("Reload aborted (not an error)", "reason", err)
+		// Atomic best-effort return to Running. If we're no longer in
+		// Reloading, Run has moved the FSM (Stopping/Stopped/Error) — that's
+		// fine, Run owns the state. If we're still in Reloading and the
+		// transition fails, that's an FSM-library-level inconsistency worth
+		// flagging as Error so it's visible.
+		if transErr := r.fsm.TransitionIfCurrentState(
+			finitestate.StatusReloading, finitestate.StatusRunning,
+		); transErr != nil {
+			current := r.fsm.GetState()
+			if current == finitestate.StatusReloading {
+				logger.Error("FSM stuck in Reloading after abort",
+					"error", transErr)
+				r.setStateError()
+			} else {
+				logger.Debug("FSM moved out of Reloading by Run during abort",
+					"current", current, "error", transErr)
+			}
+		}
+	default:
 		logger.Error("Reload failed", "error", err)
 		r.setStateError()
-		return
-	}
-
-	if err := r.fsm.Transition(finitestate.StatusRunning); err != nil {
-		logger.Error("Failed to transition to Running", "error", err)
-		r.setStateError()
-		return
 	}
 }
 
@@ -71,21 +94,40 @@ func (r *Runner[T]) doReload(ctx context.Context) error {
 // runner has already exited or the caller's context is cancelled, so callers
 // never hang on a request that nobody will receive.
 func (r *Runner[T]) dispatchMembershipReload(ctx context.Context, newConfig *Config[T]) error {
-	req := reloadRequest[T]{newConfig: newConfig, done: make(chan error, 1)}
+	cancel := make(chan struct{})
+	req := newReloadRequest(newConfig, cancel)
 	select {
 	case r.reloadCh <- req:
 		select {
 		case err := <-req.done:
 			return err
 		case <-ctx.Done():
-			return fmt.Errorf("reload cancelled: %w", ctx.Err())
+			close(cancel)
+			// Recheck non-blocking: the consumer may have written req.done
+			// concurrently with ctx firing. If so, that result is the truth
+			// and we should return it instead of the cancellation error.
+			select {
+			case err := <-req.done:
+				return err
+			default:
+			}
+			return fmt.Errorf("%w: %w", ErrReloadAborted, ctx.Err())
 		case <-r.lc.DoneCh():
-			return errors.New("runner stopped while reload pending")
+			// Same-class race as the ctx.Done() branch above: if req.done
+			// became ready in the same select tick as DoneCh(), the consumer
+			// already wrote a real result — return that, don't claim the
+			// reload was aborted.
+			select {
+			case err := <-req.done:
+				return err
+			default:
+			}
+			return fmt.Errorf("%w: runner stopped while reload pending", ErrReloadAborted)
 		}
 	case <-ctx.Done():
-		return fmt.Errorf("reload cancelled: %w", ctx.Err())
+		return fmt.Errorf("%w: %w", ErrReloadAborted, ctx.Err())
 	case <-r.lc.DoneCh():
-		return errors.New("runner stopped before reload")
+		return fmt.Errorf("%w: runner stopped before reload", ErrReloadAborted)
 	}
 }
 

--- a/runnables/composite/reload.go
+++ b/runnables/composite/reload.go
@@ -2,6 +2,7 @@ package composite
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
@@ -16,60 +17,24 @@ type ReloadableWithConfig interface {
 // Reload updates the configuration and handles runnables appropriately.
 // If membership changes (different set of runnables), all existing runnables are stopped
 // and the new set of runnables is started.
-func (r *Runner[T]) Reload(_ context.Context) {
+func (r *Runner[T]) Reload(ctx context.Context) {
 	r.reloadMu.Lock()
 	defer r.reloadMu.Unlock()
 
 	logger := r.logger.WithGroup("Reload")
-	logger.Debug("Reloading...")
-	defer func() {
-		logger.Debug("Completed.")
-	}()
 
-	// Transition to Reloading state
 	if err := r.fsm.Transition(finitestate.StatusReloading); err != nil {
 		logger.Error("Failed to transition to Reloading", "error", err)
 		r.setStateError()
 		return
 	}
 
-	// Get updated config from the callback function
-	newConfig, err := r.configCallback()
-	if err != nil {
-		logger.Error("Failed to get updated config", "error", err)
-		r.setStateError()
-		return
-	}
-	if newConfig == nil {
-		logger.Error("Config callback returned nil during reload")
+	if err := r.doReload(ctx); err != nil {
+		logger.Error("Reload failed", "error", err)
 		r.setStateError()
 		return
 	}
 
-	// Get the old config to compare
-	oldConfig := r.getConfig()
-	if oldConfig == nil {
-		logger.Warn("Failed to get current config during reload, using empty config")
-		oldConfig = &Config[T]{}
-	}
-
-	// Check if membership has changed by comparing runnable identities
-	if hasMembershipChanged(oldConfig, newConfig) {
-		logger.Debug(
-			"Membership change detected, stopping all existing runnables before updating membership and config",
-		)
-		if err := r.reloadWithRestart(newConfig); err != nil {
-			logger.Error("Failed to reload runnables due to membership change", "error", err)
-			r.setStateError()
-			return
-		}
-		logger.Debug("Reloaded runnables due to membership change")
-	} else {
-		r.reloadSkipRestart(newConfig)
-		logger.Debug("Reloaded runnables without membership change")
-	}
-
-	// Transition back to Running
 	if err := r.fsm.Transition(finitestate.StatusRunning); err != nil {
 		logger.Error("Failed to transition to Running", "error", err)
 		r.setStateError()
@@ -77,8 +42,55 @@ func (r *Runner[T]) Reload(_ context.Context) {
 	}
 }
 
+// doReload loads the new configuration and routes to the appropriate reload strategy.
+func (r *Runner[T]) doReload(ctx context.Context) error {
+	newConfig, err := r.configCallback()
+	if err != nil {
+		return fmt.Errorf("config callback: %w", err)
+	}
+	if newConfig == nil {
+		return errors.New("config callback returned nil")
+	}
+
+	oldConfig := r.getConfig()
+	if oldConfig == nil {
+		r.logger.Warn("No current config during reload, treating as empty")
+		oldConfig = &Config[T]{}
+	}
+
+	if hasMembershipChanged(oldConfig, newConfig) {
+		return r.dispatchMembershipReload(ctx, newConfig)
+	}
+
+	r.reloadSkipRestart(ctx, newConfig)
+	return nil
+}
+
+// dispatchMembershipReload sends a membership-change reload to Run's event loop
+// so new children boot into runCtx's cancellation tree. Aborts cleanly if the
+// runner has already exited or the caller's context is cancelled, so callers
+// never hang on a request that nobody will receive.
+func (r *Runner[T]) dispatchMembershipReload(ctx context.Context, newConfig *Config[T]) error {
+	req := reloadRequest[T]{newConfig: newConfig, done: make(chan error, 1)}
+	select {
+	case r.reloadCh <- req:
+		select {
+		case err := <-req.done:
+			return err
+		case <-ctx.Done():
+			return fmt.Errorf("reload cancelled: %w", ctx.Err())
+		case <-r.lc.DoneCh():
+			return errors.New("runner stopped while reload pending")
+		}
+	case <-ctx.Done():
+		return fmt.Errorf("reload cancelled: %w", ctx.Err())
+	case <-r.lc.DoneCh():
+		return errors.New("runner stopped before reload")
+	}
+}
+
 // reloadWithRestart handles the case where the membership of runnables has changed.
-func (r *Runner[T]) reloadWithRestart(newConfig *Config[T]) error {
+func (r *Runner[T]) reloadWithRestart(ctx context.Context, newConfig *Config[T]) error {
 	logger := r.logger.WithGroup("reloadWithRestart")
 	logger.Debug("Reloading runnables due to membership change")
 	defer logger.Debug("Completed.")
@@ -97,14 +109,14 @@ func (r *Runner[T]) reloadWithRestart(newConfig *Config[T]) error {
 
 	// Start all runnables from the new config
 	// This acquires the runnables mutex
-	if err := r.boot(r.ctx); err != nil {
+	if err := r.boot(ctx); err != nil {
 		return fmt.Errorf("%w: failed to start new runnables during membership change", err)
 	}
 	return nil
 }
 
 // reloadSkipRestart handles the case where the membership of runnables has not changed.
-func (r *Runner[T]) reloadSkipRestart(newConfig *Config[T]) {
+func (r *Runner[T]) reloadSkipRestart(ctx context.Context, newConfig *Config[T]) {
 	logger := r.logger.WithGroup("reloadSkipRestart")
 	logger.Debug("Reloading runnables without membership change")
 	defer logger.Debug("Completed.")
@@ -128,7 +140,7 @@ func (r *Runner[T]) reloadSkipRestart(newConfig *Config[T]) {
 			// Fall back to standard Reloadable interface, assume the configCallback
 			// has somehow updated the runnable's internal state
 			logger.Debug("Reloading child runnable")
-			reloadable.Reload(context.TODO())
+			reloadable.Reload(ctx)
 		} else {
 			logger.Warn("Child runnable does not implement Reloadable or ReloadableWithConfig")
 		}

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -563,43 +563,36 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 	t.Parallel()
 
 	t.Run("fsm transition to reloading fails", func(t *testing.T) {
-		// Setup mock FSM with specific error behavior
+		// When the initial Transition(Reloading) fails (e.g. FSM is in
+		// Stopping/Stopped/Booting/Error), Reload must NOT promote that to
+		// the Error state — it's "wrong state for reload" control flow,
+		// not a runner failure.
 		mockFSM := new(MockStateMachine)
 		mockFSM.On("Transition", finitestate.StatusReloading).
 			Return(errors.New("transition error")).
 			Once()
-		mockFSM.On("SetState", finitestate.StatusError).Return(nil).Once()
-		mockFSM.On("GetState").Return(finitestate.StatusError).Maybe()
+		mockFSM.On("GetState").Return(finitestate.StatusStopped).Maybe()
 
-		// Create mock runnables to make test more realistic
 		mockRunnable := mocks.NewMockRunnable()
 		mockRunnable.On("String").Return("runnable1").Maybe()
 
-		// Create entries for a valid config
 		entries := []RunnableEntry[*mocks.Runnable]{
 			{Runnable: mockRunnable, Config: nil},
 		}
 
-		// Create config callback that returns a valid config
 		configCallback := func() (*Config[*mocks.Runnable], error) {
 			return NewConfig("test", entries)
 		}
 
-		// Create runner
 		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
-
-		// Replace FSM with our mock that will fail transition
 		runner.fsm = mockFSM
 
-		// Call Reload - should handle the transition error
 		runner.Reload(t.Context())
 
-		// Verify FSM methods were called as expected
+		// SetState(Error) must NOT be called — that would be wrong control flow.
+		mockFSM.AssertNotCalled(t, "SetState", finitestate.StatusError)
 		mockFSM.AssertExpectations(t)
-
-		// Verify we're in error state
-		assert.Equal(t, finitestate.StatusError, mockFSM.GetState())
 	})
 
 	t.Run("config callback error during reload", func(t *testing.T) {
@@ -1677,6 +1670,332 @@ func TestCompositeRunner_ReloadCancelMidFlight(t *testing.T) {
 
 	// Release the slow child so the runner can shut down cleanly.
 	close(slowStop)
+	runCancel()
+	select {
+	case <-runErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}
+
+// TestCompositeRunner_AbandonedReloadIsSkipped verifies that a membership-change
+// reload request whose caller has signalled abandonment (cancel chan closed)
+// does NOT execute its side effects (no Stop, no config swap, no boot of new
+// entries) when Run's event loop picks it up. White-box: builds a
+// reloadRequest directly with a pre-closed cancel signal and sends it into
+// the unexported reloadCh, since the public-API path can't reliably wedge
+// between send-success and consumer-read.
+func TestCompositeRunner_AbandonedReloadIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	mockChild := mocks.NewMockRunnable()
+	mockChild.On("String").Return("child").Maybe()
+	mockChild.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		<-args.Get(0).(context.Context).Done()
+	}).Return(context.Canceled).Maybe()
+	mockChild.On("Stop").Return().Maybe()
+
+	altChild := mocks.NewMockRunnable()
+	altChild.On("String").Return("alt").Maybe()
+	altChild.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		<-args.Get(0).(context.Context).Done()
+	}).Return(context.Canceled).Maybe()
+	altChild.On("Stop").Return().Maybe()
+
+	initial := []RunnableEntry[*mocks.Runnable]{{Runnable: mockChild}}
+	cb := func() (*Config[*mocks.Runnable], error) {
+		return NewConfig("initial", initial)
+	}
+
+	runner, err := NewRunner(cb)
+	require.NoError(t, err)
+
+	runCtx, runCancel := context.WithCancel(t.Context())
+	defer runCancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- runner.Run(runCtx) }()
+
+	require.Eventually(
+		t, runner.IsRunning, 2*time.Second, 10*time.Millisecond,
+	)
+
+	originalCfg := runner.getConfig()
+	require.NotNil(t, originalCfg)
+
+	swapped := []RunnableEntry[*mocks.Runnable]{{Runnable: altChild}}
+	newCfg, err := NewConfig("swapped", swapped)
+	require.NoError(t, err)
+
+	cancel := make(chan struct{})
+	close(cancel)
+	req := newReloadRequest(newCfg, cancel)
+	runner.reloadCh <- req
+
+	var doneErr error
+	select {
+	case doneErr = <-req.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for waitForEvent to consume reloadCh")
+	}
+	require.Error(t, doneErr)
+	require.ErrorIs(t, doneErr, ErrReloadAborted)
+	require.Contains(t, doneErr.Error(), "abandoned by caller")
+
+	// Critical: side effects must NOT have happened.
+	mockChild.AssertNotCalled(t, "Stop")
+	require.Same(t, originalCfg, runner.getConfig(),
+		"config must not have been swapped for an abandoned request")
+	altChild.AssertNotCalled(t, "Run")
+
+	runCancel()
+	select {
+	case <-runErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}
+
+// TestCompositeRunner_AbandonedReloadIsSkipped_PublicAPI exercises the same
+// abandonment path as the white-box test above, but through the public
+// Reload(ctx) API. ctx is pre-cancelled so dispatchMembershipReload's outer
+// select sees ctx.Done() and returns ErrReloadAborted without enqueueing.
+func TestCompositeRunner_AbandonedReloadIsSkipped_PublicAPI(t *testing.T) {
+	t.Parallel()
+
+	mockChild := mocks.NewMockRunnable()
+	mockChild.On("String").Return("child").Maybe()
+	mockChild.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		<-args.Get(0).(context.Context).Done()
+	}).Return(context.Canceled).Maybe()
+	mockChild.On("Stop").Return().Maybe()
+
+	altChild := mocks.NewMockRunnable()
+	altChild.On("String").Return("alt").Maybe()
+	altChild.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		<-args.Get(0).(context.Context).Done()
+	}).Return(context.Canceled).Maybe()
+	altChild.On("Stop").Return().Maybe()
+
+	useSwapped := atomic.Bool{}
+	cb := func() (*Config[*mocks.Runnable], error) {
+		if useSwapped.Load() {
+			return NewConfig("swapped", []RunnableEntry[*mocks.Runnable]{{Runnable: altChild}})
+		}
+		return NewConfig("initial", []RunnableEntry[*mocks.Runnable]{{Runnable: mockChild}})
+	}
+
+	runner, err := NewRunner(cb)
+	require.NoError(t, err)
+
+	runCtx, runCancel := context.WithCancel(t.Context())
+	defer runCancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- runner.Run(runCtx) }()
+	require.Eventually(t, runner.IsRunning, 2*time.Second, 10*time.Millisecond)
+
+	originalCfg := runner.getConfig()
+	useSwapped.Store(true)
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	runner.Reload(cancelledCtx)
+
+	// FSM should still be Running (NOT Error). The cancelled reload is
+	// normal control flow, not a failure.
+	require.Equal(t, finitestate.StatusRunning, runner.GetState(),
+		"FSM must not be in Error after cancelled reload")
+	mockChild.AssertNotCalled(t, "Stop")
+	require.Same(t, originalCfg, runner.getConfig(),
+		"config must not have been swapped for a cancelled reload")
+	altChild.AssertNotCalled(t, "Run")
+
+	runCancel()
+	select {
+	case <-runErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}
+
+// TestCompositeRunner_CancelledReloadDoesNotErrorState is the focused FSM
+// contract assertion: a Reload with a cancelled ctx must leave the runner
+// in Running, never Error.
+func TestCompositeRunner_CancelledReloadDoesNotErrorState(t *testing.T) {
+	t.Parallel()
+
+	mockChild := mocks.NewMockRunnable()
+	mockChild.On("String").Return("child").Maybe()
+	mockChild.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		<-args.Get(0).(context.Context).Done()
+	}).Return(context.Canceled).Maybe()
+	mockChild.On("Stop").Return().Maybe()
+
+	useSwapped := atomic.Bool{}
+	altChild := mocks.NewMockRunnable()
+	altChild.On("String").Return("alt").Maybe()
+	cb := func() (*Config[*mocks.Runnable], error) {
+		if useSwapped.Load() {
+			return NewConfig("swapped", []RunnableEntry[*mocks.Runnable]{{Runnable: altChild}})
+		}
+		return NewConfig("initial", []RunnableEntry[*mocks.Runnable]{{Runnable: mockChild}})
+	}
+
+	runner, err := NewRunner(cb)
+	require.NoError(t, err)
+
+	runCtx, runCancel := context.WithCancel(t.Context())
+	defer runCancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- runner.Run(runCtx) }()
+	require.Eventually(t, runner.IsRunning, 2*time.Second, 10*time.Millisecond)
+
+	useSwapped.Store(true)
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	runner.Reload(cancelledCtx)
+
+	require.Equal(t, finitestate.StatusRunning, runner.GetState(),
+		"caller cancellation is normal control flow — FSM must stay in Running")
+
+	runCancel()
+	select {
+	case <-runErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}
+
+// TestCompositeRunner_ReloadAfterStopDoesNotErrorState covers the initial
+// Transition(Reloading) failure path: after Stop, FSM is Stopped, and a
+// Reload call's first transition fails. The runner must NOT be moved to
+// Error — it's a "wrong state for reload" message, not a runner failure.
+func TestCompositeRunner_ReloadAfterStopDoesNotErrorState(t *testing.T) {
+	t.Parallel()
+
+	mockChild := mocks.NewMockRunnable()
+	mockChild.On("String").Return("child").Maybe()
+	mockChild.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		<-args.Get(0).(context.Context).Done()
+	}).Return(context.Canceled).Maybe()
+	mockChild.On("Stop").Return().Maybe()
+
+	cb := func() (*Config[*mocks.Runnable], error) {
+		return NewConfig("initial", []RunnableEntry[*mocks.Runnable]{{Runnable: mockChild}})
+	}
+
+	runner, err := NewRunner(cb)
+	require.NoError(t, err)
+
+	runCtx, runCancel := context.WithCancel(t.Context())
+	defer runCancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- runner.Run(runCtx) }()
+	require.Eventually(t, runner.IsRunning, 2*time.Second, 10*time.Millisecond)
+
+	runner.Stop()
+	require.Eventually(t,
+		func() bool { return runner.GetState() == finitestate.StatusStopped },
+		2*time.Second, 10*time.Millisecond)
+
+	// Reload after Stop. Initial Transition(Reloading) will fail.
+	runner.Reload(t.Context())
+
+	require.Equal(t, finitestate.StatusStopped, runner.GetState(),
+		"Reload-after-Stop must not move FSM to Error")
+
+	runCancel()
+	select {
+	case <-runErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}
+
+// TestCompositeRunner_DrainReloadCh_OnShutdown verifies that the deferred
+// drainReloadCh in Run() clears a request that arrives DURING shutdown — the
+// window between waitForEvent exiting (and inline drain running with empty
+// buffer) and Run main returning (when defer drainReloadCh fires).
+//
+// Determinism: a slow-stop child blocks Run inside stopAllRunnables. While
+// blocked, FSM is Stopping, waitForEvent has already exited. We send the
+// stale request then — it lands in an empty buffer with no consumer. Only
+// the deferred drainReloadCh can clear it. If it gets cleared, drain ran;
+// if it survives, drain is broken.
+func TestCompositeRunner_DrainReloadCh_OnShutdown(t *testing.T) {
+	t.Parallel()
+
+	slowStop := make(chan struct{})
+	mockChild := mocks.NewMockRunnable()
+	mockChild.On("String").Return("child").Maybe()
+	mockChild.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		<-args.Get(0).(context.Context).Done()
+	}).Return(context.Canceled).Maybe()
+	mockChild.On("Stop").Run(func(_ mock.Arguments) { <-slowStop }).Return().Maybe()
+
+	altChild := mocks.NewMockRunnable()
+	altChild.On("String").Return("alt").Maybe()
+	altChild.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		<-args.Get(0).(context.Context).Done()
+	}).Return(context.Canceled).Maybe()
+	altChild.On("Stop").Return().Maybe()
+
+	cb := func() (*Config[*mocks.Runnable], error) {
+		return NewConfig("initial", []RunnableEntry[*mocks.Runnable]{{Runnable: mockChild}})
+	}
+
+	runner, err := NewRunner(cb)
+	require.NoError(t, err)
+
+	runCtx, runCancel := context.WithCancel(t.Context())
+	defer runCancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- runner.Run(runCtx) }()
+	require.Eventually(t, runner.IsRunning, 2*time.Second, 10*time.Millisecond)
+
+	// Trigger Stop in a goroutine — it'll block in stopAllRunnables on slowStop.
+	stopReturned := make(chan struct{})
+	go func() {
+		runner.Stop()
+		close(stopReturned)
+	}()
+
+	// Wait for FSM Stopping. This proves: waitForEvent has returned,
+	// inline drainReloadCh ran (with empty buffer), TransitionIfCurrentState
+	// moved Running→Stopping, and we're now blocked in stopAllRunnables.
+	require.Eventually(t,
+		func() bool { return runner.GetState() == finitestate.StatusStopping },
+		2*time.Second, 10*time.Millisecond,
+		"runner did not reach Stopping — slow-stop wedge failed")
+
+	// Now send the stale request. waitForEvent is gone; only deferred
+	// drainReloadCh can clear this.
+	cancel := make(chan struct{})
+	staleCfg, err := NewConfig("stale", []RunnableEntry[*mocks.Runnable]{{Runnable: altChild}})
+	require.NoError(t, err)
+	stale := newReloadRequest(staleCfg, cancel)
+	runner.reloadCh <- stale
+	require.Len(t, runner.reloadCh, 1, "stale request must land in buffer")
+
+	// Release stopAllRunnables — Run completes, defers fire, drainReloadCh runs.
+	close(slowStop)
+
+	select {
+	case <-stopReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not return after slowStop released")
+	}
+
+	// Buffer must be empty — only the deferred drainReloadCh could have
+	// cleared the stale request we sent during Stopping.
+	require.Empty(t, runner.reloadCh,
+		"deferred drainReloadCh must have cleared the stale request")
+
+	// Side effects from the stale request must NOT have fired — altChild
+	// was never started, and we don't see RunReload's "abandoned" message
+	// on req.done because drainReloadCh discards silently.
+	altChild.AssertNotCalled(t, "Run")
+	altChild.AssertNotCalled(t, "Stop")
+
 	runCancel()
 	select {
 	case <-runErr:

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
@@ -143,107 +144,82 @@ func TestCompositeRunner_Reload(t *testing.T) {
 	})
 
 	t.Run("reload with updated runnables", func(t *testing.T) {
-		mockRunnable1 := mocks.NewMockRunnable()
-		mockRunnable1.On("String").Return("runnable1").Maybe()
-		mockRunnable1.On("Stop").Maybe()
-		mockRunnable1.On("Run", mock.Anything).Run(func(args mock.Arguments) {
-			<-args.Get(0).(context.Context).Done()
-		}).Return(context.Canceled).Maybe()
+		synctest.Test(t, func(t *testing.T) {
+			mockRunnable1 := mocks.NewMockRunnable()
+			mockRunnable1.On("String").Return("runnable1").Maybe()
+			mockRunnable1.On("Stop").Maybe()
+			mockRunnable1.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+				<-args.Get(0).(context.Context).Done()
+			}).Return(context.Canceled).Maybe()
 
-		mockRunnable2 := mocks.NewMockRunnable()
-		mockRunnable2.On("String").Return("runnable2").Maybe()
-		mockRunnable2.On("Stop").Once() // Will be stopped
-		mockRunnable2.On("Run", mock.Anything).Run(func(args mock.Arguments) {
-			<-args.Get(0).(context.Context).Done()
-		}).Return(context.Canceled).Maybe()
+			mockRunnable2 := mocks.NewMockRunnable()
+			mockRunnable2.On("String").Return("runnable2").Maybe()
+			mockRunnable2.On("Stop").Once() // Will be stopped
+			mockRunnable2.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+				<-args.Get(0).(context.Context).Done()
+			}).Return(context.Canceled).Maybe()
 
-		mockRunnable3 := mocks.NewMockRunnable()
-		mockRunnable3.On("String").Return("runnable3").Maybe()
-		mockRunnable3.On("Stop").Maybe()
-		// run3Called signals when the child goroutine has actually entered
-		// Run. boot() returns once the goroutines have started (startWg.Done),
-		// not once they've called subRunnable.Run — without this signal, the
-		// AssertExpectations below races the goroutine in non-race builds
-		// (CI runs without -race; -race incidentally synchronizes enough to
-		// mask the race locally).
-		var run3Called atomic.Bool
-		mockRunnable3.On("Run", mock.Anything).Run(func(args mock.Arguments) {
-			run3Called.Store(true)
-			<-args.Get(0).(context.Context).Done()
-		}).Return(context.Canceled).Once()
+			mockRunnable3 := mocks.NewMockRunnable()
+			mockRunnable3.On("String").Return("runnable3").Maybe()
+			mockRunnable3.On("Stop").Maybe()
+			mockRunnable3.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+				<-args.Get(0).(context.Context).Done()
+			}).Return(context.Canceled).Once()
 
-		// Create initial entries
-		initialEntries := []RunnableEntry[*mocks.Runnable]{
-			{Runnable: mockRunnable1, Config: nil},
-			{Runnable: mockRunnable2, Config: nil},
-		}
-
-		// Create updated entries for reload
-		updatedEntries := []RunnableEntry[*mocks.Runnable]{
-			{Runnable: mockRunnable1, Config: nil},
-			{Runnable: mockRunnable3, Config: nil},
-		}
-
-		// Variable to track which set of entries to return
-		useUpdatedEntries := false
-
-		// Create config callback
-		callbackCalls := 0
-		configCallback := func() (*Config[*mocks.Runnable], error) {
-			callbackCalls++
-			if useUpdatedEntries {
-				return NewConfig("test", updatedEntries)
+			initialEntries := []RunnableEntry[*mocks.Runnable]{
+				{Runnable: mockRunnable1, Config: nil},
+				{Runnable: mockRunnable2, Config: nil},
 			}
-			return NewConfig("test", initialEntries)
-		}
 
-		// Create runner and set state to Running
-		ctx := t.Context()
-		runner, err := NewRunner(configCallback)
-		require.NoError(t, err)
-		require.Equal(t, 0, callbackCalls)
+			updatedEntries := []RunnableEntry[*mocks.Runnable]{
+				{Runnable: mockRunnable1, Config: nil},
+				{Runnable: mockRunnable3, Config: nil},
+			}
 
-		runCtx, cancel := context.WithCancel(ctx)
-		defer cancel()
-		go func() {
-			err := runner.Run(runCtx)
-			assert.NoError(t, err)
-		}()
+			useUpdatedEntries := false
 
-		require.Eventually(t, func() bool {
-			return runner.GetState() == finitestate.StatusRunning
-		}, 1*time.Second, 10*time.Millisecond)
+			callbackCalls := 0
+			configCallback := func() (*Config[*mocks.Runnable], error) {
+				callbackCalls++
+				if useUpdatedEntries {
+					return NewConfig("test", updatedEntries)
+				}
+				return NewConfig("test", initialEntries)
+			}
 
-		// Switch to using updated entries
-		useUpdatedEntries = true
+			runner, err := NewRunner(configCallback)
+			require.NoError(t, err)
+			require.Equal(t, 0, callbackCalls)
 
-		// Call Reload
-		runner.Reload(t.Context())
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- runner.Run(t.Context())
+			}()
 
-		// Verify updated config
-		config := runner.getConfig()
-		require.NotNil(t, config)
-		assert.Len(t, config.Entries, 2)
-		assert.Equal(t, mockRunnable1, config.Entries[0].Runnable)
-		assert.Equal(t, mockRunnable3, config.Entries[1].Runnable)
+			synctest.Wait()
+			require.Equal(t, finitestate.StatusRunning, runner.GetState())
 
-		// Verify state cycle completed
-		assert.Equal(t, finitestate.StatusRunning, runner.GetState())
+			useUpdatedEntries = true
+			runner.Reload(t.Context())
+			synctest.Wait()
 
-		// Wait for mockRunnable3's goroutine to actually invoke Run before
-		// asserting expectations — see the run3Called comment at the mock
-		// setup for why this is needed.
-		require.Eventually(t, run3Called.Load, 2*time.Second, 10*time.Millisecond,
-			"mockRunnable3.Run should have been entered after membership-change reload")
+			config := runner.getConfig()
+			require.NotNil(t, config)
+			assert.Len(t, config.Entries, 2)
+			assert.Equal(t, mockRunnable1, config.Entries[0].Runnable)
+			assert.Equal(t, mockRunnable3, config.Entries[1].Runnable)
 
-		runner.Stop()
-		require.Eventually(t, func() bool {
-			return runner.GetState() == finitestate.StatusStopped
-		}, 1*time.Second, 10*time.Millisecond)
+			assert.Equal(t, finitestate.StatusRunning, runner.GetState())
 
-		mockRunnable1.AssertExpectations(t)
-		mockRunnable2.AssertExpectations(t)
-		mockRunnable3.AssertExpectations(t)
+			runner.Stop()
+			synctest.Wait()
+			assert.Equal(t, finitestate.StatusStopped, runner.GetState())
+
+			mockRunnable1.AssertExpectations(t)
+			mockRunnable2.AssertExpectations(t)
+			mockRunnable3.AssertExpectations(t)
+			require.NoError(t, <-errCh)
+		})
 	})
 
 	t.Run("reload with updated configurations", func(t *testing.T) {
@@ -1146,15 +1122,11 @@ func TestReloadMembershipChanged(t *testing.T) {
 
 		// Setup mock runnables for new config
 		mockRunnable3 := mocks.NewMockRunnable()
-		// Set DelayRun to 0 to avoid timing issues
-		mockRunnable3.DelayRun = 0
 		mockRunnable3.On("String").Return("runnable3").Maybe()
 		// Allow any number of Run calls for resilience
 		mockRunnable3.On("Run", mock.Anything).Return(nil).Maybe()
 
 		mockRunnable4 := mocks.NewMockRunnable()
-		// Set DelayRun to 0 to avoid timing issues
-		mockRunnable4.DelayRun = 0
 		mockRunnable4.On("String").Return("runnable4").Maybe()
 		// Allow any number of Run calls for resilience
 		mockRunnable4.On("Run", mock.Anything).Return(nil).Maybe()
@@ -1616,80 +1588,75 @@ func TestCompositeRunner_ReloadAfterStop(t *testing.T) {
 // Run unblocks the caller via the inner ctx.Done() select case.
 func TestCompositeRunner_ReloadCancelMidFlight(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		// Slow-stop child blocks Run inside reloadWithRestart so the caller is
+		// observably parked in the post-send select. synctest.Wait() returns
+		// once the bubble is quiescent — the only path to quiescence after
+		// Reload runs through this <-slowStop park.
+		slowStop := make(chan struct{})
+		mockRunnable1 := mocks.NewMockRunnable()
+		mockRunnable1.On("String").Return("slow").Maybe()
+		mockRunnable1.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+			<-args.Get(0).(context.Context).Done()
+		}).Return(context.Canceled).Maybe()
+		mockRunnable1.On("Stop").Run(func(_ mock.Arguments) {
+			<-slowStop
+		}).Return().Maybe()
 
-	// Slow-stop child blocks Run inside reloadWithRestart so the caller is
-	// observably parked in the post-send select. slowStopEntered fires the
-	// first time Stop is called, giving the test a deterministic signal that
-	// Run has picked up the reload request.
-	slowStop := make(chan struct{})
-	slowStopEntered := atomic.Bool{}
-	mockRunnable1 := mocks.NewMockRunnable()
-	mockRunnable1.On("String").Return("slow").Maybe()
-	mockRunnable1.On("Run", mock.Anything).Run(func(args mock.Arguments) {
-		<-args.Get(0).(context.Context).Done()
-	}).Return(context.Canceled).Maybe()
-	mockRunnable1.On("Stop").Run(func(_ mock.Arguments) {
-		slowStopEntered.Store(true)
-		<-slowStop
-	}).Return().Maybe()
+		mockRunnable2 := mocks.NewMockRunnable()
+		mockRunnable2.On("String").Return("fast").Maybe()
+		mockRunnable2.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+			<-args.Get(0).(context.Context).Done()
+		}).Return(context.Canceled).Maybe()
+		mockRunnable2.On("Stop").Return().Maybe()
 
-	mockRunnable2 := mocks.NewMockRunnable()
-	mockRunnable2.On("String").Return("fast").Maybe()
-	mockRunnable2.On("Run", mock.Anything).Run(func(args mock.Arguments) {
-		<-args.Get(0).(context.Context).Done()
-	}).Return(context.Canceled).Maybe()
-	mockRunnable2.On("Stop").Return().Maybe()
-
-	initial := []RunnableEntry[*mocks.Runnable]{{Runnable: mockRunnable1}}
-	swapped := []RunnableEntry[*mocks.Runnable]{{Runnable: mockRunnable2}}
-	useSwapped := atomic.Bool{}
-	cb := func() (*Config[*mocks.Runnable], error) {
-		if useSwapped.Load() {
-			return NewConfig("swapped", swapped)
+		initial := []RunnableEntry[*mocks.Runnable]{{Runnable: mockRunnable1}}
+		swapped := []RunnableEntry[*mocks.Runnable]{{Runnable: mockRunnable2}}
+		useSwapped := atomic.Bool{}
+		cb := func() (*Config[*mocks.Runnable], error) {
+			if useSwapped.Load() {
+				return NewConfig("swapped", swapped)
+			}
+			return NewConfig("initial", initial)
 		}
-		return NewConfig("initial", initial)
-	}
 
-	runner, err := NewRunner(cb)
-	require.NoError(t, err)
+		runner, err := NewRunner(cb)
+		require.NoError(t, err)
 
-	runCtx, runCancel := context.WithCancel(t.Context())
-	defer runCancel()
-	runErr := make(chan error, 1)
-	go func() { runErr <- runner.Run(runCtx) }()
+		runCtx, runCancel := context.WithCancel(t.Context())
+		defer runCancel()
+		runErr := make(chan error, 1)
+		go func() { runErr <- runner.Run(runCtx) }()
 
-	require.Eventually(
-		t, runner.IsRunning, 2*time.Second, 10*time.Millisecond,
-	)
+		synctest.Wait()
+		require.True(t, runner.IsRunning())
 
-	useSwapped.Store(true)
-	reloadCtx, reloadCancel := context.WithCancel(context.Background())
-	reloadDone := make(chan struct{})
-	go func() {
-		defer close(reloadDone)
-		runner.Reload(reloadCtx)
-	}()
+		useSwapped.Store(true)
+		reloadCtx, reloadCancel := context.WithCancel(context.Background())
+		reloadDone := make(chan struct{})
+		go func() {
+			defer close(reloadDone)
+			runner.Reload(reloadCtx)
+		}()
 
-	require.Eventually(
-		t, slowStopEntered.Load, 2*time.Second, 10*time.Millisecond,
-		"Run should have picked up the reload and entered slow Stop",
-	)
+		synctest.Wait()
 
-	reloadCancel()
-	select {
-	case <-reloadDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Reload did not return after caller ctx cancel")
-	}
+		reloadCancel()
+		select {
+		case <-reloadDone:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Reload did not return after caller ctx cancel")
+		}
 
-	// Release the slow child so the runner can shut down cleanly.
-	close(slowStop)
-	runCancel()
-	select {
-	case <-runErr:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Run did not return after ctx cancel")
-	}
+		// Release the slow child so the runner can shut down cleanly.
+		close(slowStop)
+		runCancel()
+		select {
+		case <-runErr:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Run did not return after ctx cancel")
+		}
+	})
 }
 
 // TestCompositeRunner_AbandonedReloadIsSkipped verifies that a membership-change

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -1611,14 +1611,18 @@ func TestCompositeRunner_ReloadCancelMidFlight(t *testing.T) {
 	t.Parallel()
 
 	// Slow-stop child blocks Run inside reloadWithRestart so the caller is
-	// observably parked in the post-send select.
+	// observably parked in the post-send select. slowStopEntered fires the
+	// first time Stop is called, giving the test a deterministic signal that
+	// Run has picked up the reload request.
 	slowStop := make(chan struct{})
+	slowStopEntered := atomic.Bool{}
 	mockRunnable1 := mocks.NewMockRunnable()
 	mockRunnable1.On("String").Return("slow").Maybe()
 	mockRunnable1.On("Run", mock.Anything).Run(func(args mock.Arguments) {
 		<-args.Get(0).(context.Context).Done()
 	}).Return(context.Canceled).Maybe()
 	mockRunnable1.On("Stop").Run(func(_ mock.Arguments) {
+		slowStopEntered.Store(true)
 		<-slowStop
 	}).Return().Maybe()
 
@@ -1659,8 +1663,10 @@ func TestCompositeRunner_ReloadCancelMidFlight(t *testing.T) {
 		runner.Reload(reloadCtx)
 	}()
 
-	// Wait long enough for Run to pick up the request and block on slowStop.
-	time.Sleep(100 * time.Millisecond)
+	require.Eventually(
+		t, slowStopEntered.Load, 2*time.Second, 10*time.Millisecond,
+		"Run should have picked up the reload and entered slow Stop",
+	)
 
 	reloadCancel()
 	select {

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -160,7 +160,15 @@ func TestCompositeRunner_Reload(t *testing.T) {
 		mockRunnable3 := mocks.NewMockRunnable()
 		mockRunnable3.On("String").Return("runnable3").Maybe()
 		mockRunnable3.On("Stop").Maybe()
+		// run3Called signals when the child goroutine has actually entered
+		// Run. boot() returns once the goroutines have started (startWg.Done),
+		// not once they've called subRunnable.Run — without this signal, the
+		// AssertExpectations below races the goroutine in non-race builds
+		// (CI runs without -race; -race incidentally synchronizes enough to
+		// mask the race locally).
+		var run3Called atomic.Bool
 		mockRunnable3.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+			run3Called.Store(true)
 			<-args.Get(0).(context.Context).Done()
 		}).Return(context.Canceled).Once()
 
@@ -221,6 +229,12 @@ func TestCompositeRunner_Reload(t *testing.T) {
 
 		// Verify state cycle completed
 		assert.Equal(t, finitestate.StatusRunning, runner.GetState())
+
+		// Wait for mockRunnable3's goroutine to actually invoke Run before
+		// asserting expectations — see the run3Called comment at the mock
+		// setup for why this is needed.
+		require.Eventually(t, run3Called.Load, 2*time.Second, 10*time.Millisecond,
+			"mockRunnable3.Run should have been entered after membership-change reload")
 
 		runner.Stop()
 		require.Eventually(t, func() bool {

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1021,7 +1022,7 @@ func TestReloadConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call reloadConfig directly
-		runner.reloadSkipRestart(config)
+		runner.reloadSkipRestart(t.Context(), config)
 
 		// Verify reloadable interface methods were called
 		mockRunnable1.AssertExpectations(t)
@@ -1059,8 +1060,7 @@ func TestReloadConfig(t *testing.T) {
 		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
-		// Call reloadConfig directly
-		runner.reloadSkipRestart(config)
+		runner.reloadSkipRestart(t.Context(), config)
 
 		// Verify ReloadWithConfig was called with correct configs
 		mockReloadable1.AssertExpectations(t)
@@ -1108,9 +1108,8 @@ func TestReloadConfig(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		// Call reloadConfig on both runners
-		runner1.reloadSkipRestart(config1)
-		runner2.reloadSkipRestart(config2)
+		runner1.reloadSkipRestart(t.Context(), config1)
+		runner2.reloadSkipRestart(t.Context(), config2)
 
 		// Verify expectations
 		mockRunnable.AssertExpectations(t)
@@ -1179,13 +1178,7 @@ func TestReloadMembershipChanged(t *testing.T) {
 		assert.NotNil(t, initialConfigLoaded)
 		assert.Len(t, initialConfigLoaded.Entries, 2)
 
-		// Set runCtx (normally done by Run)
-		runner.runnablesMu.Lock()
-		runner.ctx = t.Context()
-		runner.runnablesMu.Unlock()
-
-		// Call reloadMembershipChanged directly
-		err = runner.reloadWithRestart(newConfig)
+		err = runner.reloadWithRestart(t.Context(), newConfig)
 		require.NoError(t, err)
 
 		// Verify config was updated
@@ -1223,14 +1216,7 @@ func TestReloadMembershipChanged(t *testing.T) {
 		newConfig, err := NewConfig("test", newEntries)
 		require.NoError(t, err)
 
-		// Set runCtx (normally done by Run)
-		runner.runnablesMu.Lock()
-		runner.ctx = t.Context()
-		runner.runnablesMu.Unlock()
-
-		// Call reloadMembershipChanged
-		// This should fail because getConfig() returns nil in stopRunnables
-		err = runner.reloadWithRestart(newConfig)
+		err = runner.reloadWithRestart(t.Context(), newConfig)
 
 		// Verify error
 		require.Error(t, err)
@@ -1337,13 +1323,7 @@ func TestReloadMembershipChanged(t *testing.T) {
 		// Make sure initial config is loaded
 		runner.currentConfig.Store(initialConfig)
 
-		// Set runCtx (normally done by Run)
-		runner.runnablesMu.Lock()
-		runner.ctx = t.Context()
-		runner.runnablesMu.Unlock()
-
-		// Call reloadMembershipChanged directly - should no longer error with empty entries
-		err = runner.reloadWithRestart(newConfig)
+		err = runner.reloadWithRestart(t.Context(), newConfig)
 		require.NoError(t, err)
 
 		// Verify config was updated
@@ -1494,13 +1474,9 @@ func TestHasMembershipChanged(t *testing.T) {
 			return NewConfig("test2", initialEntries)
 		}
 
-		ctx := context.Background() // Use a clean context instead of t.Context()
+		ctx := context.Background()
 		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
-
-		runner.runnablesMu.Lock()
-		runner.ctx = ctx
-		runner.runnablesMu.Unlock()
 
 		errCh := make(chan error, 1)
 		go func() {
@@ -1557,6 +1533,150 @@ func TestHasMembershipChanged(t *testing.T) {
 		mockRunnable3.AssertExpectations(t)
 		mockRunnable4.AssertExpectations(t)
 	})
+}
+
+// TestCompositeRunner_ReloadAfterStop verifies that calling Reload after Stop
+// returns promptly instead of hanging. dispatchMembershipReload's outer select
+// on lc.DoneCh() short-circuits once Run has exited.
+func TestCompositeRunner_ReloadAfterStop(t *testing.T) {
+	t.Parallel()
+
+	mockRunnable1 := mocks.NewMockRunnable()
+	mockRunnable1.On("String").Return("a").Maybe()
+	mockRunnable1.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		<-args.Get(0).(context.Context).Done()
+	}).Return(context.Canceled).Maybe()
+	mockRunnable1.On("Stop").Return().Maybe()
+
+	mockRunnable2 := mocks.NewMockRunnable()
+	mockRunnable2.On("String").Return("b").Maybe()
+
+	initial := []RunnableEntry[*mocks.Runnable]{{Runnable: mockRunnable1}}
+	swapped := []RunnableEntry[*mocks.Runnable]{{Runnable: mockRunnable2}}
+	useSwapped := atomic.Bool{}
+	cb := func() (*Config[*mocks.Runnable], error) {
+		if useSwapped.Load() {
+			return NewConfig("post-stop", swapped)
+		}
+		return NewConfig("initial", initial)
+	}
+
+	runner, err := NewRunner(cb)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- runner.Run(ctx) }()
+
+	require.Eventually(
+		t, runner.IsRunning, 2*time.Second, 10*time.Millisecond,
+	)
+
+	runner.Stop()
+	require.Eventually(
+		t,
+		func() bool { return runner.GetState() == finitestate.StatusStopped },
+		2*time.Second, 10*time.Millisecond,
+	)
+
+	// Membership-change reload after Stop must not hang. The Reload may
+	// fail at the FSM check or inside dispatchMembershipReload — both are
+	// acceptable; what matters is that it returns promptly.
+	useSwapped.Store(true)
+	reloadDone := make(chan struct{})
+	go func() {
+		defer close(reloadDone)
+		runner.Reload(t.Context())
+	}()
+	select {
+	case <-reloadDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reload after Stop did not return — likely hung in dispatchMembershipReload")
+	}
+
+	cancel()
+	select {
+	case <-runErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}
+
+// TestCompositeRunner_ReloadCancelMidFlight verifies that cancelling the
+// caller's context after dispatchMembershipReload has handed the request to
+// Run unblocks the caller via the inner ctx.Done() select case.
+func TestCompositeRunner_ReloadCancelMidFlight(t *testing.T) {
+	t.Parallel()
+
+	// Slow-stop child blocks Run inside reloadWithRestart so the caller is
+	// observably parked in the post-send select.
+	slowStop := make(chan struct{})
+	mockRunnable1 := mocks.NewMockRunnable()
+	mockRunnable1.On("String").Return("slow").Maybe()
+	mockRunnable1.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		<-args.Get(0).(context.Context).Done()
+	}).Return(context.Canceled).Maybe()
+	mockRunnable1.On("Stop").Run(func(_ mock.Arguments) {
+		<-slowStop
+	}).Return().Maybe()
+
+	mockRunnable2 := mocks.NewMockRunnable()
+	mockRunnable2.On("String").Return("fast").Maybe()
+	mockRunnable2.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		<-args.Get(0).(context.Context).Done()
+	}).Return(context.Canceled).Maybe()
+	mockRunnable2.On("Stop").Return().Maybe()
+
+	initial := []RunnableEntry[*mocks.Runnable]{{Runnable: mockRunnable1}}
+	swapped := []RunnableEntry[*mocks.Runnable]{{Runnable: mockRunnable2}}
+	useSwapped := atomic.Bool{}
+	cb := func() (*Config[*mocks.Runnable], error) {
+		if useSwapped.Load() {
+			return NewConfig("swapped", swapped)
+		}
+		return NewConfig("initial", initial)
+	}
+
+	runner, err := NewRunner(cb)
+	require.NoError(t, err)
+
+	runCtx, runCancel := context.WithCancel(t.Context())
+	defer runCancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- runner.Run(runCtx) }()
+
+	require.Eventually(
+		t, runner.IsRunning, 2*time.Second, 10*time.Millisecond,
+	)
+
+	useSwapped.Store(true)
+	reloadCtx, reloadCancel := context.WithCancel(context.Background())
+	reloadDone := make(chan struct{})
+	go func() {
+		defer close(reloadDone)
+		runner.Reload(reloadCtx)
+	}()
+
+	// Wait long enough for Run to pick up the request and block on slowStop.
+	time.Sleep(100 * time.Millisecond)
+
+	reloadCancel()
+	select {
+	case <-reloadDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reload did not return after caller ctx cancel")
+	}
+
+	// Release the slow child so the runner can shut down cleanly.
+	close(slowStop)
+	runCancel()
+	select {
+	case <-runErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
 }
 
 func TestCompositeRunner_ConcurrentReload(t *testing.T) {

--- a/runnables/composite/runner.go
+++ b/runnables/composite/runner.go
@@ -35,11 +35,14 @@ type Runner[T runnable] struct {
 	reloadMu    sync.Mutex
 	runnablesMu sync.Mutex
 
-	// will be set by Run()
-	ctx context.Context
-
+	reloadCh     chan reloadRequest[T]
 	serverErrors chan error
 	logger       *slog.Logger
+}
+
+type reloadRequest[T runnable] struct {
+	newConfig *Config[T]
+	done      chan error
 }
 
 // NewRunner creates a new CompositeRunner instance with the provided configuration callback and options.
@@ -57,6 +60,7 @@ func NewRunner[T runnable](
 		lc:             lifecycle.New(),
 		currentConfig:  atomic.Pointer[Config[T]]{},
 		configCallback: configCallback,
+		reloadCh:       make(chan reloadRequest[T], 1),
 		serverErrors:   make(chan error, 1),
 		logger:         logger,
 	}
@@ -96,15 +100,16 @@ func (r *Runner[T]) String() string {
 // Run starts all child runnables in order (first to last) and monitors for completion or errors.
 // This method blocks until all child runnables are stopped or an error occurs.
 func (r *Runner[T]) Run(ctx context.Context) error {
+	// Defer order matters: drainReloadCh runs LAST so it catches any reload
+	// request that arrived after lc.done() closed DoneCh but before this
+	// function returned. lc.done() runs before drainReloadCh so DoneCh-based
+	// callers see the runner as stopped while we drain stragglers.
+	defer r.drainReloadCh()
 	done := r.lc.Started()
 	defer done()
 
 	runCtx, runCancel := context.WithCancel(ctx)
 	defer runCancel()
-
-	r.runnablesMu.Lock()
-	r.ctx = runCtx
-	r.runnablesMu.Unlock()
 
 	// Transition from New to Booting
 	if err := r.fsm.Transition(finitestate.StatusBooting); err != nil {
@@ -123,18 +128,12 @@ func (r *Runner[T]) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to transition to Running state: %w", err)
 	}
 
-	// Wait for context cancellation, stop signal, or errors
-	select {
-	case <-runCtx.Done():
-		r.logger.Debug("Local context canceled")
-	case <-r.lc.StopCh():
-		r.logger.Debug("Stop() called")
-		runCancel()
-	case err := <-r.serverErrors:
-		r.setStateError()
-		stopErr := r.stopAllRunnables()
-		return fmt.Errorf("%w: %w", ErrRunnableFailed, errors.Join(err, stopErr))
+	if err := r.waitForEvent(runCtx); err != nil {
+		return err
 	}
+	runCancel()
+
+	r.drainReloadCh()
 
 	if err := r.fsm.TransitionIfCurrentState(finitestate.StatusRunning, finitestate.StatusStopping); err != nil {
 		// This error is expected if we're already stopping, so only log at debug level
@@ -160,6 +159,41 @@ func (r *Runner[T]) Run(ctx context.Context) error {
 // Stop signals the runner to shut down and blocks until Run() completes.
 func (r *Runner[T]) Stop() {
 	r.lc.Stop()
+}
+
+// waitForEvent blocks until context cancellation, stop signal, or a child error.
+// Membership-change reloads are processed inline via reloadCh so new children
+// boot into ctx's cancellation tree.
+func (r *Runner[T]) waitForEvent(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			r.logger.Debug("Local context canceled")
+			return nil
+		case <-r.lc.StopCh():
+			r.logger.Debug("Stop() called")
+			return nil
+		case err := <-r.serverErrors:
+			r.setStateError()
+			r.drainReloadCh()
+			stopErr := r.stopAllRunnables()
+			return fmt.Errorf("%w: %w", ErrRunnableFailed, errors.Join(err, stopErr))
+		case req := <-r.reloadCh:
+			req.done <- r.reloadWithRestart(ctx, req.newConfig)
+		}
+	}
+}
+
+// drainReloadCh rejects any pending reload requests queued after Run's select loop exits.
+func (r *Runner[T]) drainReloadCh() {
+	for {
+		select {
+		case req := <-r.reloadCh:
+			req.done <- fmt.Errorf("runner is shutting down")
+		default:
+			return
+		}
+	}
 }
 
 // boot starts all child runnables in the order they're defined.

--- a/runnables/composite/runner.go
+++ b/runnables/composite/runner.go
@@ -35,14 +35,57 @@ type Runner[T runnable] struct {
 	reloadMu    sync.Mutex
 	runnablesMu sync.Mutex
 
-	reloadCh     chan reloadRequest[T]
+	reloadCh     chan *reloadRequest[T]
 	serverErrors chan error
 	logger       *slog.Logger
 }
 
+// reloadRequest carries a membership-change reload from Reload() into Run's
+// event loop so new children boot into runCtx's cancellation tree. The cancel
+// signal lets the caller revoke the request if its own ctx fired before Run
+// picked the request up — without that, RunReload would apply side effects
+// (stop, swap, reboot) that the caller already gave up waiting for.
+//
+// The struct is a pure message — no back-reference to the runner. The
+// consumer hands RunReload the restart function it should call, which keeps
+// reloadRequest unit-testable in isolation and avoids the Runner ↔
+// reloadRequest cycle.
 type reloadRequest[T runnable] struct {
 	newConfig *Config[T]
 	done      chan error
+	cancel    <-chan struct{}
+}
+
+// newReloadRequest builds a reloadRequest with a buffered done channel. cancel
+// is the caller's "I gave up" signal; close it to ask the consumer to skip
+// the work.
+func newReloadRequest[T runnable](
+	newConfig *Config[T], cancel <-chan struct{},
+) *reloadRequest[T] {
+	return &reloadRequest[T]{
+		newConfig: newConfig,
+		done:      make(chan error, 1),
+		cancel:    cancel,
+	}
+}
+
+// RunReload is the consumer-side entry point. It checks whether the caller
+// has abandoned the request and, if not, calls restart with ctx (Run's
+// runCtx) so new children inherit the runner's lifetime rather than the
+// caller's. restart is supplied by the caller (typically
+// Runner.reloadWithRestart) so reloadRequest stays a pure message with no
+// back-reference to the runner.
+func (req *reloadRequest[T]) RunReload(
+	ctx context.Context,
+	restart func(context.Context, *Config[T]) error,
+) {
+	select {
+	case <-req.cancel:
+		req.done <- fmt.Errorf("%w: abandoned by caller", ErrReloadAborted)
+		return
+	default:
+	}
+	req.done <- restart(ctx, req.newConfig)
 }
 
 // NewRunner creates a new CompositeRunner instance with the provided configuration callback and options.
@@ -60,7 +103,7 @@ func NewRunner[T runnable](
 		lc:             lifecycle.New(),
 		currentConfig:  atomic.Pointer[Config[T]]{},
 		configCallback: configCallback,
-		reloadCh:       make(chan reloadRequest[T], 1),
+		reloadCh:       make(chan *reloadRequest[T], 1),
 		serverErrors:   make(chan error, 1),
 		logger:         logger,
 	}
@@ -179,17 +222,19 @@ func (r *Runner[T]) waitForEvent(ctx context.Context) error {
 			stopErr := r.stopAllRunnables()
 			return fmt.Errorf("%w: %w", ErrRunnableFailed, errors.Join(err, stopErr))
 		case req := <-r.reloadCh:
-			req.done <- r.reloadWithRestart(ctx, req.newConfig)
+			req.RunReload(ctx, r.reloadWithRestart)
 		}
 	}
 }
 
-// drainReloadCh rejects any pending reload requests queued after Run's select loop exits.
+// drainReloadCh discards any pending reload requests queued after Run's
+// select loop exits. The caller's inner select observes lc.DoneCh() and
+// returns "runner stopped while reload pending" on its own — drain is just
+// for clearing the buffer so a restarted runner doesn't see stale entries.
 func (r *Runner[T]) drainReloadCh() {
 	for {
 		select {
-		case req := <-r.reloadCh:
-			req.done <- fmt.Errorf("runner is shutting down")
+		case <-r.reloadCh:
 		default:
 			return
 		}

--- a/runnables/composite/runner_run_test.go
+++ b/runnables/composite/runner_run_test.go
@@ -109,7 +109,6 @@ func TestCompositeRunner_Run_AdditionalScenarios(t *testing.T) {
 
 		// Setup mock runnables that completes immediately
 		mockRunnable := mocks.NewMockRunnable()
-		mockRunnable.DelayStop = 0 // No delay on Stop to avoid flakiness
 		mockRunnable.On("String").Return("runnable").Maybe()
 		mockRunnable.On("Run", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 			ctx := args.Get(0).(context.Context)

--- a/runnables/composite/runner_test.go
+++ b/runnables/composite/runner_test.go
@@ -456,7 +456,6 @@ func TestCompositeRunner_Stop(t *testing.T) {
 				runReturned.Store(true)
 			}()
 
-			time.Sleep(10 * time.Millisecond)
 			synctest.Wait()
 			assert.Equal(t, finitestate.StatusRunning, runner.GetState())
 
@@ -498,7 +497,6 @@ func TestCompositeRunner_Stop(t *testing.T) {
 				stopReturned.Store(true)
 			}()
 
-			time.Sleep(10 * time.Millisecond)
 			synctest.Wait()
 
 			assert.False(t, stopReturned.Load(), "Stop should block until Run starts and completes")
@@ -508,7 +506,6 @@ func TestCompositeRunner_Stop(t *testing.T) {
 				errCh <- runner.Run(t.Context())
 			}()
 
-			time.Sleep(10 * time.Millisecond)
 			synctest.Wait()
 
 			assert.True(t, stopReturned.Load(), "Stop should unblock after Run completes")
@@ -522,7 +519,6 @@ func TestCompositeRunner_Stop(t *testing.T) {
 		t.Parallel()
 		synctest.Test(t, func(t *testing.T) {
 			mock1 := mocks.NewMockRunnable()
-			mock1.DelayStop = 0
 			mock1.On("String").Return("r1")
 			mock1.On("Run", mock.Anything).Run(func(args mock.Arguments) {
 				<-args.Get(0).(context.Context).Done()
@@ -545,7 +541,6 @@ func TestCompositeRunner_Stop(t *testing.T) {
 				errCh <- runner.Run(t.Context())
 			}()
 
-			time.Sleep(10 * time.Millisecond)
 			synctest.Wait()
 			assert.Equal(t, finitestate.StatusRunning, runner.GetState())
 
@@ -591,7 +586,6 @@ func TestCompositeRunner_Stop(t *testing.T) {
 				errCh <- runner.Run(ctx)
 			}()
 
-			time.Sleep(10 * time.Millisecond)
 			synctest.Wait()
 			assert.Equal(t, finitestate.StatusRunning, runner.GetState())
 
@@ -599,7 +593,6 @@ func TestCompositeRunner_Stop(t *testing.T) {
 			go cancel()
 			go runner.Stop()
 
-			time.Sleep(10 * time.Millisecond)
 			synctest.Wait()
 
 			assert.Equal(t, finitestate.StatusStopped, runner.GetState())
@@ -612,12 +605,11 @@ func TestCompositeRunner_Stop(t *testing.T) {
 		t.Parallel()
 		synctest.Test(t, func(t *testing.T) {
 			mock1 := mocks.NewMockRunnable()
-			mock1.DelayStop = 100 * time.Millisecond
 			mock1.On("String").Return("r1")
 			mock1.On("Run", mock.Anything).Run(func(args mock.Arguments) {
 				<-args.Get(0).(context.Context).Done()
 			}).Return(nil)
-			mock1.On("Stop").Once()
+			mock1.On("Stop").Once().After(100 * time.Millisecond)
 
 			entries := []RunnableEntry[*mocks.Runnable]{
 				{Runnable: mock1},
@@ -637,7 +629,6 @@ func TestCompositeRunner_Stop(t *testing.T) {
 				runReturned.Store(true)
 			}()
 
-			time.Sleep(10 * time.Millisecond)
 			synctest.Wait()
 			assert.Equal(t, finitestate.StatusRunning, runner.GetState())
 
@@ -690,14 +681,12 @@ func TestCompositeRunner_StopCancelsChildContexts(t *testing.T) {
 			errCh <- runner.Run(t.Context())
 		}()
 
-		time.Sleep(10 * time.Millisecond)
 		synctest.Wait()
 
 		assert.Equal(t, finitestate.StatusRunning, runner.GetState())
 
 		runner.Stop()
 
-		time.Sleep(10 * time.Millisecond)
 		synctest.Wait()
 
 		select {
@@ -724,13 +713,12 @@ func TestCompositeRunner_StopDuringReload(t *testing.T) {
 	t.Parallel()
 
 	mock1 := mocks.NewMockRunnable()
-	mock1.DelayReload = 50 * time.Millisecond
 	mock1.On("String").Return("r1")
 	mock1.On("Run", mock.Anything).Run(func(args mock.Arguments) {
 		<-args.Get(0).(context.Context).Done()
 	}).Return(nil)
 	mock1.On("Stop").Maybe()
-	mock1.On("Reload", mock.Anything).Maybe()
+	mock1.On("Reload", mock.Anything).Maybe().After(50 * time.Millisecond)
 
 	entries := []RunnableEntry[*mocks.Runnable]{
 		{Runnable: mock1},
@@ -752,7 +740,7 @@ func TestCompositeRunner_StopDuringReload(t *testing.T) {
 		return runner.IsRunning()
 	}, 1*time.Second, 5*time.Millisecond)
 
-	// Start reload in background (holds reloadMu for DelayReload duration)
+	// Start reload in background (the mock's Reload .After() keeps reloadMu held)
 	go runner.Reload(t.Context())
 	require.Eventually(t, func() bool {
 		return runner.GetState() == finitestate.StatusReloading
@@ -878,8 +866,6 @@ func TestCompositeRunner_MultipleChildFailures(t *testing.T) {
 			runErr <- runner.Run(t.Context())
 		}()
 
-		// Advance virtual clock past the mock's default 1ms Run delay
-		time.Sleep(10 * time.Millisecond)
 		synctest.Wait()
 
 		for range 3 {

--- a/runnables/httpserver/reload.go
+++ b/runnables/httpserver/reload.go
@@ -38,9 +38,7 @@ func (r *Runner) reloadConfig() error {
 
 // Reload refreshes the server configuration and restarts the HTTP server if necessary.
 // This method is safe to call while the server is running and will handle graceful shutdown and restart.
-//
-//nolint:contextcheck // r.ctx will be replaced by the ctx parameter in a follow-up PR
-func (r *Runner) Reload(_ context.Context) {
+func (r *Runner) Reload(ctx context.Context) {
 	r.logger.Debug("Reloading...")
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
@@ -67,13 +65,13 @@ func (r *Runner) Reload(_ context.Context) {
 		return
 	}
 
-	if err := r.stopServer(r.ctx); err != nil {
+	if err := r.stopServer(ctx); err != nil {
 		r.logger.Error("Failed to stop server during reload", "error", err)
 		r.setStateError()
 		return
 	}
 
-	if err := r.boot(); err != nil {
+	if err := r.boot(ctx); err != nil {
 		r.logger.Error("Failed to boot server during reload", "error", err)
 		r.setStateError()
 		return

--- a/runnables/httpserver/runner.go
+++ b/runnables/httpserver/runner.go
@@ -57,8 +57,6 @@ type Runner struct {
 	serverMutex     sync.RWMutex
 	serverErrors    chan error
 
-	// Set during Run()
-	ctx    context.Context
 	logger *slog.Logger
 }
 
@@ -130,10 +128,6 @@ func (r *Runner) Run(ctx context.Context) error {
 	runCtx, runCancel := context.WithCancel(ctx)
 	defer runCancel()
 
-	r.mutex.Lock()
-	r.ctx = runCtx
-	r.mutex.Unlock()
-
 	// Transition from New to Booting
 	err := r.fsm.Transition(finitestate.StatusBooting)
 	if err != nil {
@@ -141,7 +135,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	r.mutex.Lock()
-	err = r.boot()
+	err = r.boot(runCtx)
 	r.mutex.Unlock()
 
 	if err != nil {
@@ -218,18 +212,17 @@ func (r *Runner) serverReadinessProbe(ctx context.Context, addr string) error {
 	}
 }
 
-func (r *Runner) boot() error {
+func (r *Runner) boot(ctx context.Context) error {
 	originalCfg := r.getConfig()
 	if originalCfg == nil {
 		return ErrRetrieveConfig
 	}
 
-	// Create server config using Runner's context for request handling
 	serverCfg, err := NewConfig(
 		originalCfg.ListenAddr,
 		originalCfg.Routes,
 		WithConfigCopy(originalCfg), // Copy all other settings
-		WithRequestContext(r.ctx),   // Use the Runner's context
+		WithRequestContext(ctx),
 	)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrCreateConfig, err)
@@ -268,9 +261,8 @@ func (r *Runner) boot() error {
 	}()
 
 	// Verify server is ready to accept connections
-	if err := r.serverReadinessProbe(r.ctx, listenAddr); err != nil {
-		// Clean up partially started server on readiness failure
-		if err := r.stopServer(r.ctx); err != nil {
+	if err := r.serverReadinessProbe(ctx, listenAddr); err != nil {
+		if err := r.stopServer(ctx); err != nil {
 			r.logger.Warn("Error stopping server", "error", err)
 		}
 		return fmt.Errorf("%w: %w", ErrServerBoot, err)

--- a/runnables/httpserver/runner_boot_test.go
+++ b/runnables/httpserver/runner_boot_test.go
@@ -26,7 +26,7 @@ func TestBootConfigCreateFailure(t *testing.T) {
 	runner, err := NewRunner(WithConfigCallback(callback))
 	require.NoError(t, err)
 
-	err = runner.boot()
+	err = runner.boot(t.Context())
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrCreateConfig)
 }

--- a/runnables/mocks/mocks.go
+++ b/runnables/mocks/mocks.go
@@ -1,7 +1,8 @@
 /*
 Package mocks provides mock implementations of all supervisor interfaces for testing.
 These mocks implement the Runnable, Reloadable, Stateable, and ReloadSender interfaces
-with configurable delays to simulate real service behavior in tests.
+following the canonical testify/mock pattern. Tests that need delayed return values
+should use Call.After(d) per-expectation instead of mock-instance fields.
 
 Example:
 ```go
@@ -23,9 +24,9 @@ import (
 		// Create a mock service
 		mockRunnable := mocks.NewMockRunnable()
 
-		// Set expectations
+		// Set expectations (use .After(d) for delayed returns)
 		mockRunnable.On("Run", mock.Anything).Return(nil)
-		mockRunnable.On("Stop").Once()
+		mockRunnable.On("Stop").Once().After(100*time.Millisecond)
 
 		// For state-based tests
 		stateCh := make(chan string)
@@ -46,51 +47,34 @@ package mocks
 
 import (
 	"context"
-	"time"
 
 	"github.com/stretchr/testify/mock"
 )
 
-const defaultDelay = 1 * time.Millisecond
-
 // Runnable is a mock implementation of the Runnable, Reloadable, and Stateable interfaces
-// using testify/mock. It allows for configurable delays in method responses to simulate
-// service behavior.
+// using testify/mock.
 type Runnable struct {
 	mock.Mock
-	DelayRun    time.Duration // Delay before Run returns
-	DelayStop   time.Duration // Delay before Stop returns
-	DelayReload time.Duration // Delay before Reload returns
 }
 
-// NewMockRunnable creates a new Runnable mock with default delays.
+// NewMockRunnable creates a new Runnable mock.
 func NewMockRunnable() *Runnable {
-	return &Runnable{
-		DelayRun:    defaultDelay,
-		DelayStop:   defaultDelay,
-		DelayReload: defaultDelay,
-	}
+	return &Runnable{}
 }
 
 // Run mocks the Run method of the Runnable interface.
-// It sleeps for DelayRun duration before returning the mocked error result.
 func (m *Runnable) Run(ctx context.Context) error {
-	time.Sleep(m.DelayRun)
 	args := m.Called(ctx)
 	return args.Error(0)
 }
 
 // Stop mocks the Stop method of the Runnable interface.
-// It sleeps for DelayStop duration before recording the call.
 func (m *Runnable) Stop() {
-	time.Sleep(m.DelayStop)
 	m.Called()
 }
 
 // Reload mocks the Reload method of the Reloadable interface.
-// It sleeps for DelayReload duration before recording the call.
 func (m *Runnable) Reload(ctx context.Context) {
-	time.Sleep(m.DelayReload)
 	m.Called(ctx)
 }
 
@@ -106,13 +90,11 @@ func (m *Runnable) String() string {
 // MockRunnableWithStateable extends Runnable to also implement the Stateable interface.
 type MockRunnableWithStateable struct {
 	*Runnable
-	DelayGetState time.Duration // Delay before GetState and GetStateChan return
 }
 
 // GetState mocks the GetState method of the Stateable interface.
 // It returns the current state of the service as configured in test expectations.
 func (m *MockRunnableWithStateable) GetState() string {
-	time.Sleep(m.DelayGetState)
 	args := m.Called()
 	return args.String(0)
 }
@@ -131,11 +113,10 @@ func (m *MockRunnableWithStateable) IsRunning() bool {
 	return args.Bool(0)
 }
 
-// NewMockRunnableWithStateable creates a new MockRunnableWithStateable with default delays.
+// NewMockRunnableWithStateable creates a new MockRunnableWithStateable.
 func NewMockRunnableWithStateable() *MockRunnableWithStateable {
 	return &MockRunnableWithStateable{
-		Runnable:      NewMockRunnable(),
-		DelayGetState: defaultDelay,
+		Runnable: NewMockRunnable(),
 	}
 }
 
@@ -151,7 +132,7 @@ func (m *MockRunnableWithReloadSender) GetReloadTrigger() <-chan struct{} {
 	return args.Get(0).(chan struct{})
 }
 
-// NewMockRunnableWithReloadSender creates a new MockRunnableWithReload with default delays.
+// NewMockRunnableWithReloadSender creates a new MockRunnableWithReload.
 func NewMockRunnableWithReloadSender() *MockRunnableWithReloadSender {
 	return &MockRunnableWithReloadSender{
 		Runnable: NewMockRunnable(),
@@ -170,7 +151,7 @@ func (m *MockRunnableWithShutdownSender) GetShutdownTrigger() <-chan struct{} {
 	return args.Get(0).(chan struct{})
 }
 
-// NewMockRunnableWithShutdown creates a new MockRunnableWithReload with default delays.
+// NewMockRunnableWithShutdown creates a new MockRunnableWithReload.
 func NewMockRunnableWithShutdownSender() *MockRunnableWithShutdownSender {
 	return &MockRunnableWithShutdownSender{
 		Runnable: NewMockRunnable(),

--- a/runnables/mocks/mocks_test.go
+++ b/runnables/mocks/mocks_test.go
@@ -121,58 +121,32 @@ func testHelperInheritedMethods(t *testing.T, mockRunnable any, displayName stri
 
 func TestMockRunnable(t *testing.T) {
 	t.Run("Run method", func(t *testing.T) {
-		// Create a mock with a shorter delay for testing
 		mockRunnable := mocks.NewMockRunnable()
-		mockRunnable.DelayRun = 5 * time.Millisecond
 
-		// Set up expectations
 		expectedErr := errors.New("test error")
 		mockRunnable.On("Run", mock.Anything).Return(expectedErr)
 
-		// Call the method
-		start := time.Now()
 		err := mockRunnable.Run(context.Background())
-		elapsed := time.Since(start)
 
-		// Verify behavior
 		assert.Equal(t, expectedErr, err)
-		assert.GreaterOrEqual(t, elapsed, 5*time.Millisecond)
 		mockRunnable.AssertExpectations(t)
 	})
 
 	t.Run("Stop method", func(t *testing.T) {
-		// Create a mock with a shorter delay for testing
 		mockRunnable := mocks.NewMockRunnable()
-		mockRunnable.DelayStop = 5 * time.Millisecond
-
-		// Set up expectations
 		mockRunnable.On("Stop").Return()
 
-		// Call the method
-		start := time.Now()
 		mockRunnable.Stop()
-		elapsed := time.Since(start)
 
-		// Verify behavior
-		assert.GreaterOrEqual(t, elapsed, 5*time.Millisecond)
 		mockRunnable.AssertExpectations(t)
 	})
 
 	t.Run("Reload method", func(t *testing.T) {
-		// Create a mock with a shorter delay for testing
 		mockRunnable := mocks.NewMockRunnable()
-		mockRunnable.DelayReload = 5 * time.Millisecond
-
-		// Set up expectations
 		mockRunnable.On("Reload", mock.Anything).Return()
 
-		// Call the method
-		start := time.Now()
 		mockRunnable.Reload(t.Context())
-		elapsed := time.Since(start)
 
-		// Verify behavior
-		assert.GreaterOrEqual(t, elapsed, 5*time.Millisecond)
 		mockRunnable.AssertExpectations(t)
 	})
 
@@ -209,21 +183,12 @@ func TestMockRunnable(t *testing.T) {
 
 func TestMockRunnableWithStateable(t *testing.T) {
 	t.Run("GetState method", func(t *testing.T) {
-		// Create a mock with a shorter delay for testing
 		mockRunnable := mocks.NewMockRunnableWithStateable()
-		mockRunnable.DelayGetState = 5 * time.Millisecond
-
-		// Set up expectations
 		mockRunnable.On("GetState").Return("running")
 
-		// Call the method
-		start := time.Now()
 		state := mockRunnable.GetState()
-		elapsed := time.Since(start)
 
-		// Verify behavior
 		assert.Equal(t, "running", state)
-		assert.GreaterOrEqual(t, elapsed, 5*time.Millisecond)
 		mockRunnable.AssertExpectations(t)
 	})
 
@@ -325,32 +290,23 @@ func TestMockRunnableWithShutdownSender(t *testing.T) {
 
 // TestFactoryMethods tests the constructor functions for all mock types
 func TestFactoryMethods(t *testing.T) {
-	t.Run("NewMockRunnable creates with default delays", func(t *testing.T) {
-		mock := mocks.NewMockRunnable()
-		assert.Equal(t, 1*time.Millisecond, mock.DelayRun)
-		assert.Equal(t, 1*time.Millisecond, mock.DelayStop)
-		assert.Equal(t, 1*time.Millisecond, mock.DelayReload)
+	t.Run("NewMockRunnable", func(t *testing.T) {
+		m := mocks.NewMockRunnable()
+		assert.NotNil(t, m)
 	})
 
-	t.Run("NewMockRunnableWithStateable creates with default delays", func(t *testing.T) {
-		mock := mocks.NewMockRunnableWithStateable()
-		assert.Equal(t, 1*time.Millisecond, mock.DelayRun)
-		assert.Equal(t, 1*time.Millisecond, mock.DelayStop)
-		assert.Equal(t, 1*time.Millisecond, mock.DelayReload)
-		assert.Equal(t, 1*time.Millisecond, mock.DelayGetState)
+	t.Run("NewMockRunnableWithStateable", func(t *testing.T) {
+		m := mocks.NewMockRunnableWithStateable()
+		assert.NotNil(t, m)
 	})
 
-	t.Run("NewMockRunnableWithReloadSender creates with default delays", func(t *testing.T) {
-		mock := mocks.NewMockRunnableWithReloadSender()
-		assert.Equal(t, 1*time.Millisecond, mock.DelayRun)
-		assert.Equal(t, 1*time.Millisecond, mock.DelayStop)
-		assert.Equal(t, 1*time.Millisecond, mock.DelayReload)
+	t.Run("NewMockRunnableWithReloadSender", func(t *testing.T) {
+		m := mocks.NewMockRunnableWithReloadSender()
+		assert.NotNil(t, m)
 	})
 
-	t.Run("NewMockRunnableWithShutdownSender creates with default delays", func(t *testing.T) {
-		mock := mocks.NewMockRunnableWithShutdownSender()
-		assert.Equal(t, 1*time.Millisecond, mock.DelayRun)
-		assert.Equal(t, 1*time.Millisecond, mock.DelayStop)
-		assert.Equal(t, 1*time.Millisecond, mock.DelayReload)
+	t.Run("NewMockRunnableWithShutdownSender", func(t *testing.T) {
+		m := mocks.NewMockRunnableWithShutdownSender()
+		assert.NotNil(t, m)
 	})
 }

--- a/supervisor/lifecycle/startstop.go
+++ b/supervisor/lifecycle/startstop.go
@@ -2,6 +2,16 @@ package lifecycle
 
 import "sync"
 
+// closedDoneCh is returned by DoneCh() when Started() has not been called.
+// Pre-Run state is treated the same as post-Run for callers: there is no
+// live Run() goroutine, so callers selecting on DoneCh() should abort
+// rather than send into runner-internal channels with no reader.
+var closedDoneCh = func() chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}()
+
 // StartStop manages the Run/Stop synchronization for a Runnable.
 // It ensures Stop() blocks until Run() has completed, handling all
 // orderings: stop-before-run, stop-during-run, stop-after-run,
@@ -79,4 +89,22 @@ func (l *StartStop) StopCh() <-chan struct{} {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.stopCh
+}
+
+// DoneCh returns a channel that is closed when Run() has exited (the done
+// func returned by Started has been called). If Started has not yet been
+// called, DoneCh returns an already-closed channel: callers should treat
+// pre-Run identically to post-Run, since neither state has a live Run()
+// goroutine to receive from runner-internal channels.
+//
+// Use this to avoid sending into a buffered runner channel that no
+// goroutine will drain, e.g. a reload-request channel after Run has
+// finished its select loop.
+func (l *StartStop) DoneCh() <-chan struct{} {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.doneCh == nil {
+		return closedDoneCh
+	}
+	return l.doneCh
 }

--- a/supervisor/lifecycle/startstop_test.go
+++ b/supervisor/lifecycle/startstop_test.go
@@ -5,7 +5,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -23,7 +22,6 @@ func TestStartStop_StopBlocksUntilRunCompletes(t *testing.T) {
 			runReturned.Store(true)
 		}()
 
-		time.Sleep(time.Second)
 		synctest.Wait()
 
 		lc.Stop()
@@ -43,7 +41,6 @@ func TestStartStop_StopBeforeRun(t *testing.T) {
 			stopReturned.Store(true)
 		}()
 
-		time.Sleep(time.Second)
 		synctest.Wait()
 
 		assert.False(t, stopReturned.Load(), "Stop should block until Run starts and completes")
@@ -51,7 +48,6 @@ func TestStartStop_StopBeforeRun(t *testing.T) {
 		done := lc.Started()
 		done()
 
-		time.Sleep(time.Second)
 		synctest.Wait()
 
 		assert.True(t, stopReturned.Load(), "Stop should unblock after Run completes")
@@ -81,7 +77,6 @@ func TestStartStop_MultipleConcurrentStops(t *testing.T) {
 			<-lc.StopCh()
 		}()
 
-		time.Sleep(time.Second)
 		synctest.Wait()
 
 		var wg sync.WaitGroup
@@ -135,7 +130,6 @@ func TestStartStop_Restart(t *testing.T) {
 				runReturned.Store(true)
 			}()
 
-			time.Sleep(time.Second)
 			synctest.Wait()
 
 			lc.Stop()
@@ -226,7 +220,6 @@ func TestStartStop_StopChClosedAfterStop(t *testing.T) {
 			<-lc.StopCh()
 		}()
 
-		time.Sleep(time.Second)
 		synctest.Wait()
 
 		lc.Stop()

--- a/supervisor/lifecycle/startstop_test.go
+++ b/supervisor/lifecycle/startstop_test.go
@@ -145,6 +145,76 @@ func TestStartStop_Restart(t *testing.T) {
 	})
 }
 
+func TestStartStop_DoneChClosedBeforeStarted(t *testing.T) {
+	t.Parallel()
+	lc := New()
+
+	select {
+	case <-lc.DoneCh():
+	default:
+		t.Fatal("DoneCh should be closed before Started() is called")
+	}
+}
+
+func TestStartStop_DoneChOpenWhileRunning(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		lc := New()
+
+		done := lc.Started()
+
+		select {
+		case <-lc.DoneCh():
+			t.Fatal("DoneCh should not be closed while Run is in progress")
+		default:
+		}
+
+		done()
+
+		select {
+		case <-lc.DoneCh():
+		default:
+			t.Fatal("DoneCh should be closed after done() is called")
+		}
+	})
+}
+
+func TestStartStop_DoneChAcrossRestart(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		lc := New()
+
+		// First cycle: open then closed.
+		done := lc.Started()
+		select {
+		case <-lc.DoneCh():
+			t.Fatal("DoneCh should be open during first run")
+		default:
+		}
+		done()
+		lc.Stop()
+		select {
+		case <-lc.DoneCh():
+		default:
+			t.Fatal("DoneCh should be closed after first cycle")
+		}
+
+		// Second cycle: a fresh open channel must be returned.
+		done = lc.Started()
+		select {
+		case <-lc.DoneCh():
+			t.Fatal("DoneCh should be a fresh open channel for the second run")
+		default:
+		}
+		done()
+		select {
+		case <-lc.DoneCh():
+		default:
+			t.Fatal("DoneCh should be closed after second cycle done()")
+		}
+	})
+}
+
 func TestStartStop_StopChClosedAfterStop(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {

--- a/supervisor/reload_test.go
+++ b/supervisor/reload_test.go
@@ -240,8 +240,7 @@ func TestPIDZero_ReloadManager(t *testing.T) {
 		mockService := mocks.NewMockRunnable()
 		mockService.On("Run", mock.Anything).Return(nil)
 		mockService.On("Stop").Return()
-		mockService.DelayReload = 500 * time.Millisecond
-		mockService.On("Reload", mock.Anything).Return()
+		mockService.On("Reload", mock.Anything).Return().After(500 * time.Millisecond)
 
 		pid0, err := New(WithContext(context.Background()), WithRunnables(mockService))
 		require.NoError(t, err)

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -714,12 +714,10 @@ func TestPIDZero_ShutdownIgnoresSIGHUP(t *testing.T) {
 	t.Parallel()
 	// Create a mock runnable
 	mockRunnable := mocks.NewMockRunnable()
-	mockRunnable.DelayStop = 500 * time.Millisecond
-	mockRunnable.DelayRun = 1 * time.Millisecond
 	mockRunnable.On("Run", mock.Anything).Return(nil).Once()
 	// Expect Reload not to be called
 	// Stop should be called once during shutdown
-	mockRunnable.On("Stop").Once()
+	mockRunnable.On("Stop").Once().After(500 * time.Millisecond)
 	mockRunnable.On("Reload", mock.Anything).Panic("Reload should not be called")
 
 	// Setup for Stateable interface
@@ -795,12 +793,10 @@ func TestPIDZero_CancelContextFromParent(t *testing.T) {
 	t.Parallel()
 	// Create a mock runnable
 	mockRunnable := mocks.NewMockRunnable()
-	mockRunnable.DelayStop = 500 * time.Millisecond
-	mockRunnable.DelayRun = 1 * time.Millisecond
 	mockRunnable.On("Run", mock.Anything).Return(nil).Once()
 	// Expect Reload not to be called
 	// Stop should be called once during shutdown
-	mockRunnable.On("Stop").Once()
+	mockRunnable.On("Stop").Once().After(500 * time.Millisecond)
 
 	// Setup for Stateable interface
 	stateChan := make(chan string)
@@ -981,9 +977,8 @@ func TestPIDZero_Shutdown_NoTimeout(t *testing.T) {
 
 	mockRunnable := mocks.NewMockRunnableWithStateable()
 	mockRunnable.On("String").Return("noTimeoutRunnable").Maybe()
-	mockRunnable.DelayStop = 50 * time.Millisecond // Small delay to test wait
 	mockRunnable.On("Run", mock.Anything).Return(nil).Once()
-	mockRunnable.On("Stop").Once()
+	mockRunnable.On("Stop").Once().After(50 * time.Millisecond) // Small delay to test wait
 	mockRunnable.On("IsRunning").Return(true)
 
 	// Setup for Stateable interface


### PR DESCRIPTION
## Summary

Final piece of the context lifecycle redesign series (#89, #90, #92). Removes stored `r.ctx` from the composite and httpserver runners by wiring `Reload(ctx)` (added in #92) through to internal calls. PR review (Copilot + Codex + Gemini) surfaced a correctness bug in cancelled-reload behavior, fixed in a follow-up commit; review also surfaced flaky tests that prompted a mock-infrastructure and `testing/synctest` cleanup.

## Production changes

### HTTPServer
`Reload(ctx)` passes ctx straight to `stopServer(ctx)` and `boot(ctx)`. The `//nolint:contextcheck` workaround on `Reload` is removed.

### Composite — context wiring
Membership-changing reloads dispatch through `Run`'s event loop via a new `reloadCh` so that restarted children boot into `runCtx`'s cancellation tree (rather than the supervisor's outer context). Non-membership reloads pass ctx straight to child `Reload(ctx)`. `Run`'s select loop is extracted into `waitForEvent(ctx)`; `drainReloadCh()` rejects in-flight requests at shutdown.

### Composite — cancelled reloads are honest and FSM-safe (`fb8f893`, from review feedback)
- `dispatchMembershipReload` now rechecks `req.done` after `ctx.Done()` AND `lc.DoneCh()` fire, so a reload that completes concurrently with caller cancellation or runner shutdown returns its real result instead of the cancellation lie.
- Cancelled reloads, runner-stopped reloads, and "runner not in Running" reloads no longer move the FSM to `Error` — they're normal control flow. A single `ErrReloadAborted` sentinel lets callers (and `Reload` itself) distinguish those from real failures.
- `reloadRequest` is a pure message — no back-reference to the runner. `RunReload` takes the restart function as a parameter, so the request is unit-testable in isolation. Drops the `reloadExecutor` interface (speculative, one impl) and uses the concrete `*reloadRequest` directly.

### lifecycle.StartStop
Adds `DoneCh()` so callers (specifically `dispatchMembershipReload`) can detect when `Run()` has exited and abort cleanly instead of hanging on a buffered channel with no reader. The composite `Run()` defer order is adjusted so the lifecycle done signal fires before the final deferred `drainReloadCh()` runs, narrowing the post-exit window where late requests could otherwise sit unhandled.

## Test infrastructure changes

### `make test-norace`
New Makefile target that mimics CI: `go test -timeout 3m -count=10 ./...` with no `-race`. The `-race` detector incidentally synchronizes enough to mask several goroutine-ordering races; CI runs without it. This target reproduces those races locally.

### Mock cleanup (`runnables/mocks/mocks.go`)
The mock's `Run`/`Stop`/`Reload`/`GetState` methods called `time.Sleep` BEFORE `m.Called`, delaying the call's registration with testify by ~1ms (the default `Delay*` value). Tests asserting on the mock right after triggering it raced this window — passed with `-race`, failed in CI. Removed `DelayRun`/`DelayStop`/`DelayReload`/`DelayGetState` fields and `defaultDelay` entirely; mocks now follow testify's canonical pattern (`args := m.Called(ctx); return args.Error(0)`). Tests that needed delayed returns migrated to per-expectation `Call.After(d)`.

### `testing/synctest` migration
Removing the sleep narrowed but didn't close the goroutine-scheduling race in `TestCompositeRunner_Reload/reload_with_updated_runnables` — `boot()` returns before children's `Run` is invoked. Migrated that test (and `TestCompositeRunner_ReloadCancelMidFlight`) to `synctest.Test` + `synctest.Wait()`, which deterministically waits until all children are durably blocked before assertions fire. Follow-up sweep removed redundant `time.Sleep` calls in `lifecycle/startstop_test.go`, `composite/runner_test.go`, and `composite/integration_race_test.go` that were dead weight inside synctest bubbles.