### PR TITLE
Bound per-runnable Stop() with the shutdown deadline

### DIFF
--- a/supervisor/shutdown_test.go
+++ b/supervisor/shutdown_test.go
@@ -12,266 +12,405 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPIDZero_StartShutdownManager_TriggersShutdown verifies that receiving a signal
-// on a ShutdownSender's trigger channel calls the supervisor's Shutdown method.
-// Cannot use synctest: the listener goroutine calls Shutdown() which calls wg.Wait()
-// on the same WaitGroup that includes startShutdownManager, creating a circular dependency
-// that synctest's "all goroutines must complete" requirement turns into a deadlock.
-func TestPIDZero_StartShutdownManager_TriggersShutdown(t *testing.T) {
+func TestPIDZero_Shutdown(t *testing.T) {
 	t.Parallel()
 
-	supervisorCtx, supervisorCancel := context.WithCancel(context.Background())
-	defer supervisorCancel()
-
-	mockService := mocks.NewMockRunnableWithShutdownSender()
-	shutdownChan := make(chan struct{}, 1)
-	stopCalled := make(chan struct{})
-
-	mockService.On("GetShutdownTrigger").Return(shutdownChan).Once()
-	mockService.On("String").Return("mockShutdownService")
-	mockService.On("Stop").Return().Once().Run(func(args mock.Arguments) {
-		close(stopCalled)
-	})
-
-	pidZero, err := New(WithContext(supervisorCtx), WithRunnables(mockService))
-	require.NoError(t, err)
-
-	pidZero.wg.Go(pidZero.startShutdownManager)
-
-	shutdownChan <- struct{}{}
-
-	select {
-	case <-stopCalled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Stop() was not called, Shutdown() likely not invoked")
-	}
-
-	mockService.AssertExpectations(t)
-}
-
-// TestPIDZero_StartShutdownManager_ContextCancel verifies that the manager
-// cleans up its listener goroutines when the main context is cancelled.
-func TestPIDZero_StartShutdownManager_ContextCancel(t *testing.T) {
-	t.Parallel()
-	synctest.Test(t, func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
+	// Cannot use synctest: the listener goroutine calls Shutdown() which calls
+	// wg.Wait() on the same WaitGroup that includes startShutdownManager,
+	// creating a circular dependency that synctest's "all goroutines must
+	// complete" requirement turns into a deadlock.
+	t.Run("shutdown sender trigger calls shutdown", func(t *testing.T) {
+		supervisorCtx, supervisorCancel := context.WithCancel(context.Background())
+		defer supervisorCancel()
 
 		mockService := mocks.NewMockRunnableWithShutdownSender()
-		shutdownChan := make(chan struct{})
+		shutdownChan := make(chan struct{}, 1)
+		stopCalled := make(chan struct{})
 
 		mockService.On("GetShutdownTrigger").Return(shutdownChan).Once()
+		mockService.On("String").Return("mockShutdownService")
+		mockService.On("Stop").Return().Once().Run(func(args mock.Arguments) {
+			close(stopCalled)
+		})
 
-		pidZero, err := New(WithContext(ctx), WithRunnables(mockService))
-		require.NoError(t, err)
-
+		pidZero := newTestPIDZero(t, WithContext(supervisorCtx), WithRunnables(mockService))
 		pidZero.wg.Go(pidZero.startShutdownManager)
 
-		cancel()
-		synctest.Wait()
+		shutdownChan <- struct{}{}
+		eventuallyClosed(t, stopCalled, "Stop() was not called, Shutdown() likely not invoked")
 
 		mockService.AssertExpectations(t)
 	})
-}
 
-// TestPIDZero_StartShutdownManager_NoSenders verifies that the manager
-// starts and stops cleanly even if no runnables implement ShutdownSender.
-func TestPIDZero_StartShutdownManager_NoSenders(t *testing.T) {
-	t.Parallel()
-	synctest.Test(t, func(t *testing.T) {
-		ctx, cancel := context.WithCancel(t.Context())
-		defer cancel()
+	t.Run("shutdown manager exits on context cancel", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
 
-		nonSenderRunnable := mocks.NewMockRunnable()
+			mockService := mocks.NewMockRunnableWithShutdownSender()
+			shutdownChan := make(chan struct{})
 
-		pidZero, err := New(WithContext(ctx), WithRunnables(nonSenderRunnable))
-		require.NoError(t, err)
+			mockService.On("GetShutdownTrigger").Return(shutdownChan).Once()
 
-		pidZero.wg.Go(pidZero.startShutdownManager)
+			pidZero := newTestPIDZero(t, WithContext(ctx), WithRunnables(mockService))
+			pidZero.wg.Go(pidZero.startShutdownManager)
 
-		cancel()
-		synctest.Wait()
+			cancel()
+			synctest.Wait()
 
-		nonSenderRunnable.AssertExpectations(t)
-	})
-}
-
-// TestPIDZero_Shutdown_WithTimeoutNotExceeded verifies that shutdown completes
-// successfully when runnables finish within the configured timeout.
-// Cannot use synctest: calls pidZero.Run() which uses signal.Notify.
-func TestPIDZero_Shutdown_WithTimeoutNotExceeded(t *testing.T) {
-	t.Parallel()
-
-	stopCalled := make(chan struct{})
-
-	runnable := mocks.NewMockRunnable()
-	runStarted := make(chan struct{})
-
-	runnable.On("Run", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-		close(runStarted)
-		<-stopCalled
+			mockService.AssertExpectations(t)
+		})
 	})
 
-	runnable.On("Stop").Once().Run(func(args mock.Arguments) {
-		close(stopCalled)
+	t.Run("shutdown manager handles no senders", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			nonSenderRunnable := mocks.NewMockRunnable()
+
+			pidZero := newTestPIDZero(t, WithContext(ctx), WithRunnables(nonSenderRunnable))
+			pidZero.wg.Go(pidZero.startShutdownManager)
+
+			cancel()
+			synctest.Wait()
+
+			nonSenderRunnable.AssertExpectations(t)
+		})
 	})
 
