### PR TITLE
Break circular wait between ShutdownSender listener and shutdown manager

### DIFF
--- a/supervisor/shutdown.go
+++ b/supervisor/shutdown.go
@@ -13,21 +13,23 @@ func (p *PIDZero) startShutdownManager() {
 	for _, r := range p.runnables {
 		if sdSender, ok := r.(ShutdownSender); ok {
 			shutdownWg.Add(1)
-			// Pass both Runnable 'r' and ShutdownSender 's' for clarity
 			go func(r Runnable, s ShutdownSender) {
 				defer shutdownWg.Done()
 				triggerChan := s.GetShutdownTrigger()
-				for {
-					select {
-					case <-p.ctx.Done():
-						return
-					case <-triggerChan:
-						p.logger.Info("Shutdown requested by runnable", "runnable", r)
-						p.Shutdown() // Trigger supervisor shutdown
-						return       // Exit this goroutine after triggering shutdown
-					}
+				select {
+				case <-p.ctx.Done():
+				case <-triggerChan:
+					p.logger.Info("Shutdown requested by runnable", "runnable", r)
+					// Dispatch via ctx cancellation; reap's existing
+					// <-p.ctx.Done() handler invokes Shutdown. The
+					// listener stays a notifier — it doesn't run
+					// Shutdown itself, which is what previously created
+					// a circular wait (listener inside Shutdown's
+					// p.wg.Wait while startShutdownManager waited on
+					// the listener via shutdownWg.Wait).
+					p.cancel()
 				}
-			}(r, sdSender) // Pass both variables
+			}(r, sdSender)
 		}
 	}
 

--- a/supervisor/shutdown_test.go
+++ b/supervisor/shutdown_test.go
@@ -15,31 +15,48 @@ import (
 func TestPIDZero_Shutdown(t *testing.T) {
 	t.Parallel()
 
-	// Cannot use synctest: the listener goroutine calls Shutdown() which calls
-	// wg.Wait() on the same WaitGroup that includes startShutdownManager,
-	// creating a circular dependency that synctest's "all goroutines must
-	// complete" requirement turns into a deadlock.
-	t.Run("shutdown sender trigger calls shutdown", func(t *testing.T) {
-		supervisorCtx, supervisorCancel := context.WithCancel(context.Background())
-		defer supervisorCancel()
+	t.Run("shutdown sender trigger completes without deadlock", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
 
-		mockService := mocks.NewMockRunnableWithShutdownSender()
-		shutdownChan := make(chan struct{}, 1)
-		stopCalled := make(chan struct{})
+			mockService := mocks.NewMockRunnableWithShutdownSender()
+			shutdownChan := make(chan struct{}, 1)
 
-		mockService.On("GetShutdownTrigger").Return(shutdownChan).Once()
-		mockService.On("String").Return("mockShutdownService")
-		mockService.On("Stop").Return().Once().Run(func(args mock.Arguments) {
-			close(stopCalled)
+			mockService.On("GetShutdownTrigger").Return(shutdownChan).Once()
+			mockService.On("String").Return("mockShutdownService")
+			mockService.On("Stop").Return().Once()
+
+			pidZero := newTestPIDZero(t, WithContext(ctx), WithRunnables(mockService))
+			pidZero.wg.Go(pidZero.startShutdownManager)
+
+			shutdownChan <- struct{}{}
+			synctest.Wait()
+
+			// With the fix, the listener cancels the supervisor ctx
+			// instead of running Shutdown itself, so it returns
+			// promptly and shutdownWg drains. The test's Shutdown call
+			// below picks up shutdownOnce and runs the body
+			// uncontested. Without the fix, the listener was stuck
+			// inside Shutdown's p.wg.Wait while startShutdownManager
+			// waited on the listener via shutdownWg.Wait — circular
+			// wait — and a second Shutdown call would block on
+			// shutdownOnce indefinitely.
+			shutdownDone := make(chan struct{})
+			go func() {
+				pidZero.Shutdown()
+				close(shutdownDone)
+			}()
+			synctest.Wait()
+
+			select {
+			case <-shutdownDone:
+			default:
+				t.Fatal("Shutdown blocked: circular wait between listener and startShutdownManager")
+			}
+
+			mockService.AssertExpectations(t)
 		})
-
-		pidZero := newTestPIDZero(t, WithContext(supervisorCtx), WithRunnables(mockService))
-		pidZero.wg.Go(pidZero.startShutdownManager)
-
-		shutdownChan <- struct{}{}
-		eventuallyClosed(t, stopCalled, "Stop() was not called, Shutdown() likely not invoked")
-
-		mockService.AssertExpectations(t)
 	})
 
 	t.Run("shutdown manager exits on context cancel", func(t *testing.T) {

--- a/supervisor/shutdown_test.go
+++ b/supervisor/shutdown_test.go
@@ -59,6 +59,39 @@ func TestPIDZero_Shutdown(t *testing.T) {
 		})
 	})
 
+	// Cannot use synctest: this calls pidZero.Run(), which uses signal.Notify.
+	// Exercises the production dispatch path (listener cancels p.ctx → reap
+	// picks up <-p.ctx.Done() → Shutdown). The other synctest test above
+	// drives startShutdownManager + Shutdown directly and would still pass if
+	// the listener's p.cancel() somehow stopped reaching reap.
+	t.Run("shutdown sender trigger drives Run loop to clean exit", func(t *testing.T) {
+		runnable := mocks.NewMockRunnableWithShutdownSender()
+		shutdownChan := make(chan struct{}, 1)
+		runStarted := make(chan struct{})
+
+		runnable.On("GetShutdownTrigger").Return(shutdownChan).Once()
+		runnable.On("String").Return("shutdownSenderRunnable").Maybe()
+		runnable.On("Run", mock.Anything).Return(nil).Once().Run(func(args mock.Arguments) {
+			ctx := args.Get(0).(context.Context)
+			close(runStarted)
+			<-ctx.Done()
+		})
+		runnable.On("Stop").Once()
+
+		pidZero := newTestPIDZero(t,
+			WithRunnables(runnable),
+			WithShutdownTimeout(time.Second),
+		)
+
+		execDone := startPIDZeroRun(t, pidZero)
+		eventuallyClosed(t, runStarted, "Run did not start in time")
+
+		shutdownChan <- struct{}{}
+
+		requirePIDZeroRunDone(t, execDone, time.Second)
+		runnable.AssertExpectations(t)
+	})
+
 	t.Run("shutdown manager exits on context cancel", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(t.Context())


### PR DESCRIPTION
When a `ShutdownSender`'s trigger channel fired, the listener goroutine called p.Shutdown() inline. That created a circular wait:

- The listener was registered in `shutdownWg`.
- `startShutdownManager` (registered in `p.wg`) waited on `shutdownWg.Wait()` before returning.
- Shutdown waited on `p.wg.Wait()`, which was blocked on `startShutdownManager`.

Until the per-runnable `Stop()` deadline landed, this could wedge Shutdown forever; with the deadline it just burned the full `WithShutdownTimeout` budget on every `ShutdownSender`-triggered shutdown.

Fix the dispatch model rather than the bookkeeping: the listener cancels the supervisor ctx instead of running Shutdown itself, and reap's existing <-p.ctx.Done() handler picks up the dispatch. This mirrors composite's Reload-via-channel pattern — listener is a notifier, reap is the actor — so the listener never enters Shutdown and the circular wait can't form.

Drop the dead for{} wrapper around the select. Convert the regression test to synctest now that the deadlock is gone, and assert Shutdown returns rather than just that Stop() was called.