### PR TITLE
Honor ctx cancellation in Run's startup loop

### DIFF
--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -230,12 +230,28 @@ func (p *PIDZero) Run() error {
 		if stateable, ok := r.(Stateable); ok {
 			err := p.blockUntilRunnableReady(stateable)
 			if err != nil {
+				// Ctx-cancellation is a clean shutdown trigger, not a
+				// runnable failure — match reap's nil return.
+				if p.ctx.Err() != nil {
+					p.logger.Debug("Context canceled while waiting for runnable", "runnable", r)
+					p.Shutdown()
+					return nil
+				}
 				p.logger.Error("Failed to start runnable", "runnable", r, "error", err)
 				p.Shutdown()
-				return err // exit Run loop
+				return err
 			}
 		} else {
 			p.logger.Debug("Runnable does not implement Stateable, continuing", "runnable", r)
+		}
+
+		// Honor cancellation between iterations so a mid-startup cancel
+		// (e.g. ShutdownSender firing, parent ctx) doesn't keep spawning
+		// later runnables against an already-cancelled ctx.
+		if p.ctx.Err() != nil {
+			p.logger.Debug("Context canceled during startup")
+			p.Shutdown()
+			return nil
 		}
 	}
 
@@ -274,8 +290,8 @@ func (p *PIDZero) blockUntilRunnableReady(r Stateable) error {
 		case <-startupCtx.Done():
 			return fmt.Errorf("timeout waiting for runnable to start: %w", startupCtx.Err())
 		case <-p.ctx.Done():
-			logger.Debug("Context canceled, stopping runnables")
-			return nil
+			logger.Debug("Context canceled while waiting for runnable to start")
+			return p.ctx.Err()
 		case <-ticker.C:
 			// continue waiting, adding an exponential backoff
 			if r.IsRunning() {

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -217,7 +217,19 @@ func (p *PIDZero) Run() error {
 	}
 
 	// Start each service in sequence
-	for _, r := range p.runnables {
+	for i, r := range p.runnables {
+		// From iter 1 onwards, honor cancellation before spawning so a
+		// mid-startup cancel (parent ctx, ShutdownSender firing, SIGTERM
+		// during boot) closes the gap between iterations. The first
+		// iteration always spawns: if ctx is pre-cancelled, the runnable
+		// observes it via runCtx and exits, then Shutdown reaps via
+		// reverse-order Stop.
+		if i > 0 && p.ctx.Err() != nil {
+			p.logger.Debug("Context canceled before spawning next runnable", "runnable", r)
+			p.Shutdown()
+			return nil
+		}
+
 		p.wg.Go(func() {
 			err := p.startRunnable(r)
 			if err != nil {
@@ -288,6 +300,14 @@ func (p *PIDZero) blockUntilRunnableReady(r Stateable) error {
 		case err := <-p.errorChan:
 			return err
 		case <-startupCtx.Done():
+			// startupCtx derives from p.ctx, so when p.ctx is cancelled
+			// both Done() channels fire and select picks randomly. Prefer
+			// the cancellation error over a misleading "timeout" wrap so
+			// callers see the true cause.
+			if p.ctx.Err() != nil {
+				logger.Debug("Context canceled while waiting for runnable to start")
+				return p.ctx.Err()
+			}
 			return fmt.Errorf("timeout waiting for runnable to start: %w", startupCtx.Err())
 		case <-p.ctx.Done():
 			logger.Debug("Context canceled while waiting for runnable to start")

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -256,7 +256,39 @@ func TestBlockUntilRunnableReady(t *testing.T) {
 
 		err = sv.blockUntilRunnableReady(mockRunnable)
 		require.ErrorIs(t, err, context.Canceled)
+		require.NotContains(t, err.Error(), "timeout",
+			"ctx-cancel must not be wrapped as a timeout error")
 		mockRunnable.AssertExpectations(t)
+	})
+
+	// startupCtx is derived from p.ctx, so when p.ctx is cancelled both
+	// startupCtx.Done() and p.ctx.Done() are immediately ready and select
+	// picks randomly. Repeat enough that without the precedence fix at
+	// least one iteration takes the startupCtx branch and returns a
+	// misleading "timeout" wrap.
+	t.Run("cancel beats timeout when both fire", func(t *testing.T) {
+		const iterations = 20
+		for i := range iterations {
+			mockRunnable := mocks.NewMockRunnableWithStateable()
+			mockRunnable.On("String").Return("racy-runnable").Maybe()
+			mockRunnable.On("IsRunning").Return(false).Maybe()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			sv, err := New(
+				WithContext(ctx),
+				WithRunnables(mockRunnable),
+				WithStartupTimeout(time.Second),
+				WithStartupInitial(time.Millisecond),
+			)
+			require.NoError(t, err)
+
+			cancel()
+
+			err = sv.blockUntilRunnableReady(mockRunnable)
+			require.ErrorIsf(t, err, context.Canceled, "iteration %d", i)
+			require.NotContainsf(t, err.Error(), "timeout",
+				"iteration %d: cancellation must take precedence over the startupCtx timeout wrap", i)
+		}
 	})
 
 	t.Run("error from runnable", func(t *testing.T) {
@@ -900,6 +932,57 @@ func TestPIDZero_Run_StartupCancelStopsLoop(t *testing.T) {
 		"B's Run must not be called after parent ctx cancelled mid-startup")
 	require.Error(t, pidZero.ctx.Err(),
 		"pidZero.ctx must be cancelled (proves Shutdown was reached)")
+}
+
+// TestPIDZero_Run_PreCancelledCtxStopsAtFirst verifies the top-of-iteration
+// ctx check (i > 0): when Run is invoked with an already-cancelled p.ctx,
+// the first runnable still spawns (preserving the long-standing contract
+// that Run gives every registered runnable at least an attempt) but no
+// later runnable is spawned. Without the iter>0 check, the supervisor
+// could keep spawning subsequent runnables against an already-cancelled
+// ctx between iterations.
+func TestPIDZero_Run_PreCancelledCtxStopsAtFirst(t *testing.T) {
+	t.Parallel()
+
+	var bRunCalled atomic.Bool
+	var cRunCalled atomic.Bool
+
+	a := mocks.NewMockRunnable()
+	a.On("String").Return("a").Maybe()
+	a.On("Run", mock.Anything).Return(nil).Maybe()
+	a.On("Stop").Maybe()
+
+	b := mocks.NewMockRunnable()
+	b.On("String").Return("b").Maybe()
+	b.On("Run", mock.Anything).Return(nil).Maybe().Run(func(args mock.Arguments) {
+		bRunCalled.Store(true)
+	})
+	b.On("Stop").Maybe()
+
+	c := mocks.NewMockRunnable()
+	c.On("String").Return("c").Maybe()
+	c.On("Run", mock.Anything).Return(nil).Maybe().Run(func(args mock.Arguments) {
+		cRunCalled.Store(true)
+	})
+	c.On("Stop").Maybe()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel() // cancel before Run is even called
+
+	pidZero := newTestPIDZero(t,
+		WithContext(ctx),
+		WithRunnables(a, b, c),
+		WithStartupTimeout(time.Second),
+		WithShutdownTimeout(time.Second),
+	)
+
+	execDone := startPIDZeroRun(t, pidZero)
+	requirePIDZeroRunDone(t, execDone, 2*time.Second)
+
+	require.False(t, bRunCalled.Load(),
+		"B's Run must not be called when parent ctx is pre-cancelled (iter > 0)")
+	require.False(t, cRunCalled.Load(),
+		"C's Run must not be called when parent ctx is pre-cancelled (iter > 0)")
 }
 
 // TestPIDZero_Reap_UnhandledSignal tests the default case in signal handling.

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -931,7 +931,7 @@ func TestPIDZero_Run_StartupCancelStopsLoop(t *testing.T) {
 	require.False(t, bRunCalled.Load(),
 		"B's Run must not be called after parent ctx cancelled mid-startup")
 	require.Error(t, pidZero.ctx.Err(),
-		"pidZero.ctx must be cancelled (proves Shutdown was reached)")
+		"pidZero.ctx must be cancelled after the parent ctx is cancelled")
 }
 
 // TestPIDZero_Run_PreCancelledCtxStopsAtFirst verifies the top-of-iteration

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -248,16 +249,13 @@ func TestBlockUntilRunnableReady(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		// Cancel the context right away
+		// Cancel the context right away. blockUntilRunnableReady must surface
+		// this as ctx.Err() so the Run loop bails instead of advancing to
+		// the next runnable.
 		cancel()
 
-		// Use Eventually to verify the correct result
-		result := assert.Eventually(t, func() bool {
-			err := sv.blockUntilRunnableReady(mockRunnable)
-			return err == nil // Should return nil when parent context is canceled
-		}, 200*time.Millisecond, 10*time.Millisecond, "Should return nil when context is canceled")
-
-		assert.True(t, result, "blockUntilRunnableReady should return nil when context is canceled")
+		err = sv.blockUntilRunnableReady(mockRunnable)
+		require.ErrorIs(t, err, context.Canceled)
 		mockRunnable.AssertExpectations(t)
 	})
 
@@ -831,6 +829,77 @@ func TestPIDZero_CancelContextFromParent(t *testing.T) {
 
 	// Ensure Stop was called only once
 	mockRunnable.AssertNumberOfCalls(t, "Stop", 1)
+}
+
+// TestPIDZero_Run_StartupCancelStopsLoop verifies that Run's startup loop bails
+// when p.ctx is cancelled mid-startup, instead of advancing to spawn later
+// runnables against an already-cancelled ctx.
+//
+// Regression: pre-fix, blockUntilRunnableReady returned nil on <-p.ctx.Done(),
+// so the Run loop interpreted ctx-cancellation as "ready, proceed to next
+// runnable" and kept spawning. With the fix, blockUntilRunnableReady returns
+// p.ctx.Err() and the loop honors it.
+//
+// Cannot use synctest: pidZero.Run() calls signal.Notify, which is incompatible
+// with synctest. Synchronization is via a sync.Once-guarded channel send from
+// A's IsRunning callback — deterministic without timing assumptions.
+func TestPIDZero_Run_StartupCancelStopsLoop(t *testing.T) {
+	t.Parallel()
+
+	// A: Stateable, IsRunning always returns false so blockUntilRunnableReady
+	// stays in its polling loop. The first IsRunning call signals reachedCh,
+	// which the test uses to know Run has entered blockUntilRunnableReady.
+	reachedCh := make(chan struct{}, 1)
+	var signalOnce sync.Once
+	a := mocks.NewMockRunnableWithStateable()
+	a.On("String").Return("a").Maybe()
+	a.On("GetState").Return("not-running").Maybe()
+	aStateChan := make(chan string)
+	a.On("GetStateChan", mock.Anything).Return(aStateChan).Maybe()
+	a.On("IsRunning").Return(false).Run(func(args mock.Arguments) {
+		signalOnce.Do(func() { reachedCh <- struct{}{} })
+	})
+	a.On("Run", mock.Anything).Return(nil).Once().Run(func(args mock.Arguments) {
+		ctx := args.Get(0).(context.Context)
+		<-ctx.Done()
+	})
+	a.On("Stop").Once()
+
+	// B: must NEVER have Run called. Registered .Maybe() so a regression
+	// flips bRunCalled and the assertion at the end catches it (rather
+	// than panicking inside B's goroutine via testify's missing-expectation
+	// behavior).
+	var bRunCalled atomic.Bool
+	b := mocks.NewMockRunnable()
+	b.On("String").Return("b").Maybe()
+	b.On("Run", mock.Anything).Return(nil).Maybe().Run(func(args mock.Arguments) {
+		bRunCalled.Store(true)
+	})
+	b.On("Stop").Maybe()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	pidZero := newTestPIDZero(t,
+		WithContext(ctx),
+		WithRunnables(a, b),
+		WithStartupTimeout(2*time.Second),
+		WithStartupInitial(10*time.Millisecond),
+		WithShutdownTimeout(time.Second),
+	)
+
+	execDone := startPIDZeroRun(t, pidZero)
+
+	// Wait until Run is inside blockUntilRunnableReady for A, then cancel.
+	eventuallyClosed(t, reachedCh, "Run did not reach blockUntilRunnableReady for A")
+	cancel()
+
+	requirePIDZeroRunDone(t, execDone, 2*time.Second)
+
+	require.False(t, bRunCalled.Load(),
+		"B's Run must not be called after parent ctx cancelled mid-startup")
+	require.Error(t, pidZero.ctx.Err(),
+		"pidZero.ctx must be cancelled (proves Shutdown was reached)")
 }
 
 // TestPIDZero_Reap_UnhandledSignal tests the default case in signal handling.


### PR DESCRIPTION
## Summary

- `supervisor.Run`'s startup loop kept spawning later runnables when `p.ctx` was cancelled mid-startup. Two gaps: `blockUntilRunnableReady` returned `nil` on `<-p.ctx.Done()` (so the caller read it as "ready"), and the loop had no ctx check between iterations.
- Fix: `blockUntilRunnableReady` returns `p.ctx.Err()`; the loop checks `p.ctx.Err()` at the bottom of each iteration. Both ctx-cancel paths return `nil` from `Run` to match `reap`'s clean-shutdown semantics, so `TestPIDZero_CancelContextFromParent` and similar tests are unaffected.
- Surfaced by Copilot's review of #97 ([comment](https://github.com/robbyt/go-supervisor/pull/97#discussion_r3178555312)). Pre-existing — pre-#97 the listener called `Shutdown()` inline (which cancels `p.ctx`), hitting the same race. #97 didn't introduce or fix it.

## Test plan

- [x] `go test -race ./...` passes
- [x] `make lint` clean (0 issues)
- [x] Updated `TestBlockUntilRunnableReady/parent_context_canceled` expects `context.Canceled` (was: `nil`). Sanity-checked: with the fix reverted, the test fails as expected.
- [x] New `TestPIDZero_Run_StartupCancelStopsLoop` drives `Run()` end-to-end with two runnables, cancels mid-startup, asserts the second runnable's `Run` is never invoked. Synchronization via `sync.Once`-guarded channel send from A's `IsRunning` callback — deterministic. Cannot use synctest because `Run()` calls `signal.Notify` (same constraint as #97's integration test).

## Out of scope

- `blockUntilRunnableReady` does an unconditional `time.Sleep(timeout)` before its first ctx check (a startup-cancel observed during that 50 ms sleep still pays the full sleep). Tightening with `select { case <-time.After(timeout): case <-p.ctx.Done(): }` is a follow-up — not load-bearing.