-	pidZero, err := New(
-		WithRunnables(runnable),
-		WithShutdownTimeout(2*time.Second),
-	)
-	require.NoError(t, err)
+	// Cannot use synctest: this calls pidZero.Run(), which uses signal.Notify.
+	t.Run("shutdown completes before timeout", func(t *testing.T) {
+		stopCalled := make(chan struct{})
 
-	execDone := make(chan error, 1)
-	go func() {
-		execDone <- pidZero.Run()
-	}()
+		runnable := mocks.NewMockRunnable()
+		runStarted := make(chan struct{})
 
-	select {
-	case <-runStarted:
-	case <-time.After(time.Second):
-		t.Fatal("Run did not start in time")
-	}
+		runnable.On("Run", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			close(runStarted)
+			<-stopCalled
+		})
 
-	shutdownStart := time.Now()
-	pidZero.Shutdown()
-	shutdownDuration := time.Since(shutdownStart)
+		runnable.On("Stop").Once().Run(func(args mock.Arguments) {
+			close(stopCalled)
+		})
 
-	assert.Less(t, shutdownDuration, 1*time.Second,
-		"Shutdown took too long: %v", shutdownDuration)
+		pidZero := newTestPIDZero(t,
+			WithRunnables(runnable),
+			WithShutdownTimeout(2*time.Second),
+		)
 
-	select {
-	case err := <-execDone:
-		require.NoError(t, err)
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("Run did not complete after shutdown")
-	}
+		execDone := startPIDZeroRun(t, pidZero)
+		eventuallyClosed(t, runStarted, "Run did not start in time")
 
-	runnable.AssertExpectations(t)
-}
-
-// TestPIDZero_Shutdown_WithTimeoutExceeded verifies that shutdown still completes
-// but logs a warning when the timeout is exceeded by goroutines that don't stop timely.
-// Cannot use synctest: calls pidZero.Run() which uses signal.Notify.
-func TestPIDZero_Shutdown_WithTimeoutExceeded(t *testing.T) {
-	t.Parallel()
-
-	stopCalled := make(chan struct{})
-	shutdownComplete := make(chan struct{})
-
-	runnable := mocks.NewMockRunnable()
-
-	runStarted := make(chan struct{})
-	runnable.On("Run", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-		close(runStarted)
-		select {
-		case <-stopCalled:
-		case <-shutdownComplete:
-		}
-	})
-
-	runnable.On("Stop").Once().Run(func(args mock.Arguments) {
-		time.Sleep(50 * time.Millisecond)
-	})
-
-	pidZero, err := New(
-		WithRunnables(runnable),
-		WithShutdownTimeout(200*time.Millisecond),
-	)
-	require.NoError(t, err)
-
-	execDone := make(chan error, 1)
-	go func() {
-		execDone <- pidZero.Run()
-	}()
-
-	select {
-	case <-runStarted:
-	case <-time.After(time.Second):
-		t.Fatal("Run did not start in time")
-	}
-
-	shutdownStart := time.Now()
-	shutdownDone := make(chan struct{})
-	go func() {
+		shutdownStart := time.Now()
 		pidZero.Shutdown()
-		close(shutdownDone)
-	}()
+		shutdownDuration := time.Since(shutdownStart)
 
