### PR TITLE
Surface httpcluster child failures via FSM StatusError

### DIFF
--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -241,7 +241,9 @@ func (r *Runner) shutdown(ctx context.Context) error {
 	// Empty map means all servers should be removed
 	desiredEntries := newEntries(stopConfigs)
 	pendingEntries := r.currentEntries.buildPendingEntries(desiredEntries)
-	updatedEntries := r.executeActions(ctx, pendingEntries)
+	// Shutdown ignores the start-failure flag: nothing to start during shutdown,
+	// and the cluster is already moving to Stopped.
+	updatedEntries, _ := r.executeActions(ctx, pendingEntries)
 	r.currentEntries = updatedEntries.commit()
 
 	if err := r.fsm.Transition(finitestate.StatusStopped); err != nil {
@@ -284,10 +286,18 @@ func (r *Runner) processConfigUpdate(
 		"toStop", len(toStop))
 
 	// Phase 2: Execute all pending actions
-	updatedEntries := r.executeActions(ctx, pendingEntries)
+	updatedEntries, hadFailure := r.executeActions(ctx, pendingEntries)
 
 	// Commit: Finalize the entries state
 	r.currentEntries = updatedEntries.commit()
+
+	// If any server failed to start, mark the cluster degraded so consumers
+	// watching GetStateChan see the failure. Don't fall through to a back-to-
+	// Running transition; that's the historical silent-success path.
+	if hadFailure {
+		r.setStateError()
+		return fmt.Errorf("one or more servers failed to start during config update")
+	}
 
 	// Transition back to running state using conditional transition
 	if err := r.fsm.TransitionIfCurrentState(finitestate.StatusReloading, finitestate.StatusRunning); err != nil {
@@ -299,7 +309,9 @@ func (r *Runner) processConfigUpdate(
 }
 
 // executeActions orchestrates server lifecycle changes by stopping and starting servers.
-func (r *Runner) executeActions(ctx context.Context, pending entriesManager) entriesManager {
+// The bool return is true if any server failed to start; callers use it to decide
+// whether to surface the failure (e.g., transition the cluster FSM to Error).
+func (r *Runner) executeActions(ctx context.Context, pending entriesManager) (entriesManager, bool) {
 	logger := r.logger.WithGroup("executeActions")
 	current := pending
 	toStart, toStop := pending.getPendingActions()
@@ -315,7 +327,7 @@ func (r *Runner) executeActions(ctx context.Context, pending entriesManager) ent
 			select {
 			case <-ctx.Done():
 				logger.Debug("Context cancelled during port release wait")
-				return current
+				return current, false
 			case <-time.After(r.restartDelay):
 				// Continue after delay
 			}
@@ -323,11 +335,12 @@ func (r *Runner) executeActions(ctx context.Context, pending entriesManager) ent
 	}
 
 	// Phase 2: Start servers that need to be started
+	var startFailed bool
 	if len(toStart) > 0 {
-		current = r.startServers(ctx, current, toStart)
+		current, startFailed = r.startServers(ctx, current, toStart)
 	}
 
-	return current
+	return current, startFailed
 }
 
 // stopServers handles stopping servers and clearing their runtime state.
@@ -377,14 +390,17 @@ func (r *Runner) stopServers(
 }
 
 // startServers handles starting new servers and waiting for them to be ready.
+// The bool return is true if any server failed to be created or to reach Running
+// within the deadline. Failed entries are removed from the returned collection.
 func (r *Runner) startServers(
 	ctx context.Context,
 	current entriesManager,
 	toStart []string,
-) entriesManager {
+) (entriesManager, bool) {
 	logger := r.logger.WithGroup("startServers")
 	logger.Debug("Processing server starts", "count", len(toStart))
 
+	var hadFailure bool
 	for _, id := range toStart {
 		entry := current.get(id)
 		logger := logger.With("id", id)
@@ -400,6 +416,7 @@ func (r *Runner) startServers(
 		runner, serverCtx, serverCancel, err := r.createAndStartServer(ctx, entry)
 		if err != nil {
 			logger.Error("Failed to create server", "error", err)
+			hadFailure = true
 			// Remove entry since server failed to create
 			current = current.removeEntry(id)
 			continue
@@ -412,12 +429,24 @@ func (r *Runner) startServers(
 
 		// Wait for server to be ready
 		if !r.waitForIsRunning(ctx, r.deadlineServerStart, runner) {
+			// Distinguish parent-ctx cancellation (the cluster is being told
+			// to stop — not a server failure) from a real readiness failure
+			// (timeout elapsed or server reached Error/Stopped). Only the
+			// latter should trip the cluster into StatusError.
+			if ctx.Err() != nil {
+				logger.Debug("Server start aborted by context cancellation")
+				serverCancel()
+				runner.Stop()
+				current = current.removeEntry(id)
+				continue
+			}
 			logger.Error("Server failed to become ready",
 				"timeout", r.deadlineServerStart,
 				"state", runner.GetState())
 			// Cancel the server context to clean up
 			serverCancel()
 			runner.Stop()
+			hadFailure = true
 			// Remove entry since server failed to start
 			current = current.removeEntry(id)
 			continue
@@ -426,7 +455,7 @@ func (r *Runner) startServers(
 		logger.Debug("Server instance started")
 	}
 
-	return current
+	return current, hadFailure
 }
 
 // createAndStartServer creates a new HTTP server runner and starts it in a goroutine.
@@ -445,17 +474,39 @@ func (r *Runner) createAndStartServer(
 	}
 
 	// Start that Runnable implementation in a goroutine
-	go func(id string, runner httpServerRunner, c context.Context) {
+	go func(id string, runner httpServerRunner, c context.Context, cancel context.CancelFunc) {
+		// Always release this server's ctx when the goroutine exits — the
+		// crash path didn't otherwise call cancel(), so per-server ctx
+		// resources would have stayed referenced until the cluster runCtx
+		// was cancelled (process-lifetime). Idempotent if a stop path
+		// already cancelled.
+		defer cancel()
 		logger := r.logger.WithGroup("cluster").With("id", id)
 		logger.Debug("Starting server instance")
-		if err := runner.Run(c); err != nil {
-			if c.Err() == nil {
-				// Context not cancelled, this is an actual error
-				logger.Error("Server instance failed", "error", err)
-			}
+		err := runner.Run(c)
+		if err != nil && c.Err() == nil {
+			// Context not cancelled, this is an actual error: mark the
+			// cluster degraded so consumers watching GetStateChan see it,
+			// and drop the dead entry from currentEntries.
+			logger.Error("Server instance failed", "error", err)
+			r.setStateError()
+			r.removeEntryIfMatches(id, runner)
 		}
 		logger.Debug("Instance stopped")
-	}(entry.id, runner, serverCtx)
+	}(entry.id, runner, serverCtx, serverCancel)
 
 	return runner, serverCtx, serverCancel, nil
+}
+
+// removeEntryIfMatches drops the entry stored under id only if it still points
+// at the given runner. Called from the per-server crash handler to avoid
+// racing a concurrent restart that has already committed a different runner
+// under the same id — without this guard, an old goroutine's late error path
+// would delete the new healthy server from currentEntries.
+func (r *Runner) removeEntryIfMatches(id string, runner httpServerRunner) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if cur := r.currentEntries.get(id); cur != nil && cur.runner == runner {
+		r.currentEntries = r.currentEntries.removeEntry(id)
+	}
 }

--- a/runnables/httpcluster/runner_failure_test.go
+++ b/runnables/httpcluster/runner_failure_test.go
@@ -1,0 +1,302 @@
+package httpcluster
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/robbyt/go-supervisor/internal/finitestate"
+	"github.com/robbyt/go-supervisor/runnables/httpserver"
+	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// createCrashingMockServer returns a mock that reports Running until crashCh is
+// closed or ctx is done, then has Run() return crashErr. The cluster's child
+// goroutine distinguishes a real crash (its server-ctx still live) from a
+// shutdown-driven exit (ctx cancelled), so always returning the same error
+// is safe — the cleanup-path return is filtered out by `c.Err() != nil`.
+func createCrashingMockServer(
+	ctx context.Context,
+	crashCh <-chan struct{},
+	crashErr error,
+) *mocks.MockRunnableWithStateable {
+	mockServer := mocks.NewMockRunnableWithStateable()
+	mockServer.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		select {
+		case <-ctx.Done():
+		case <-crashCh:
+		}
+	}).Return(crashErr)
+	mockServer.On("Stop").Return().Maybe()
+	mockServer.On("GetState").Return(finitestate.StatusRunning).Maybe()
+	mockServer.On("IsRunning").Return(true).Maybe()
+	stateChan := make(chan string, 1)
+	stateChan <- finitestate.StatusRunning
+	mockServer.On("GetStateChan", mock.Anything).Return(stateChan).Maybe()
+	return mockServer
+}
+
+// createErroredMockServer returns a mock whose GetState reports Error so
+// waitForIsRunning short-circuits via its `s == "Error"` branch. Used to
+// simulate a child that fails to reach Running during a config update.
+func createErroredMockServer(ctx context.Context) *mocks.MockRunnableWithStateable {
+	mockServer := mocks.NewMockRunnableWithStateable()
+	mockServer.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		<-ctx.Done()
+	}).Return(nil)
+	mockServer.On("Stop").Return().Maybe()
+	mockServer.On("GetState").Return(finitestate.StatusError).Maybe()
+	mockServer.On("IsRunning").Return(false).Maybe()
+	stateChan := make(chan string, 1)
+	stateChan <- finitestate.StatusError
+	mockServer.On("GetStateChan", mock.Anything).Return(stateChan).Maybe()
+	return mockServer
+}
+
+// TestRunner_ChildRuntimeError_TransitionsToError covers Bug A: a child
+// server's Run() returning an error during steady-state must transition the
+// cluster to StatusError and drop the dead entry. Cluster Run() must not exit;
+// healthy siblings must keep running.
+func TestRunner_ChildRuntimeError_TransitionsToError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	crashErr := errors.New("simulated server crash")
+	crashCh := make(chan struct{})
+
+	var (
+		mu              sync.Mutex
+		survivor        *mocks.MockRunnableWithStateable
+		failingServerID = "failing"
+	)
+
+	mockFactory := func(_ context.Context, id string, _ *httpserver.Config, _ slog.Handler) (httpServerRunner, error) {
+		if id == failingServerID {
+			return createCrashingMockServer(ctx, crashCh, crashErr), nil
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		survivor = createMockServer(ctx)
+		return survivor, nil
+	}
+
+	cluster, err := NewRunner(WithRunnerFactory(mockFactory))
+	require.NoError(t, err)
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- cluster.Run(ctx)
+	}()
+	require.Eventually(t, cluster.IsRunning, time.Second, 5*time.Millisecond)
+
+	cluster.configSiphon <- map[string]*httpserver.Config{
+		failingServerID: createTestHTTPConfig(t, ":18001"),
+		"survivor":      createTestHTTPConfig(t, ":18002"),
+	}
+	require.Eventually(t, func() bool { return cluster.GetServerCount() == 2 },
+		2*time.Second, 10*time.Millisecond)
+
+	close(crashCh)
+
+	require.Eventually(t, func() bool {
+		return cluster.GetState() == finitestate.StatusError &&
+			cluster.GetServerCount() == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"cluster must enter Error and drop the dead entry")
+
+	select {
+	case err := <-runErr:
+		t.Fatalf("cluster Run() returned unexpectedly: %v", err)
+	case <-time.After(50 * time.Millisecond):
+		// Run must keep going — one bad child shouldn't kill the cluster.
+	}
+
+	mu.Lock()
+	require.NotNil(t, survivor, "survivor mock should have been created")
+	mu.Unlock()
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("cluster did not shut down after ctx cancel")
+	}
+}
+
+// TestRunner_ConfigUpdateFailure_TransitionsToError covers Bug B: when a
+// config update spawns a server that fails readiness, the cluster must
+// transition to StatusError instead of silently transitioning back to Running.
+func TestRunner_ConfigUpdateFailure_TransitionsToError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	mockFactory := func(serverCtx context.Context, _ string, _ *httpserver.Config, _ slog.Handler) (httpServerRunner, error) {
+		return createErroredMockServer(serverCtx), nil
+	}
+
+	cluster, err := NewRunner(WithRunnerFactory(mockFactory))
+	require.NoError(t, err)
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- cluster.Run(ctx)
+	}()
+	require.Eventually(t, cluster.IsRunning, time.Second, 5*time.Millisecond)
+
+	cluster.configSiphon <- map[string]*httpserver.Config{
+		"broken": createTestHTTPConfig(t, ":18101"),
+	}
+
+	require.Eventually(t, func() bool {
+		return cluster.GetState() == finitestate.StatusError &&
+			cluster.GetServerCount() == 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"cluster must enter Error after a failed config-update server")
+
+	select {
+	case err := <-runErr:
+		t.Fatalf("cluster Run() returned unexpectedly: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("cluster did not shut down after ctx cancel")
+	}
+}
+
+// TestRunner_PartialFailure_GoodSiblingsSurvive ensures one failing server in
+// a config update transitions the cluster to Error but the surviving server
+// stays running and accounted for.
+func TestRunner_PartialFailure_GoodSiblingsSurvive(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	const brokenID = "broken"
+
+	var (
+		mu       sync.Mutex
+		survivor *mocks.MockRunnableWithStateable
+	)
+
+	mockFactory := func(serverCtx context.Context, id string, _ *httpserver.Config, _ slog.Handler) (httpServerRunner, error) {
+		if id == brokenID {
+			return createErroredMockServer(serverCtx), nil
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		survivor = createMockServer(serverCtx)
+		return survivor, nil
+	}
+
+	cluster, err := NewRunner(WithRunnerFactory(mockFactory))
+	require.NoError(t, err)
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- cluster.Run(ctx)
+	}()
+	require.Eventually(t, cluster.IsRunning, time.Second, 5*time.Millisecond)
+
+	cluster.configSiphon <- map[string]*httpserver.Config{
+		brokenID:   createTestHTTPConfig(t, ":18201"),
+		"survivor": createTestHTTPConfig(t, ":18202"),
+	}
+
+	require.Eventually(t, func() bool {
+		return cluster.GetState() == finitestate.StatusError &&
+			cluster.GetServerCount() == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"cluster must enter Error and keep the survivor")
+
+	mu.Lock()
+	require.NotNil(t, survivor, "survivor mock must have been created")
+	mu.Unlock()
+
+	select {
+	case err := <-runErr:
+		t.Fatalf("cluster Run() returned unexpectedly: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("cluster did not shut down after ctx cancel")
+	}
+}
+
+// TestRemoveEntryIfMatches covers the per-server crash handler's identity
+// guard. The fix keeps an old goroutine's late error path from removing a
+// healthy replacement entry that landed under the same id during a restart.
+func TestRemoveEntryIfMatches(t *testing.T) {
+	t.Parallel()
+
+	makeEntries := func(t *testing.T, id string, runner httpServerRunner) *entries {
+		t.Helper()
+		return &entries{
+			servers: map[string]*serverEntry{
+				id: {id: id, runner: runner},
+			},
+		}
+	}
+
+	t.Run("removes when runner matches", func(t *testing.T) {
+		runner, err := NewRunner()
+		require.NoError(t, err)
+
+		mockServer := mocks.NewMockRunnableWithStateable()
+		runner.currentEntries = makeEntries(t, "x", mockServer)
+
+		runner.removeEntryIfMatches("x", mockServer)
+
+		require.Equal(t, 0, runner.currentEntries.count(),
+			"entry should be removed when runner matches")
+	})
+
+	t.Run("keeps entry when runner differs (replacement race)", func(t *testing.T) {
+		runner, err := NewRunner()
+		require.NoError(t, err)
+
+		oldServer := mocks.NewMockRunnableWithStateable()
+		newServer := mocks.NewMockRunnableWithStateable()
+		runner.currentEntries = makeEntries(t, "x", newServer)
+
+		// Old goroutine fires its crash handler after the entry has been
+		// replaced — the stale id reference must not delete the new entry.
+		runner.removeEntryIfMatches("x", oldServer)
+
+		require.Equal(t, 1, runner.currentEntries.count(),
+			"replacement entry must not be dropped by old runner's crash path")
+		got := runner.currentEntries.get("x")
+		require.NotNil(t, got)
+		require.Same(t, newServer, got.runner)
+	})
+
+	t.Run("no-op when id absent", func(t *testing.T) {
+		runner, err := NewRunner()
+		require.NoError(t, err)
+		mockServer := mocks.NewMockRunnableWithStateable()
+
+		// Does not panic; entries collection unchanged.
+		runner.removeEntryIfMatches("missing", mockServer)
+		require.Equal(t, 0, runner.currentEntries.count())
+	})
+}

--- a/runnables/httpcluster/runner_test.go
+++ b/runnables/httpcluster/runner_test.go
@@ -649,8 +649,9 @@ func TestRunnerExecuteActions(t *testing.T) {
 		mockEntries := &MockEntriesManager{}
 		mockEntries.On("getPendingActions").Return([]string{}, []string{})
 
-		result := runner.executeActions(t.Context(), mockEntries)
+		result, hadFailure := runner.executeActions(t.Context(), mockEntries)
 		assert.Equal(t, mockEntries, result)
+		assert.False(t, hadFailure)
 
 		mockEntries.AssertExpectations(t)
 	})
@@ -682,7 +683,10 @@ func TestRunnerExecuteActions(t *testing.T) {
 		// Mock removeEntry in case the server fails to start (can happen when no run context)
 		mockEntries.On("removeEntry", "start1").Return(mockEntries).Maybe()
 
-		result := runner.executeActions(t.Context(), mockEntries)
+		// hadFailure may be either true or false depending on scheduling under
+		// the missing run-context path; this test only asserts that the
+		// returned entries collection threads through unchanged.
+		result, _ := runner.executeActions(t.Context(), mockEntries)
 		assert.Equal(t, mockEntries, result)
 
 		mockEntries.AssertExpectations(t)


### PR DESCRIPTION
## Summary

T1.4 from the outstanding-defects plan. Both silent-failure paths in `runnables/httpcluster` now transition the cluster's FSM to `StatusError` so consumers watching `GetStateChan` see the degraded state. The cluster's `Run()` keeps running — multi-server clusters are designed for partial availability, so one bad child should not take down healthy siblings (mirrors the httpserver-reload pattern, not composite's fail-fast pattern).

- **Bug A** (`createAndStartServer`, `runner.go:451-454`): a child server's `Run()` returning an error during steady-state was logged and dropped silently. The child goroutine now calls `setStateError()` and removes the dead entry from `currentEntries` under `r.mu`.
- **Bug B** (`startServers` / `executeActions` / `processConfigUpdate`): a server that failed readiness during a config update was removed and the cluster transitioned back to `Running` as if the update succeeded. `startServers` and `executeActions` now return a `(entriesManager, hadFailure)` pair; `processConfigUpdate` transitions to `Error` on `hadFailure`. Parent-ctx cancellation during the readiness wait is distinguished from a real readiness failure so ordinary shutdown does not trip the cluster into `Error`.

Three new regression tests in `runner_failure_test.go` cover both bugs and the partial-failure interaction. Each test was sanity-checked by reverting the corresponding production change and confirming the test fails for the right reason.

## Out of scope

Recovery from `StatusError` — `processConfigUpdate`'s `TransitionIfCurrentState(Running, Reloading)` gate still rejects non-Running config updates, so a degraded cluster needs to be torn down and restarted. Allowing `Error → Reloading` on a successful follow-up update would need an FSM transition-table review and is filed as a follow-up.

## Test plan

- [x] `go test -race ./runnables/httpcluster/...`
- [x] `go test -race ./...` (full repo green)
- [x] `make lint` (0 issues)
- [x] Sanity-check: revert each fix one at a time, confirm the corresponding regression test fails before the fix and passes after