-	select {
-	case <-shutdownDone:
+		assert.Less(t, shutdownDuration, time.Second,
+			"Shutdown took too long: %v", shutdownDuration)
+		requirePIDZeroRunDone(t, execDone, 200*time.Millisecond)
+
+		runnable.AssertExpectations(t)
+	})
+
+	// Cannot use synctest: this calls pidZero.Run(), which uses signal.Notify.
+	t.Run("shutdown times out waiting for goroutines", func(t *testing.T) {
+		stopCalled := make(chan struct{})
+		shutdownComplete := make(chan struct{})
+
+		runnable := mocks.NewMockRunnable()
+
+		runStarted := make(chan struct{})
+		runnable.On("Run", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			close(runStarted)
+			select {
+			case <-stopCalled:
+			case <-shutdownComplete:
+			}
+		})
+
+		runnable.On("Stop").Once().Run(func(args mock.Arguments) {
+			time.Sleep(50 * time.Millisecond)
+		})
+
+		pidZero := newTestPIDZero(t,
+			WithRunnables(runnable),
+			WithShutdownTimeout(200*time.Millisecond),
+		)
+
+		_ = startPIDZeroRun(t, pidZero)
+		eventuallyClosed(t, runStarted, "Run did not start in time")
+
+		shutdownStart := time.Now()
+		shutdownDone := make(chan struct{})
+		go func() {
+			pidZero.Shutdown()
+			close(shutdownDone)
+		}()
+
+		eventuallyClosed(t, shutdownDone, "Shutdown did not complete despite timeout")
 		shutdownDuration := time.Since(shutdownStart)
 
 		assert.GreaterOrEqual(t, shutdownDuration, 200*time.Millisecond,
 			"Shutdown returned too quickly: %v", shutdownDuration)
 		assert.Less(t, shutdownDuration, 500*time.Millisecond,
 			"Shutdown took too long: %v", shutdownDuration)
-	case <-time.After(1 * time.Second):
-		t.Fatal("Shutdown did not complete despite timeout")
-	}
 
-	close(shutdownComplete)
-	runnable.AssertExpectations(t)
-}
-
-// TestPIDZero_Shutdown_HungStopBoundedByDeadline verifies that a runnable
-// whose Stop() never returns does NOT wedge the supervisor's Shutdown()
-// indefinitely. The total shutdown timeout bounds Stop() calls; on expiry,
-// the goroutine is abandoned and shutdown proceeds.
-//
-// Regression: prior to the total-deadline fix, Shutdown() called Stop()
-// synchronously and the timeout only bounded the post-Stop wg.Wait(). A
-// single hung Stop() blocked shutdown forever before the timeout engaged.
-func TestPIDZero_Shutdown_HungStopBoundedByDeadline(t *testing.T) {
-	t.Parallel()
-
-	hangForever := make(chan struct{}) // never closed by the test path
-	t.Cleanup(func() {
-		// Release the orphaned Stop goroutine so the test's runnable
-		// goroutines can exit cleanly when the test framework tears down.
-		close(hangForever)
+		close(shutdownComplete)
+		runnable.AssertExpectations(t)
 	})
 
-	runnable := mocks.NewMockRunnable()
-	runStarted := make(chan struct{})
-	runnable.On("Run", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-		close(runStarted)
-		<-hangForever
-	})
-	runnable.On("Stop").Run(func(args mock.Arguments) {
-		<-hangForever
-	})
+	t.Run("hung stop is bounded by deadline", func(t *testing.T) {
+		hangForever := make(chan struct{})
+		t.Cleanup(func() {
+			close(hangForever)
+		})
 
-	pidZero, err := New(
-		WithRunnables(runnable),
-		WithShutdownTimeout(150*time.Millisecond),
-	)
-	require.NoError(t, err)
+		runnable := mocks.NewMockRunnable()
+		runStarted := make(chan struct{})
+		runnable.On("Run", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			close(runStarted)
+			<-hangForever
+		})
+		runnable.On("Stop").Run(func(args mock.Arguments) {
+			<-hangForever
+		})
 
-	execDone := make(chan error, 1)
-	go func() { execDone <- pidZero.Run() }()
+		pidZero := newTestPIDZero(t,
+			WithRunnables(runnable),
+			WithShutdownTimeout(150*time.Millisecond),
+		)
 
-	select {
-	case <-runStarted:
-	case <-time.After(time.Second):
-		t.Fatal("Run did not start in time")
-	}
+		_ = startPIDZeroRun(t, pidZero)
+		eventuallyClosed(t, runStarted, "Run did not start in time")
 
-	shutdownStart := time.Now()
-	shutdownDone := make(chan struct{})
-	go func() {
-		pidZero.Shutdown()
-		close(shutdownDone)
-	}()
+		shutdownStart := time.Now()
+		shutdownDone := make(chan struct{})
+		go func() {
+			pidZero.Shutdown()
+			close(shutdownDone)
+		}()
 
-	select {
-	case <-shutdownDone:
+		eventuallyClosed(t, shutdownDone, "Shutdown blocked despite timeout; total-deadline fix not active")
 		elapsed := time.Since(shutdownStart)
+
 		assert.GreaterOrEqual(t, elapsed, 150*time.Millisecond,
 			"Shutdown returned too quickly: %v", elapsed)
-		assert.Less(t, elapsed, 1*time.Second,
+		assert.Less(t, elapsed, time.Second,
 			"Shutdown should return near the deadline despite hung Stop(); got %v", elapsed)
-	case <-time.After(3 * time.Second):
-		t.Fatal("Shutdown blocked despite timeout — total-deadline fix not active")
+	})
+
+	t.Run("abandoned runnable can return error after shutdown", func(t *testing.T) {
+		releaseRun := make(chan struct{})
+		releaseStop := make(chan struct{})
+		t.Cleanup(func() {
+			close(releaseStop)
+		})
+
+		runnable := mocks.NewMockRunnable()
+		runStarted := make(chan struct{})
+		runnable.On("Run", mock.Anything).Return(assert.AnError).Run(func(args mock.Arguments) {
+			close(runStarted)
+			<-releaseRun
+		})
+		runnable.On("Stop").Run(func(args mock.Arguments) {
+			<-releaseStop
+		})
+
+		pidZero := newTestPIDZero(t,
+			WithRunnables(runnable),
+			WithShutdownTimeout(50*time.Millisecond),
+		)
+
+		execDone := startPIDZeroRun(t, pidZero)
+		eventuallyClosed(t, runStarted, "Run did not start in time")
+
+		shutdownDone := make(chan struct{})
+		go func() {
+			pidZero.Shutdown()
+			close(shutdownDone)
+		}()
+
+		eventuallyClosed(t, shutdownDone, "Shutdown did not complete after abandoning Stop()")
+
+		close(releaseRun)
+
+		assert.Eventually(t, func() bool {
+			return len(pidZero.errorChan) == 1
+		}, time.Second, 10*time.Millisecond)
+
+		select {
+		case err := <-execDone:
+			require.NoError(t, err)
+		default:
+		}
+
+		runnable.AssertExpectations(t)
+	})
+
+	t.Run("abandoned stop does not cache post state", func(t *testing.T) {
+		releaseStop := make(chan struct{})
+		t.Cleanup(func() {
+			close(releaseStop)
+		})
+
+		runnable := mocks.NewMockRunnableWithStateable()
+		runnable.On("String").Return("stateable-runnable").Maybe()
+		runnable.On("GetState").Return("running").Once()
+		runnable.On("Stop").Run(func(args mock.Arguments) {
+			<-releaseStop
+		})
+
+		pidZero := newTestPIDZero(t,
+			WithRunnables(runnable),
+			WithShutdownTimeout(50*time.Millisecond),
+		)
+		pidZero.stateMap.Store(runnable, "cached-running")
+
+		shutdownDone := make(chan struct{})
+		go func() {
+			pidZero.Shutdown()
+			close(shutdownDone)
+		}()
+
+		eventuallyClosed(t, shutdownDone, "Shutdown did not complete after abandoning Stop()")
+
+		cachedState, ok := pidZero.stateMap.Load(runnable)
+		require.True(t, ok)
+		assert.Equal(t, "cached-running", cachedState)
+		runnable.AssertExpectations(t)
+	})
+
+	t.Run("completed stop caches post state", func(t *testing.T) {
+		runnable := mocks.NewMockRunnableWithStateable()
+		runnable.On("String").Return("stateable-runnable").Maybe()
+		runnable.On("GetState").Return("running").Once()
+		runnable.On("GetState").Return("stopped").Once()
+		runnable.On("Stop").Once()
+
+		pidZero := newTestPIDZero(t,
+			WithRunnables(runnable),
+			WithShutdownTimeout(time.Second),
+		)
+		pidZero.stateMap.Store(runnable, "cached-running")
+
+		pidZero.Shutdown()
+
+		cachedState, ok := pidZero.stateMap.Load(runnable)
+		require.True(t, ok)
+		assert.Equal(t, "stopped", cachedState)
+		runnable.AssertExpectations(t)
+	})
+
+	t.Run("stop runnable bounded completes before deadline", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			runnable := mocks.NewMockRunnable()
+			runnable.On("Stop").Once()
+
+			pidZero := newTestPIDZero(t, WithRunnables(runnable))
+
+			stopped := pidZero.stopRunnableBounded(
+				runnable,
+				time.Now().Add(time.Second),
+				time.Now(),
+			)
+
+			assert.True(t, stopped)
+			runnable.AssertExpectations(t)
+		})
+	})
+
+	t.Run("stop runnable bounded deadline expires", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			releaseStop := make(chan struct{})
+
+			runnable := mocks.NewMockRunnable()
+			runnable.On("Stop").Run(func(args mock.Arguments) {
+				<-releaseStop
+			})
+
+			pidZero := newTestPIDZero(t,
+				WithRunnables(runnable),
+				WithShutdownTimeout(time.Second),
+			)
+
+			stopped := pidZero.stopRunnableBounded(
+				runnable,
+				time.Now().Add(time.Second),
+				time.Now(),
+			)
+			assert.False(t, stopped)
+
+			close(releaseStop)
+			synctest.Wait()
+			runnable.AssertExpectations(t)
+		})
+	})
+
+	t.Run("stop runnable bounded deadline already expired", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			releaseStop := make(chan struct{})
+
+			runnable := mocks.NewMockRunnable()
+			runnable.On("Stop").Run(func(args mock.Arguments) {
+				<-releaseStop
+			})
+
+			pidZero := newTestPIDZero(t, WithRunnables(runnable))
+
+			stopped := pidZero.stopRunnableBounded(
+				runnable,
+				time.Now().Add(-time.Nanosecond),
+				time.Now(),
+			)
+			assert.False(t, stopped)
+
+			close(releaseStop)
+			synctest.Wait()
+			runnable.AssertExpectations(t)
+		})
+	})
+}
+
+func newTestPIDZero(t *testing.T, opts ...Option) *PIDZero {
+	t.Helper()
+
+	pidZero, err := New(opts...)
+	require.NoError(t, err)
+	return pidZero
+}
+
+func startPIDZeroRun(t *testing.T, pidZero *PIDZero) <-chan error {
+	t.Helper()
+
+	execDone := make(chan error, 1)
+	go func() {
+		execDone <- pidZero.Run()
+	}()
+	return execDone
+}
+
+func eventuallyClosed(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+
+	assert.Eventually(t, func() bool {
+		select {
+		case <-ch:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond, message)
+}
+
+func requirePIDZeroRunDone(t *testing.T, execDone <-chan error, timeout time.Duration) {
+	t.Helper()
+
+	select {
+	case err := <-execDone:
+		require.NoError(t, err)
+	case <-time.After(timeout):
+		t.Fatal("Run did not complete after shutdown")
 	}
 }

--- a/supervisor/shutdown_test.go
+++ b/supervisor/shutdown_test.go
@@ -25,10 +25,13 @@ func TestPIDZero_StartShutdownManager_TriggersShutdown(t *testing.T) {
 
 	mockService := mocks.NewMockRunnableWithShutdownSender()
 	shutdownChan := make(chan struct{}, 1)
+	stopCalled := make(chan struct{})
 
 	mockService.On("GetShutdownTrigger").Return(shutdownChan).Once()
 	mockService.On("String").Return("mockShutdownService")
-	mockService.On("Stop").Return().Once()
+	mockService.On("Stop").Return().Once().Run(func(args mock.Arguments) {
+		close(stopCalled)
+	})
 
 	pidZero, err := New(WithContext(supervisorCtx), WithRunnables(mockService))
 	require.NoError(t, err)
@@ -38,9 +41,9 @@ func TestPIDZero_StartShutdownManager_TriggersShutdown(t *testing.T) {
 	shutdownChan <- struct{}{}
 
 	select {
-	case <-pidZero.ctx.Done():
+	case <-stopCalled:
 	case <-time.After(2 * time.Second):
-		t.Fatal("Supervisor context was not cancelled, Shutdown() likely not called")
+		t.Fatal("Stop() was not called, Shutdown() likely not invoked")
 	}
 
 	mockService.AssertExpectations(t)
@@ -209,4 +212,66 @@ func TestPIDZero_Shutdown_WithTimeoutExceeded(t *testing.T) {
 
 	close(shutdownComplete)
 	runnable.AssertExpectations(t)
+}
+
+// TestPIDZero_Shutdown_HungStopBoundedByDeadline verifies that a runnable
+// whose Stop() never returns does NOT wedge the supervisor's Shutdown()
+// indefinitely. The total shutdown timeout bounds Stop() calls; on expiry,
+// the goroutine is abandoned and shutdown proceeds.
+//
+// Regression: prior to the total-deadline fix, Shutdown() called Stop()
+// synchronously and the timeout only bounded the post-Stop wg.Wait(). A
+// single hung Stop() blocked shutdown forever before the timeout engaged.
+func TestPIDZero_Shutdown_HungStopBoundedByDeadline(t *testing.T) {
+	t.Parallel()
+
+	hangForever := make(chan struct{}) // never closed by the test path
+	t.Cleanup(func() {
+		// Release the orphaned Stop goroutine so the test's runnable
+		// goroutines can exit cleanly when the test framework tears down.
+		close(hangForever)
+	})
+
+	runnable := mocks.NewMockRunnable()
+	runStarted := make(chan struct{})
+	runnable.On("Run", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		close(runStarted)
+		<-hangForever
+	})
+	runnable.On("Stop").Run(func(args mock.Arguments) {
+		<-hangForever
+	})
+
+	pidZero, err := New(
+		WithRunnables(runnable),
+		WithShutdownTimeout(150*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	execDone := make(chan error, 1)
+	go func() { execDone <- pidZero.Run() }()
+
+	select {
+	case <-runStarted:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not start in time")
+	}
+
+	shutdownStart := time.Now()
+	shutdownDone := make(chan struct{})
+	go func() {
+		pidZero.Shutdown()
+		close(shutdownDone)
+	}()
+
+	select {
+	case <-shutdownDone:
+		elapsed := time.Since(shutdownStart)
+		assert.GreaterOrEqual(t, elapsed, 150*time.Millisecond,
+			"Shutdown returned too quickly: %v", elapsed)
+		assert.Less(t, elapsed, 1*time.Second,
+			"Shutdown should return near the deadline despite hung Stop(); got %v", elapsed)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Shutdown blocked despite timeout — total-deadline fix not active")
+	}
 }

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -293,8 +293,9 @@ func (p *PIDZero) blockUntilRunnableReady(r Stateable) error {
 // wall-clock budget for the entire shutdown, shared between per-runnable
 // Stop() calls and the final wait for goroutines. If a runnable's Stop()
 // blocks past the remaining budget, its goroutine is abandoned (logged
-// warning) and shutdown continues — the orphaned goroutine will be reaped
-// when the process exits. A timeout of 0 disables the deadline.
+// warning) and shutdown continues. Abandoned runnable goroutines may keep
+// running after Shutdown returns and will be reaped when the process exits.
+// A timeout of 0 disables the deadline.
 //
 // The supervisor's context is cancelled before the Stop loop begins so that
 // runnables which watch their runCtx for cancellation can begin teardown
@@ -330,13 +331,13 @@ func (p *PIDZero) Shutdown() {
 			p.logger.Debug("Stopping", "runnable", r)
 			stopped := p.stopRunnableBounded(r, deadline, shutdownStart)
 
-			if stateable, ok := r.(Stateable); ok {
-				finalState := stateable.GetState()
-				p.stateMap.Store(r, finalState)
-				p.logger.Debug("Post-shutdown state",
-					"runnable", r, "state", finalState)
-			}
 			if stopped {
+				if stateable, ok := r.(Stateable); ok {
+					finalState := stateable.GetState()
+					p.stateMap.Store(r, finalState)
+					p.logger.Debug("Post-shutdown state",
+						"runnable", r, "state", finalState)
+				}
 				p.logger.Debug("Runnable stopped",
 					"runnable", r, "duration", time.Since(runnableStart))
 			}
@@ -345,7 +346,6 @@ func (p *PIDZero) Shutdown() {
 		p.logger.Debug("Waiting for runnables to complete...")
 		p.waitForGoroutines(deadline, shutdownStart)
 
-		close(p.errorChan) // close the error channel, since no runnables can send errors
 		p.logger.Debug("Shutdown complete", "duration", time.Since(shutdownStart))
 	})
 }

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -32,9 +32,11 @@ const (
 	DefaultStartupTimeout = 2 * time.Minute       // Default per-Runnable max timeout for startup
 	DefaultStartupInitial = 50 * time.Millisecond // Initial wait time for startup
 
-	// DefaultShutdownTimeout is the TOTAL timeout for waiting on all supervisor goroutines
-	// (including external runnables) to complete during shutdown, *after* Stop() has been called
-	// on all of the runnables.
+	// DefaultShutdownTimeout is the TOTAL wall-clock budget for graceful
+	// shutdown, shared between per-runnable Stop() calls and the final wait
+	// for goroutine completion. If a runnable's Stop() blocks past the
+	// remaining budget, its goroutine is abandoned (logged) and shutdown
+	// continues. A timeout of 0 disables the deadline.
 	DefaultShutdownTimeout = 2 * time.Minute
 )
 
@@ -122,9 +124,12 @@ func WithStartupInitial(initial time.Duration) Option {
 	}
 }
 
-// WithShutdownTimeout sets the timeout for graceful shutdown of all runnables.
-// If the timeout is reached before all runnables have completed their shutdown,
-// the supervisor will log a warning but continue with the shutdown process.
+// WithShutdownTimeout sets the TOTAL wall-clock timeout for graceful shutdown.
+// The budget bounds both per-runnable Stop() calls and the final wait for
+// goroutines to complete. If a runnable's Stop() blocks past the remaining
+// budget, its goroutine is abandoned (logged warning) and shutdown
+// continues to the next runnable. A timeout of 0 disables the deadline
+// (waits indefinitely).
 func WithShutdownTimeout(timeout time.Duration) Option {
 	return func(p *PIDZero) {
 		if timeout > 0 {
@@ -283,74 +288,133 @@ func (p *PIDZero) blockUntilRunnableReady(r Stateable) error {
 	}
 }
 
-// Shutdown stops all runnables in reverse initialization order and attempts
-// to wait for their goroutines to complete. Each runnable's Stop method will
-// always be called regardless of timeouts. However, if shutdownTimeout is
-// configured and exceeded, this function will return before all goroutines
-// complete, potentially causing unclean termination if the program exits
-// immediately afterward.
+// Shutdown stops all runnables in reverse initialization order and waits for
+// their goroutines to complete. The configured shutdown timeout is the TOTAL
+// wall-clock budget for the entire shutdown, shared between per-runnable
+// Stop() calls and the final wait for goroutines. If a runnable's Stop()
+// blocks past the remaining budget, its goroutine is abandoned (logged
+// warning) and shutdown continues — the orphaned goroutine will be reaped
+// when the process exits. A timeout of 0 disables the deadline.
+//
+// The supervisor's context is cancelled before the Stop loop begins so that
+// runnables which watch their runCtx for cancellation can begin teardown
+// immediately, rather than waiting for the serial Stop() loop to reach them.
 func (p *PIDZero) Shutdown() {
 	p.shutdownOnce.Do(func() {
 		shutdownStart := time.Now()
 		p.logger.Info("Graceful shutdown has been initiated...")
 		signal.Stop(p.signalChan) // stop listening for new signals
 
-		// Stop each runnable in reverse order
+		// Cancel first so runnables watching runCtx can start teardown
+		// before potentially-blocking Stop() calls reach them.
+		p.cancel()
+
+		// Compute the wall-clock deadline for the entire shutdown. Zero
+		// means no deadline (wait indefinitely).
+		var deadline time.Time
+		if p.shutdownTimeout > 0 {
+			deadline = shutdownStart.Add(p.shutdownTimeout)
+		}
+
+		// Stop each runnable in reverse order. Each Stop() runs in its own
+		// goroutine so we can bound it by the remaining budget.
 		for i := len(p.runnables) - 1; i >= 0; i-- {
 			r := p.runnables[i]
 
-			// Log the state before stopping if available
 			if stateable, ok := r.(Stateable); ok {
-				currentState := stateable.GetState()
-				p.logger.Debug("Pre-shutdown state", "runnable", r, "state", currentState)
+				p.logger.Debug("Pre-shutdown state",
+					"runnable", r, "state", stateable.GetState())
 			}
 
 			runnableStart := time.Now()
 			p.logger.Debug("Stopping", "runnable", r)
-			r.Stop()
-			stopDuration := time.Since(runnableStart)
+			p.stopRunnableBounded(r, deadline, shutdownStart)
 
-			// Log the state after stopping if available
 			if stateable, ok := r.(Stateable); ok {
 				finalState := stateable.GetState()
 				p.stateMap.Store(r, finalState)
-				p.logger.Debug("Post-shutdown state", "runnable", r, "state", finalState)
+				p.logger.Debug("Post-shutdown state",
+					"runnable", r, "state", finalState)
 			}
-
-			p.logger.Debug("Runnable stopped", "runnable", r, "duration", stopDuration)
+			p.logger.Debug("Runnable stopped",
+				"runnable", r, "duration", time.Since(runnableStart))
 		}
 
 		p.logger.Debug("Waiting for runnables to complete...")
-		p.cancel() // cancel the context for any remaining goroutines
-
-		// Set up a timeout for wait if configured
-		if p.shutdownTimeout > 0 {
-			// Create a channel to signal when wg.Wait() completes
-			done := make(chan struct{})
-			go func() {
-				p.wg.Wait()
-				close(done)
-			}()
-
-			// Wait for either completion or timeout
-			select {
-			case <-done:
-				p.logger.Debug("All goroutines completed")
-			case <-time.After(p.shutdownTimeout):
-				p.logger.Warn("Shutdown timeout exceeded waiting for goroutines",
-					"timeout", p.shutdownTimeout,
-					"elapsed", time.Since(shutdownStart))
-			}
-		} else {
-			// No timeout configured, wait indefinitely
-			p.wg.Wait()
-		}
+		p.waitForGoroutines(deadline, shutdownStart)
 
 		close(p.errorChan) // close the error channel, since no runnables can send errors
-
-		totalShutdownTime := time.Since(shutdownStart)
-		p.logger.Debug("Shutdown complete", "duration", totalShutdownTime)
+		p.logger.Debug("Shutdown complete", "duration", time.Since(shutdownStart))
 	})
+}
+
+// stopRunnableBounded calls r.Stop() in a goroutine and waits up to the
+// remaining budget. If the deadline expires first, the goroutine is left
+// running (orphaned) and the function returns so shutdown can proceed. A
+// zero deadline means no deadline.
+func (p *PIDZero) stopRunnableBounded(r Runnable, deadline, shutdownStart time.Time) {
+	stopDone := make(chan struct{})
+	go func() {
+		r.Stop()
+		close(stopDone)
+	}()
+
+	if deadline.IsZero() {
+		<-stopDone
+		return
+	}
+
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		p.logger.Warn("Shutdown deadline already exceeded; abandoning Stop()",
+			"runnable", r, "elapsed", time.Since(shutdownStart))
+		return
+	}
+
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+	select {
+	case <-stopDone:
+	case <-timer.C:
+		p.logger.Warn("Stop() exceeded shutdown deadline; abandoning goroutine",
+			"runnable", r,
+			"elapsed", time.Since(shutdownStart),
+			"timeout", p.shutdownTimeout)
+	}
+}
+
+// waitForGoroutines waits for all runnable goroutines to complete, bounded
+// by the remaining budget. A zero deadline waits indefinitely.
+func (p *PIDZero) waitForGoroutines(deadline, shutdownStart time.Time) {
+	if deadline.IsZero() {
+		p.wg.Wait()
+		return
+	}
+
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		p.logger.Warn("Shutdown timeout exceeded; not waiting for goroutines",
+			"timeout", p.shutdownTimeout,
+			"elapsed", time.Since(shutdownStart))
+		return
+	}
+
+	done := make(chan struct{})
+	go func() {
+		p.wg.Wait()
+		close(done)
+	}()
+
+	timer := time.NewTimer(remaining)
+	defer timer.Stop()
+	select {
+	case <-done:
+		p.logger.Debug("All goroutines completed")
+	case <-timer.C:
+		p.logger.Warn("Shutdown timeout exceeded waiting for goroutines",
+			"timeout", p.shutdownTimeout,
+			"elapsed", time.Since(shutdownStart))
+	}
 }
 
 // SendSignal injects a signal into the supervisor's signal handling loop.

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -328,7 +328,7 @@ func (p *PIDZero) Shutdown() {
 
 			runnableStart := time.Now()
 			p.logger.Debug("Stopping", "runnable", r)
-			p.stopRunnableBounded(r, deadline, shutdownStart)
+			stopped := p.stopRunnableBounded(r, deadline, shutdownStart)
 
 			if stateable, ok := r.(Stateable); ok {
 				finalState := stateable.GetState()
@@ -336,8 +336,10 @@ func (p *PIDZero) Shutdown() {
 				p.logger.Debug("Post-shutdown state",
 					"runnable", r, "state", finalState)
 			}
-			p.logger.Debug("Runnable stopped",
-				"runnable", r, "duration", time.Since(runnableStart))
+			if stopped {
+				p.logger.Debug("Runnable stopped",
+					"runnable", r, "duration", time.Since(runnableStart))
+			}
 		}
 
 		p.logger.Debug("Waiting for runnables to complete...")
@@ -349,10 +351,9 @@ func (p *PIDZero) Shutdown() {
 }
 
 // stopRunnableBounded calls r.Stop() in a goroutine and waits up to the
-// remaining budget. If the deadline expires first, the goroutine is left
-// running (orphaned) and the function returns so shutdown can proceed. A
-// zero deadline means no deadline.
-func (p *PIDZero) stopRunnableBounded(r Runnable, deadline, shutdownStart time.Time) {
+// remaining budget. Returns true if Stop() completed before the deadline,
+// false if the goroutine was abandoned. A zero deadline means no deadline.
+func (p *PIDZero) stopRunnableBounded(r Runnable, deadline, shutdownStart time.Time) bool {
 	stopDone := make(chan struct{})
 	go func() {
 		r.Stop()
@@ -361,25 +362,27 @@ func (p *PIDZero) stopRunnableBounded(r Runnable, deadline, shutdownStart time.T
 
 	if deadline.IsZero() {
 		<-stopDone
-		return
+		return true
 	}
 
 	remaining := time.Until(deadline)
 	if remaining <= 0 {
 		p.logger.Warn("Shutdown deadline already exceeded; abandoning Stop()",
 			"runnable", r, "elapsed", time.Since(shutdownStart))
-		return
+		return false
 	}
 
 	timer := time.NewTimer(remaining)
 	defer timer.Stop()
 	select {
 	case <-stopDone:
+		return true
 	case <-timer.C:
 		p.logger.Warn("Stop() exceeded shutdown deadline; abandoning goroutine",
 			"runnable", r,
 			"elapsed", time.Since(shutdownStart),
 			"timeout", p.shutdownTimeout)
+		return false
 	}
 }
 


### PR DESCRIPTION
Shutdown() called Stop() synchronously, so a single hung Stop() wedged the supervisor forever — the configured timeout only bounded the post-Stop wg.Wait() and never engaged. Repurpose WithShutdownTimeout as a TOTAL wall-clock budget shared between Stop() calls and the final wait. Each Stop() runs in its own goroutine; on deadline expiry the goroutine is abandoned (logged) and shutdown proceeds.

Cancel the supervisor ctx before the Stop loop so runnables that watch their runCtx for cancellation can begin teardown without waiting for the serial Stop loop to reach them.

Adds TestPIDZero_Shutdown_HungStopBoundedByDeadline regression test. Existing TestPIDZero_StartShutdownManager_TriggersShutdown updated to wait on Stop() being called rather than ctx.Done(), since cancel-first breaks the implicit ordering.