### PR TITLE
Replace composite reloadMu with FSM admission gate

### DIFF
--- a/runnables/composite/errors.go
+++ b/runnables/composite/errors.go
@@ -14,19 +14,4 @@ var (
 
 	// ErrOldConfig is returned when the config hasn't changed during a reload
 	ErrOldConfig = errors.New("configuration unchanged")
-
-	// ErrReloadAborted is returned when a Reload(ctx) call did not run to
-	// completion as the result of normal control flow — caller's ctx
-	// cancellation, runner shutting down, or the consumer observing the
-	// caller's abandonment signal before starting work. Callers can use
-	// errors.Is to distinguish this from real reload failures (config
-	// callback errors, child stop/boot failures).
-	//
-	// IMPORTANT: only the dispatch layer (dispatchMembershipReload) and the
-	// consumer abandonment path (reloadRequest.RunReload) may wrap this
-	// sentinel. Operational failures from reloadWithRestart, boot, or
-	// stopAllRunnables MUST return errors that do NOT wrap ErrReloadAborted —
-	// otherwise Reload's triage will silently treat them as normal control
-	// flow and skip setStateError().
-	ErrReloadAborted = errors.New("reload aborted")
 )

--- a/runnables/composite/reload.go
+++ b/runnables/composite/reload.go
@@ -17,15 +17,23 @@ type ReloadableWithConfig interface {
 // Reload updates the configuration and handles runnables appropriately.
 // If membership changes (different set of runnables), all existing runnables are stopped
 // and the new set of runnables is started.
+//
+// Concurrent callers are admitted via the FSM, not a mutex: the atomic
+// Running→Reloading transition is the single-flight gate. A second caller that
+// arrives while a reload is already in flight observes Reloading, fails the
+// transition, and returns without queueing — matching httpserver's pattern. If
+// every caller must produce an effect, callers should serialize themselves.
 func (r *Runner[T]) Reload(ctx context.Context) {
-	r.reloadMu.Lock()
-	defer r.reloadMu.Unlock()
-
 	logger := r.logger.WithGroup("Reload")
 
-	if err := r.fsm.Transition(finitestate.StatusReloading); err != nil {
-		// Common reason: runner is in Stopping/Stopped/Booting/Error — not a
-		// failure of the reload itself, so don't move the FSM to Error.
+	if err := r.fsm.TransitionIfCurrentState(
+		finitestate.StatusRunning,
+		finitestate.StatusReloading,
+	); err != nil {
+		// Either another reload is already in flight (FSM in Reloading) or the
+		// runner is in Stopping/Stopped/Booting/Error. Either way, drop this
+		// request — there is no failure of *this* reload to surface, so don't
+		// move the FSM to Error.
 		logger.Debug("Cannot reload — runner not in Running state",
 			"current", r.fsm.GetState(), "error", err)
 		return

--- a/runnables/composite/reload.go
+++ b/runnables/composite/reload.go
@@ -30,6 +30,13 @@ type ReloadableWithConfig interface {
 // accepted by Run's loop. Once accepted, Reload waits for the work to finish
 // — caller's ctx is intentionally ignored at that point so the caller never
 // observes FSM=Reloading after Reload returns.
+//
+// Cleanup follows httpserver's per-branch pattern (no catch-all defer): each
+// abort path that leaves FSM=Reloading transitions it back explicitly. A
+// catch-all defer would race the next admission gate — after handleReload
+// completed Reloading→Running and a new caller won the gate, the previous
+// caller's defer could fire `TIC(Reloading→Running)` and erroneously release
+// the new caller's gate, derailing the new request's Run loop transition.
 func (r *Runner[T]) Reload(ctx context.Context) {
 	logger := r.logger.WithGroup("Reload")
 
@@ -57,25 +64,6 @@ func (r *Runner[T]) Reload(ctx context.Context) {
 		return
 	}
 
-	// Best-effort FSM cleanup: covers the outer-abort cases (Run never picked
-	// up the request) where we hold Reloading but no apply ever ran. Run's
-	// handleReload owns the transition for any request it dispatched, so this
-	// is a no-op in the success path.
-	defer func() {
-		if transErr := r.fsm.TransitionIfCurrentState(
-			finitestate.StatusReloading, finitestate.StatusRunning,
-		); transErr != nil {
-			current := r.fsm.GetState()
-			if current == finitestate.StatusReloading {
-				logger.Error("FSM stuck in Reloading after dispatch", "error", transErr)
-				r.setStateError()
-			} else {
-				logger.Debug("FSM moved out of Reloading during reload",
-					"current", current)
-			}
-		}
-	}()
-
 	newConfig, err := r.configCallback()
 	if err != nil {
 		logger.Error("config callback failed", "error", err)
@@ -92,10 +80,12 @@ func (r *Runner[T]) Reload(ctx context.Context) {
 }
 
 // dispatchReload sends an accepted reload to Run's event loop and waits for
-// completion. Aborts cleanly if the runner has already exited or the caller's
-// ctx fires before Run picks the request up — once dispatched, the work runs
-// to completion and the caller waits unconditionally on done (mirrors
-// httpserver's pattern).
+// completion. On the happy path, handleReload owns the FSM transition
+// Reloading→Running; on the shutdown path, drainReloadCh owns it. On either
+// abort path before send (caller's ctx fires, runner stops), this function
+// transitions the FSM back to Running explicitly. Mirrors httpserver's
+// per-branch cleanup so we never leave a catch-all defer racing the next
+// caller's admission gate.
 func (r *Runner[T]) dispatchReload(ctx context.Context, newConfig *Config[T]) {
 	logger := r.logger.WithGroup("dispatchReload")
 	req := &reloadReq[T]{cfg: newConfig, done: make(chan struct{})}
@@ -106,8 +96,16 @@ func (r *Runner[T]) dispatchReload(ctx context.Context, newConfig *Config[T]) {
 		<-req.done
 	case <-ctx.Done():
 		logger.Debug("Reload caller ctx done before dispatch", "error", ctx.Err())
+		if err := r.fsm.Transition(finitestate.StatusRunning); err != nil {
+			logger.Error("Failed to transition Reloading→Running", "error", err)
+			r.setStateError()
+		}
 	case <-r.lc.DoneCh():
 		logger.Debug("Runner stopped before reload dispatch")
+		if err := r.fsm.Transition(finitestate.StatusRunning); err != nil {
+			logger.Error("Failed to transition Reloading→Running", "error", err)
+			r.setStateError()
+		}
 	}
 }
 

--- a/runnables/composite/reload.go
+++ b/runnables/composite/reload.go
@@ -2,7 +2,6 @@ package composite
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
@@ -14,17 +13,36 @@ type ReloadableWithConfig interface {
 	ReloadWithConfig(config any)
 }
 
-// Reload updates the configuration and handles runnables appropriately.
-// If membership changes (different set of runnables), all existing runnables are stopped
-// and the new set of runnables is started.
+// Reload updates the configuration and handles runnables appropriately. If
+// membership changes (different set of runnables), all existing runnables are
+// stopped and the new set is started.
 //
-// Concurrent callers are admitted via the FSM, not a mutex: the atomic
-// Running→Reloading transition is the single-flight gate. A second caller that
-// arrives while a reload is already in flight observes Reloading, fails the
-// transition, and returns without queueing — matching httpserver's pattern. If
-// every caller must produce an effect, callers should serialize themselves.
+// Concurrent callers are admitted via the FSM: the atomic Running→Reloading
+// transition is the single-flight gate. A second caller arriving while a
+// reload is already in flight observes Reloading, fails the transition, and
+// returns without queueing.
+//
+// Once admitted, the work is dispatched to Run's event loop, which owns the
+// FSM transition back to Running (or to Error on failure). This keeps Run as
+// the single FSM mutator during reload, eliminating the Run-vs-Reload race
+// where Run's shutdown sequence could otherwise observe FSM=Reloading. The
+// caller's ctx is admission-only: it cancels the request before it has been
+// accepted by Run's loop. Once accepted, Reload waits for the work to finish
+// — caller's ctx is intentionally ignored at that point so the caller never
+// observes FSM=Reloading after Reload returns.
 func (r *Runner[T]) Reload(ctx context.Context) {
 	logger := r.logger.WithGroup("Reload")
+
+	// Fast-path: if the caller's ctx is already cancelled, bail before
+	// touching the FSM or invoking configCallback. Without this, the select
+	// in dispatchReload can race ctx.Done() against the reloadCh send and
+	// dispatch a request the caller has already abandoned.
+	select {
+	case <-ctx.Done():
+		logger.Debug("Reload caller ctx done before dispatch", "error", ctx.Err())
+		return
+	default:
+	}
 
 	if err := r.fsm.TransitionIfCurrentState(
 		finitestate.StatusRunning,
@@ -39,103 +57,57 @@ func (r *Runner[T]) Reload(ctx context.Context) {
 		return
 	}
 
-	err := r.doReload(ctx)
-	switch {
-	case err == nil:
-		if transErr := r.fsm.Transition(finitestate.StatusRunning); transErr != nil {
-			logger.Error("Failed to transition to Running", "error", transErr)
-			r.setStateError()
-		}
-	case errors.Is(err, ErrReloadAborted):
-		// Normal control flow — caller cancelled or runner is shutting down.
-		logger.Debug("Reload aborted (not an error)", "reason", err)
-		// Atomic best-effort return to Running. If we're no longer in
-		// Reloading, Run has moved the FSM (Stopping/Stopped/Error) — that's
-		// fine, Run owns the state. If we're still in Reloading and the
-		// transition fails, that's an FSM-library-level inconsistency worth
-		// flagging as Error so it's visible.
+	// Best-effort FSM cleanup: covers the outer-abort cases (Run never picked
+	// up the request) where we hold Reloading but no apply ever ran. Run's
+	// handleReload owns the transition for any request it dispatched, so this
+	// is a no-op in the success path.
+	defer func() {
 		if transErr := r.fsm.TransitionIfCurrentState(
 			finitestate.StatusReloading, finitestate.StatusRunning,
 		); transErr != nil {
 			current := r.fsm.GetState()
 			if current == finitestate.StatusReloading {
-				logger.Error("FSM stuck in Reloading after abort",
-					"error", transErr)
+				logger.Error("FSM stuck in Reloading after dispatch", "error", transErr)
 				r.setStateError()
 			} else {
-				logger.Debug("FSM moved out of Reloading by Run during abort",
-					"current", current, "error", transErr)
+				logger.Debug("FSM moved out of Reloading during reload",
+					"current", current)
 			}
 		}
-	default:
-		logger.Error("Reload failed", "error", err)
-		r.setStateError()
-	}
-}
+	}()
 
-// doReload loads the new configuration and routes to the appropriate reload strategy.
-func (r *Runner[T]) doReload(ctx context.Context) error {
 	newConfig, err := r.configCallback()
 	if err != nil {
-		return fmt.Errorf("config callback: %w", err)
+		logger.Error("config callback failed", "error", err)
+		r.setStateError()
+		return
 	}
 	if newConfig == nil {
-		return errors.New("config callback returned nil")
+		logger.Error("config callback returned nil")
+		r.setStateError()
+		return
 	}
 
-	oldConfig := r.getConfig()
-	if oldConfig == nil {
-		r.logger.Warn("No current config during reload, treating as empty")
-		oldConfig = &Config[T]{}
-	}
-
-	if hasMembershipChanged(oldConfig, newConfig) {
-		return r.dispatchMembershipReload(ctx, newConfig)
-	}
-
-	r.reloadSkipRestart(ctx, newConfig)
-	return nil
+	r.dispatchReload(ctx, newConfig)
 }
 
-// dispatchMembershipReload sends a membership-change reload to Run's event loop
-// so new children boot into runCtx's cancellation tree. Aborts cleanly if the
-// runner has already exited or the caller's context is cancelled, so callers
-// never hang on a request that nobody will receive.
-func (r *Runner[T]) dispatchMembershipReload(ctx context.Context, newConfig *Config[T]) error {
-	cancel := make(chan struct{})
-	req := newReloadRequest(newConfig, cancel)
+// dispatchReload sends an accepted reload to Run's event loop and waits for
+// completion. Aborts cleanly if the runner has already exited or the caller's
+// ctx fires before Run picks the request up — once dispatched, the work runs
+// to completion and the caller waits unconditionally on done (mirrors
+// httpserver's pattern).
+func (r *Runner[T]) dispatchReload(ctx context.Context, newConfig *Config[T]) {
+	logger := r.logger.WithGroup("dispatchReload")
+	req := &reloadReq[T]{cfg: newConfig, done: make(chan struct{})}
 	select {
 	case r.reloadCh <- req:
-		select {
-		case err := <-req.done:
-			return err
-		case <-ctx.Done():
-			close(cancel)
-			// Recheck non-blocking: the consumer may have written req.done
-			// concurrently with ctx firing. If so, that result is the truth
-			// and we should return it instead of the cancellation error.
-			select {
-			case err := <-req.done:
-				return err
-			default:
-			}
-			return fmt.Errorf("%w: %w", ErrReloadAborted, ctx.Err())
-		case <-r.lc.DoneCh():
-			// Same-class race as the ctx.Done() branch above: if req.done
-			// became ready in the same select tick as DoneCh(), the consumer
-			// already wrote a real result — return that, don't claim the
-			// reload was aborted.
-			select {
-			case err := <-req.done:
-				return err
-			default:
-			}
-			return fmt.Errorf("%w: runner stopped while reload pending", ErrReloadAborted)
-		}
+		// Accepted. Wait for Run to finish (or for drainReloadCh to close
+		// done if Run exits before processing).
+		<-req.done
 	case <-ctx.Done():
-		return fmt.Errorf("%w: %w", ErrReloadAborted, ctx.Err())
+		logger.Debug("Reload caller ctx done before dispatch", "error", ctx.Err())
 	case <-r.lc.DoneCh():
-		return fmt.Errorf("%w: runner stopped before reload", ErrReloadAborted)
+		logger.Debug("Runner stopped before reload dispatch")
 	}
 }
 
@@ -165,8 +137,12 @@ func (r *Runner[T]) reloadWithRestart(ctx context.Context, newConfig *Config[T])
 	return nil
 }
 
-// reloadSkipRestart handles the case where the membership of runnables has not changed.
-func (r *Runner[T]) reloadSkipRestart(ctx context.Context, newConfig *Config[T]) {
+// reloadSkipRestart handles the case where the membership of runnables has not
+// changed. Called from Run's event loop (handleReload) so the inline child
+// reloads execute on Run's goroutine, single-threaded with Run's lifecycle
+// transitions. Returns nil today — the signature returns error so it can be
+// dispatched alongside reloadWithRestart through the same handleReload path.
+func (r *Runner[T]) reloadSkipRestart(ctx context.Context, newConfig *Config[T]) error {
 	logger := r.logger.WithGroup("reloadSkipRestart")
 	logger.Debug("Reloading runnables without membership change")
 	defer logger.Debug("Completed.")
@@ -195,6 +171,7 @@ func (r *Runner[T]) reloadSkipRestart(ctx context.Context, newConfig *Config[T])
 			logger.Warn("Child runnable does not implement Reloadable or ReloadableWithConfig")
 		}
 	}
+	return nil
 }
 
 // hasMembershipChanged checks if the set of runnables has changed between configurations

--- a/runnables/composite/reload.go
+++ b/runnables/composite/reload.go
@@ -87,7 +87,6 @@ func (r *Runner[T]) Reload(ctx context.Context) {
 // per-branch cleanup so we never leave a catch-all defer racing the next
 // caller's admission gate.
 func (r *Runner[T]) dispatchReload(ctx context.Context, newConfig *Config[T]) {
-	logger := r.logger.WithGroup("dispatchReload")
 	req := &reloadReq[T]{cfg: newConfig, done: make(chan struct{})}
 	select {
 	case r.reloadCh <- req:
@@ -95,17 +94,24 @@ func (r *Runner[T]) dispatchReload(ctx context.Context, newConfig *Config[T]) {
 		// done if Run exits before processing).
 		<-req.done
 	case <-ctx.Done():
-		logger.Debug("Reload caller ctx done before dispatch", "error", ctx.Err())
-		if err := r.fsm.Transition(finitestate.StatusRunning); err != nil {
-			logger.Error("Failed to transition Reloading→Running", "error", err)
-			r.setStateError()
-		}
+		r.abortDispatch("Reload caller ctx done before dispatch", "error", ctx.Err())
 	case <-r.lc.DoneCh():
-		logger.Debug("Runner stopped before reload dispatch")
-		if err := r.fsm.Transition(finitestate.StatusRunning); err != nil {
-			logger.Error("Failed to transition Reloading→Running", "error", err)
-			r.setStateError()
-		}
+		r.abortDispatch("Runner stopped before reload dispatch")
+	}
+}
+
+// abortDispatch is the per-branch cleanup for dispatchReload's abort paths.
+// Reload moved FSM Running→Reloading at admission; we must put it back to
+// Running before returning so the next admission gate sees a clean state. If
+// the transition fails (e.g., FSM was already moved by a concurrent shutdown
+// or setStateError), escalate to Error: by this point the FSM is in some
+// terminal-leaning state and a stuck Reloading is the worst outcome.
+func (r *Runner[T]) abortDispatch(reason string, attrs ...any) {
+	logger := r.logger.WithGroup("dispatchReload")
+	logger.Debug(reason, attrs...)
+	if err := r.fsm.Transition(finitestate.StatusRunning); err != nil {
+		logger.Error("Failed to transition Reloading→Running", "error", err)
+		r.setStateError()
 	}
 }
 

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -750,6 +750,206 @@ func TestSetStateError(t *testing.T) {
 	})
 }
 
+// TestAbortDispatch covers the per-branch cleanup helper used by
+// dispatchReload's ctx.Done()/lc.DoneCh() abort paths.
+func TestAbortDispatch(t *testing.T) {
+	t.Parallel()
+
+	configCallback := func() (*Config[*mocks.Runnable], error) {
+		return NewConfig("test", []RunnableEntry[*mocks.Runnable]{})
+	}
+
+	t.Run("transitions Reloading to Running", func(t *testing.T) {
+		runner, err := NewRunner(configCallback)
+		require.NoError(t, err)
+
+		require.NoError(t, runner.fsm.Transition(finitestate.StatusBooting))
+		require.NoError(t, runner.fsm.Transition(finitestate.StatusRunning))
+		require.NoError(t, runner.fsm.Transition(finitestate.StatusReloading))
+
+		runner.abortDispatch("test reason")
+
+		assert.Equal(t, finitestate.StatusRunning, runner.fsm.GetState())
+	})
+
+	t.Run("escalates to Error when transition fails", func(t *testing.T) {
+		mockFSM := new(MockStateMachine)
+		mockFSM.On("Transition", finitestate.StatusRunning).
+			Return(errors.New("transition failed")).Once()
+		mockFSM.On("SetState", finitestate.StatusError).Return(nil).Once()
+
+		runner, err := NewRunner(configCallback)
+		require.NoError(t, err)
+		runner.fsm = mockFSM
+
+		runner.abortDispatch("test reason", "key", "value")
+
+		mockFSM.AssertExpectations(t)
+	})
+}
+
+// TestDispatchReload_AbortBranches exercises the two abort cases of
+// dispatchReload's select. Both branches require reloadCh to be unable to
+// accept the send, so the test pre-fills the cap-1 buffer with a sentinel
+// request that no goroutine will consume.
+func TestDispatchReload_AbortBranches(t *testing.T) {
+	t.Parallel()
+
+	configCallback := func() (*Config[*mocks.Runnable], error) {
+		return NewConfig("test", []RunnableEntry[*mocks.Runnable]{})
+	}
+
+	bringToReloading := func(t *testing.T, r *Runner[*mocks.Runnable]) {
+		t.Helper()
+		require.NoError(t, r.fsm.Transition(finitestate.StatusBooting))
+		require.NoError(t, r.fsm.Transition(finitestate.StatusRunning))
+		require.NoError(t, r.fsm.Transition(finitestate.StatusReloading))
+	}
+
+	t.Run("ctx.Done branch", func(t *testing.T) {
+		runner, err := NewRunner(configCallback)
+		require.NoError(t, err)
+
+		// Hold lc.DoneCh open so the lc.DoneCh case is not ready and the
+		// select must pick ctx.Done deterministically. Don't call the
+		// returned `done` — it stays held for the duration of the test.
+		_ = runner.lc.Started()
+
+		bringToReloading(t, runner)
+
+		// Fill the cap-1 reloadCh buffer so the send case blocks.
+		runner.reloadCh <- &reloadReq[*mocks.Runnable]{done: make(chan struct{})}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		newConfig, err := NewConfig("dispatched", []RunnableEntry[*mocks.Runnable]{})
+		require.NoError(t, err)
+
+		runner.dispatchReload(ctx, newConfig)
+
+		assert.Equal(t, finitestate.StatusRunning, runner.fsm.GetState())
+	})
+
+	t.Run("lc.DoneCh branch", func(t *testing.T) {
+		runner, err := NewRunner(configCallback)
+		require.NoError(t, err)
+
+		// Don't call lc.Started() — DoneCh returns the always-closed
+		// sentinel, making the lc.DoneCh case the only ready case once
+		// the buffer is full and ctx is live.
+		bringToReloading(t, runner)
+
+		runner.reloadCh <- &reloadReq[*mocks.Runnable]{done: make(chan struct{})}
+
+		newConfig, err := NewConfig("dispatched", []RunnableEntry[*mocks.Runnable]{})
+		require.NoError(t, err)
+
+		runner.dispatchReload(t.Context(), newConfig)
+
+		assert.Equal(t, finitestate.StatusRunning, runner.fsm.GetState())
+	})
+}
+
+// TestHandleReload_Branches covers the defensive branches in handleReload:
+// the oldConfig==nil treat-as-empty fallback, the reload-failed setStateError
+// path, and the Transition(Running)-fails escalation.
+func TestHandleReload_Branches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil oldConfig treated as empty", func(t *testing.T) {
+		// A fresh runner has no currentConfig. With an empty new config,
+		// hasMembershipChanged(empty, empty) is false → reloadSkipRestart
+		// runs (no-op for empty entries) and FSM transitions back to
+		// Running. This exercises the `oldConfig == nil` fallback at the
+		// top of handleReload.
+		configCallback := func() (*Config[*mocks.Runnable], error) {
+			return NewConfig("test", []RunnableEntry[*mocks.Runnable]{})
+		}
+		runner, err := NewRunner(configCallback)
+		require.NoError(t, err)
+
+		require.NoError(t, runner.fsm.Transition(finitestate.StatusBooting))
+		require.NoError(t, runner.fsm.Transition(finitestate.StatusRunning))
+		require.NoError(t, runner.fsm.Transition(finitestate.StatusReloading))
+
+		emptyConfig, err := NewConfig("empty", []RunnableEntry[*mocks.Runnable]{})
+		require.NoError(t, err)
+
+		req := &reloadReq[*mocks.Runnable]{cfg: emptyConfig, done: make(chan struct{})}
+		runner.handleReload(t.Context(), req)
+
+		select {
+		case <-req.done:
+		default:
+			t.Fatal("handleReload must close req.done")
+		}
+		assert.Equal(t, finitestate.StatusRunning, runner.fsm.GetState())
+	})
+
+	t.Run("reload error sets Error state", func(t *testing.T) {
+		// Force reloadWithRestart to fail without spawning child Run
+		// goroutines: the configCallback returns nil, so getConfig stays
+		// nil and stopAllRunnables returns ErrConfigMissing before boot
+		// is reached.
+		configCallback := func() (*Config[*mocks.Runnable], error) {
+			return nil, nil
+		}
+		runner, err := NewRunner(configCallback)
+		require.NoError(t, err)
+
+		require.NoError(t, runner.fsm.Transition(finitestate.StatusBooting))
+		require.NoError(t, runner.fsm.Transition(finitestate.StatusRunning))
+		require.NoError(t, runner.fsm.Transition(finitestate.StatusReloading))
+
+		mockRunnable := mocks.NewMockRunnable()
+		mockRunnable.On("String").Return("forces-membership-change").Maybe()
+		newConfig, err := NewConfig("new", []RunnableEntry[*mocks.Runnable]{
+			{Runnable: mockRunnable, Config: nil},
+		})
+		require.NoError(t, err)
+
+		req := &reloadReq[*mocks.Runnable]{cfg: newConfig, done: make(chan struct{})}
+		runner.handleReload(t.Context(), req)
+
+		select {
+		case <-req.done:
+		default:
+			t.Fatal("handleReload must close req.done")
+		}
+		assert.Equal(t, finitestate.StatusError, runner.fsm.GetState())
+	})
+
+	t.Run("Transition failure escalates to Error", func(t *testing.T) {
+		// Mock the FSM so the success-path Transition(Running) returns an
+		// error after reloadSkipRestart succeeds.
+		mockFSM := new(MockStateMachine)
+		mockFSM.On("Transition", finitestate.StatusRunning).
+			Return(errors.New("transition failed")).Once()
+		mockFSM.On("SetState", finitestate.StatusError).Return(nil).Once()
+
+		configCallback := func() (*Config[*mocks.Runnable], error) {
+			return NewConfig("test", []RunnableEntry[*mocks.Runnable]{})
+		}
+		runner, err := NewRunner(configCallback)
+		require.NoError(t, err)
+		runner.fsm = mockFSM
+
+		emptyConfig, err := NewConfig("empty", []RunnableEntry[*mocks.Runnable]{})
+		require.NoError(t, err)
+
+		req := &reloadReq[*mocks.Runnable]{cfg: emptyConfig, done: make(chan struct{})}
+		runner.handleReload(t.Context(), req)
+
+		select {
+		case <-req.done:
+		default:
+			t.Fatal("handleReload must close req.done")
+		}
+		mockFSM.AssertExpectations(t)
+	})
+}
+
 // TestGetChildStates tests the GetChildStates method with various types of runnables
 func TestGetChildStates(t *testing.T) {
 	t.Parallel()

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -591,11 +591,6 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 		mockFSM.On("TransitionIfCurrentState",
 			finitestate.StatusRunning, finitestate.StatusReloading).
 			Return(nil).Once()
-		// Reload's deferred best-effort cleanup. May or may not fire depending
-		// on whether the test path reaches it; .Maybe() leaves it tolerant.
-		mockFSM.On("TransitionIfCurrentState",
-			finitestate.StatusReloading, finitestate.StatusRunning).
-			Return(errors.New("not in Reloading")).Maybe()
 		mockFSM.On("SetState", finitestate.StatusError).Return(nil).Once()
 		mockFSM.On("GetState").Return(finitestate.StatusError).Maybe()
 		// Must not expect Transition to Running since error path should prevent that
@@ -629,11 +624,6 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 		mockFSM.On("TransitionIfCurrentState",
 			finitestate.StatusRunning, finitestate.StatusReloading).
 			Return(nil).Once()
-		// Reload's deferred best-effort cleanup. May or may not fire depending
-		// on whether the test path reaches it; .Maybe() leaves it tolerant.
-		mockFSM.On("TransitionIfCurrentState",
-			finitestate.StatusReloading, finitestate.StatusRunning).
-			Return(errors.New("not in Reloading")).Maybe()
 		mockFSM.On("SetState", finitestate.StatusError).Return(nil).Once()
 		mockFSM.On("GetState").Return(finitestate.StatusError).Maybe()
 		// Must not expect Transition to Running since error path should prevent that
@@ -1845,60 +1835,72 @@ func TestCompositeRunner_ConcurrentReload_DropsOnBusy(t *testing.T) {
 	}, 2*time.Second, 10*time.Millisecond, "runner should shut down cleanly")
 }
 
+// TestCompositeRunner_ConcurrentReload exercises the FSM admission gate
+// under fan-in: 10 concurrent Reload callers must leave the runner in
+// Running, never Error. The FSM gate (TIC(Running, Reloading)) admits at
+// most one in-flight reload at a time; the rest drop.
+//
+// Run under synctest so the scheduling is deterministic and the test does
+// not depend on wall-clock budgets — an earlier wall-clock variant flaked on
+// slow CI runners where preemption between the now-removed catch-all defer
+// and the next admission could drive the FSM to Error.
 func TestCompositeRunner_ConcurrentReload(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		mockRunnable := mocks.NewMockRunnable()
+		mockRunnable.On("String").Return("concurrent-reloader").Maybe()
+		mockRunnable.On("Reload", mock.Anything).Return()
+		mockRunnable.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+			<-args.Get(0).(context.Context).Done()
+		}).Return(context.Canceled).Maybe()
+		mockRunnable.On("Stop").Return().Maybe()
 
-	mockRunnable := mocks.NewMockRunnable()
-	mockRunnable.On("String").Return("concurrent-reloader").Maybe()
-	mockRunnable.On("Reload", mock.Anything).Return()
-	mockRunnable.On("Run", mock.Anything).Run(func(args mock.Arguments) {
-		<-args.Get(0).(context.Context).Done()
-	}).Return(context.Canceled).Maybe()
-	mockRunnable.On("Stop").Return().Maybe()
+		entries := []RunnableEntry[*mocks.Runnable]{
+			{Runnable: mockRunnable, Config: nil},
+		}
 
-	entries := []RunnableEntry[*mocks.Runnable]{
-		{Runnable: mockRunnable, Config: nil},
-	}
+		configCallback := func() (*Config[*mocks.Runnable], error) {
+			return NewConfig("test", entries)
+		}
 
-	configCallback := func() (*Config[*mocks.Runnable], error) {
-		return NewConfig("test", entries)
-	}
+		runner, err := NewRunner(configCallback)
+		require.NoError(t, err)
 
-	runner, err := NewRunner(configCallback)
-	require.NoError(t, err)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+		runErr := make(chan error, 1)
+		go func() {
+			runErr <- runner.Run(ctx)
+		}()
 
-	runErr := make(chan error, 1)
-	go func() {
-		runErr <- runner.Run(ctx)
-	}()
+		synctest.Wait()
+		require.True(t, runner.IsRunning())
 
-	require.Eventually(t, func() bool {
-		return runner.IsRunning()
-	}, 2*time.Second, 10*time.Millisecond)
+		// Fan out 10 concurrent Reload callers. The FSM admission gate
+		// (TIC(Running, Reloading)) admits one at a time; the rest fail the
+		// gate and drop. Each admitted call dispatches through Run's event
+		// loop, which owns the Reloading→Running transition on completion.
+		// wg.Wait is durably blocking under synctest because wg.Go was
+		// called inside the bubble.
+		var wg sync.WaitGroup
+		for range 10 {
+			wg.Go(func() {
+				runner.Reload(t.Context())
+			})
+		}
+		wg.Wait()
 
-	var wg sync.WaitGroup
-	for range 10 {
-		wg.Go(func() {
-			runner.Reload(t.Context())
-		})
-	}
-	wg.Wait()
+		require.Equal(t, finitestate.StatusRunning, runner.GetState(),
+			"runner should be Running after concurrent reloads, not Error")
 
-	require.Eventually(t, func() bool {
-		return runner.IsRunning()
-	}, 2*time.Second, 10*time.Millisecond, "runner should be Running after concurrent reloads, not Error")
-
-	cancel()
-	require.Eventually(t, func() bool {
+		cancel()
+		synctest.Wait()
 		select {
 		case err := <-runErr:
-			assert.NoError(t, err)
-			return true
+			require.NoError(t, err)
 		default:
-			return false
+			t.Fatal("runner should shut down cleanly")
 		}
-	}, 2*time.Second, 10*time.Millisecond, "runner should shut down cleanly")
+	})
 }

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -3,7 +3,6 @@ package composite
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"os"
 	"sync"
@@ -592,6 +591,11 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 		mockFSM.On("TransitionIfCurrentState",
 			finitestate.StatusRunning, finitestate.StatusReloading).
 			Return(nil).Once()
+		// Reload's deferred best-effort cleanup. May or may not fire depending
+		// on whether the test path reaches it; .Maybe() leaves it tolerant.
+		mockFSM.On("TransitionIfCurrentState",
+			finitestate.StatusReloading, finitestate.StatusRunning).
+			Return(errors.New("not in Reloading")).Maybe()
 		mockFSM.On("SetState", finitestate.StatusError).Return(nil).Once()
 		mockFSM.On("GetState").Return(finitestate.StatusError).Maybe()
 		// Must not expect Transition to Running since error path should prevent that
@@ -625,6 +629,11 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 		mockFSM.On("TransitionIfCurrentState",
 			finitestate.StatusRunning, finitestate.StatusReloading).
 			Return(nil).Once()
+		// Reload's deferred best-effort cleanup. May or may not fire depending
+		// on whether the test path reaches it; .Maybe() leaves it tolerant.
+		mockFSM.On("TransitionIfCurrentState",
+			finitestate.StatusReloading, finitestate.StatusRunning).
+			Return(errors.New("not in Reloading")).Maybe()
 		mockFSM.On("SetState", finitestate.StatusError).Return(nil).Once()
 		mockFSM.On("GetState").Return(finitestate.StatusError).Maybe()
 		// Must not expect Transition to Running since error path should prevent that
@@ -653,224 +662,11 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 		assert.Equal(t, finitestate.StatusError, mockFSM.GetState(), "Should be in error state")
 	})
 
-	t.Run("reloadable runnable fails", func(t *testing.T) {
-		// Setup mock FSM with expected transitions
-		mockFSM := new(MockStateMachine)
-		mockFSM.On("TransitionIfCurrentState",
-			finitestate.StatusRunning, finitestate.StatusReloading).
-			Return(nil).Once()
-		// Do NOT expect SetState(StatusError) since the panic will interrupt execution
-		mockFSM.On("GetState").Return(finitestate.StatusReloading).Maybe()
-
-		// Setup mock runnable that fails on Reload
-		mockRunnable := mocks.NewMockRunnable()
-		mockRunnable.On("String").Return("runnable1").Maybe()
-		mockRunnable.On("Reload", mock.Anything).
-			Panic("reload failure").
-			Once()
-			// Use Panic() instead of Run() with panic
-
-		// Create entries
-		entries := []RunnableEntry[*mocks.Runnable]{
-			{Runnable: mockRunnable, Config: nil},
-		}
-
-		// Create config and ensure it's non-nil
-		initialConfig, err := NewConfig("test", entries)
-		require.NoError(t, err)
-
-		// Create config callback
-		configCallback := func() (*Config[*mocks.Runnable], error) {
-			return initialConfig, nil
-		}
-
-		// Create runner
-		runner, err := NewRunner(configCallback)
-		require.NoError(t, err)
-
-		// Manually set current config (skipping initial load)
-		runner.currentConfig.Store(initialConfig)
-
-		// Replace FSM with our mock
-		runner.fsm = mockFSM
-
-		// Call Reload with panic recovery - expect the panic to propagate
-		didPanic := false
-		panicMsg := ""
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					didPanic = true
-					panicMsg = fmt.Sprintf("%v", r)
-				}
-			}()
-			runner.Reload(t.Context())
-		}()
-
-		// Verify that the panic was propagated (not handled internally)
-		assert.True(t, didPanic, "Runner.Reload() should propagate panics")
-		assert.Contains(t, panicMsg, "reload failure",
-			"Panic message should contain the original panic reason")
-
-		// Since execution was interrupted by panic, only the first mock expectation should be met
-		mockFSM.AssertCalled(t, "TransitionIfCurrentState",
-			finitestate.StatusRunning, finitestate.StatusReloading)
-
-		// Verify our mock expectations
-		mockRunnable.AssertExpectations(t)
-	})
-
-	t.Run("reload with ReloadableWithConfig that panics", func(t *testing.T) {
-		// Setup mock FSM with expected transitions
-		mockFSM := new(MockStateMachine)
-		mockFSM.On("TransitionIfCurrentState",
-			finitestate.StatusRunning, finitestate.StatusReloading).
-			Return(nil).Once()
-		// No SetState error expectation since we won't reach that code due to panic
-		mockFSM.On("GetState").Return(finitestate.StatusReloading).Maybe()
-
-		// Setup initial config
-		initialConfig := map[string]string{"key": "initial"}
-		updatedConfig := map[string]string{"key": "updated"}
-
-		// Create a mock that will panic when ReloadWithConfig is called
-		mockReloadable := NewMockReloadableWithConfig()
-		mockReloadable.On("String").Return("reloadable-panic").Maybe()
-		// Use Panic() instead of Run() with a manual panic - more readable and direct
-		mockReloadable.On("ReloadWithConfig", updatedConfig).
-			Panic("intentional panic in ReloadWithConfig").
-			Once()
-		mockReloadable.On("Run", mock.Anything).Run(func(args mock.Arguments) {
-			<-args.Get(0).(context.Context).Done()
-		}).Return(context.Canceled).Maybe()
-		mockReloadable.Runnable.On("Stop").Return(nil).Maybe()
-
-		// Create entries
-		initialEntries := []RunnableEntry[*MockReloadableWithConfig]{
-			{Runnable: mockReloadable, Config: initialConfig},
-		}
-
-		updatedEntries := []RunnableEntry[*MockReloadableWithConfig]{
-			{Runnable: mockReloadable, Config: updatedConfig},
-		}
-
-		// Create initial config
-		config, err := NewConfig("test", initialEntries)
-		require.NoError(t, err)
-
-		updatedConfigObj, err := NewConfig("test", updatedEntries)
-		require.NoError(t, err)
-
-		// Variable to track which config to return
-		useUpdatedConfig := false
-
-		// Create config callback
-		configCallback := func() (*Config[*MockReloadableWithConfig], error) {
-			if useUpdatedConfig {
-				return updatedConfigObj, nil
-			}
-			return config, nil
-		}
-
-		// Create runner
-		runner, err := NewRunner(configCallback)
-		require.NoError(t, err)
-
-		// Manually set current config (skipping initial load)
-		runner.currentConfig.Store(config)
-
-		// Replace FSM with our mock
-		runner.fsm = mockFSM
-
-		// Switch to updated config that will cause panic
-		useUpdatedConfig = true
-
-		// Call Reload with panic recovery - we expect the panic to propagate
-		didPanic := false
-		panicMsg := ""
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					didPanic = true
-					panicMsg = fmt.Sprintf("%v", r)
-				}
-			}()
-			runner.Reload(t.Context())
-		}()
-
-		// Verify that the panic was propagated (not handled internally)
-		assert.True(t, didPanic, "Runner.Reload() should propagate panics")
-		assert.Contains(t, panicMsg, "intentional panic in ReloadWithConfig",
-			"Panic message should contain the original panic reason")
-
-		// Since execution was interrupted by panic, only the first mock expectation should be met
-		mockFSM.AssertCalled(t, "TransitionIfCurrentState",
-			finitestate.StatusRunning, finitestate.StatusReloading)
-
-		// We shouldn't have reached the error state since panic interrupted execution
-		mockReloadable.AssertExpectations(t)
-	})
-
-	t.Run("reloadable runnable fails with Panic", func(t *testing.T) {
-		// Setup mock FSM with expected transitions
-		mockFSM := new(MockStateMachine)
-		mockFSM.On("TransitionIfCurrentState",
-			finitestate.StatusRunning, finitestate.StatusReloading).
-			Return(nil).Once()
-		// We don't expect SetState to be called since panic will interrupt execution
-		mockFSM.On("GetState").Return(finitestate.StatusReloading).Maybe()
-
-		// Setup mock runnable that fails on Reload using Panic() instead of Run()
-		mockRunnable := mocks.NewMockRunnable()
-		mockRunnable.On("String").Return("runnable-panic").Maybe()
-		mockRunnable.On("Reload", mock.Anything).Panic("intentional panic in Reload").Once()
-
-		// Create entries
-		entries := []RunnableEntry[*mocks.Runnable]{
-			{Runnable: mockRunnable, Config: nil},
-		}
-
-		// Create config
-		initialConfig, err := NewConfig("test", entries)
-		require.NoError(t, err)
-
-		// Create config callback
-		configCallback := func() (*Config[*mocks.Runnable], error) {
-			return initialConfig, nil
-		}
-
-		// Create runner
-		runner, err := NewRunner(configCallback)
-		require.NoError(t, err)
-
-		// Manually set current config (skipping initial load)
-		runner.currentConfig.Store(initialConfig)
-
-		// Replace FSM with our mock
-		runner.fsm = mockFSM
-
-		// Call Reload with panic recovery - expect the panic to propagate
-		didPanic := false
-		panicMsg := ""
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					didPanic = true
-					panicMsg = fmt.Sprintf("%v", r)
-				}
-			}()
-			runner.Reload(t.Context())
-		}()
-
-		// The runner does NOT handle panics internally, so we should see one
-		assert.True(t, didPanic, "Runner.Reload() should propagate panics")
-		assert.Contains(t, panicMsg, "intentional panic in Reload",
-			"Panic message should contain the original panic reason")
-
-		// Since execution was interrupted by panic, only the first mock expectation should be met
-		mockFSM.AssertCalled(t, "TransitionIfCurrentState",
-			finitestate.StatusRunning, finitestate.StatusReloading)
-	})
+	// Panic-propagation subtests deleted: child Reload now runs in Run's
+	// goroutine (handleReload) rather than inline in Reload's caller, so a
+	// panicking child no longer propagates through Reload's stack frame.
+	// That tradeoff is the explicit point of the structural refactor — keep
+	// FSM mutation single-threaded inside Run.
 }
 
 // TestGetConfig_NilCase tests the getConfig method's handling of nil cases
@@ -1019,7 +815,7 @@ func TestReloadConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		// Call reloadConfig directly
-		runner.reloadSkipRestart(t.Context(), config)
+		require.NoError(t, runner.reloadSkipRestart(t.Context(), config))
 
 		// Verify reloadable interface methods were called
 		mockRunnable1.AssertExpectations(t)
@@ -1057,7 +853,7 @@ func TestReloadConfig(t *testing.T) {
 		runner, err := NewRunner(configCallback)
 		require.NoError(t, err)
 
-		runner.reloadSkipRestart(t.Context(), config)
+		require.NoError(t, runner.reloadSkipRestart(t.Context(), config))
 
 		// Verify ReloadWithConfig was called with correct configs
 		mockReloadable1.AssertExpectations(t)
@@ -1105,8 +901,8 @@ func TestReloadConfig(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		runner1.reloadSkipRestart(t.Context(), config1)
-		runner2.reloadSkipRestart(t.Context(), config2)
+		require.NoError(t, runner1.reloadSkipRestart(t.Context(), config1))
+		require.NoError(t, runner2.reloadSkipRestart(t.Context(), config2))
 
 		// Verify expectations
 		mockRunnable.AssertExpectations(t)
@@ -1529,8 +1325,8 @@ func TestHasMembershipChanged(t *testing.T) {
 }
 
 // TestCompositeRunner_ReloadAfterStop verifies that calling Reload after Stop
-// returns promptly instead of hanging. dispatchMembershipReload's outer select
-// on lc.DoneCh() short-circuits once Run has exited.
+// returns promptly instead of hanging. The FSM admission gate fails (state is
+// Stopped, not Running), so Reload returns without dispatching.
 func TestCompositeRunner_ReloadAfterStop(t *testing.T) {
 	t.Parallel()
 
@@ -1574,9 +1370,9 @@ func TestCompositeRunner_ReloadAfterStop(t *testing.T) {
 		2*time.Second, 10*time.Millisecond,
 	)
 
-	// Membership-change reload after Stop must not hang. The Reload may
-	// fail at the FSM check or inside dispatchMembershipReload — both are
-	// acceptable; what matters is that it returns promptly.
+	// Membership-change reload after Stop must not hang. The FSM admission
+	// gate fails (state is Stopped, not Running), so Reload returns without
+	// dispatching.
 	useSwapped.Store(true)
 	reloadDone := make(chan struct{})
 	go func() {
@@ -1586,7 +1382,7 @@ func TestCompositeRunner_ReloadAfterStop(t *testing.T) {
 	select {
 	case <-reloadDone:
 	case <-time.After(2 * time.Second):
-		t.Fatal("Reload after Stop did not return — likely hung in dispatchMembershipReload")
+		t.Fatal("Reload after Stop did not return — likely hung in dispatchReload")
 	}
 
 	cancel()
@@ -1597,16 +1393,17 @@ func TestCompositeRunner_ReloadAfterStop(t *testing.T) {
 	}
 }
 
-// TestCompositeRunner_ReloadCancelMidFlight verifies that cancelling the
-// caller's context after dispatchMembershipReload has handed the request to
-// Run unblocks the caller via the inner ctx.Done() select case.
-func TestCompositeRunner_ReloadCancelMidFlight(t *testing.T) {
+// TestCompositeRunner_ReloadWaitsThroughCallerCtxCancel verifies the
+// post-dispatch contract: once Reload has handed the request to Run, the
+// caller's ctx is intentionally ignored and Reload blocks until the work
+// completes. This guarantees callers never observe FSM=Reloading after
+// Reload has returned.
+func TestCompositeRunner_ReloadWaitsThroughCallerCtxCancel(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
-		// Slow-stop child blocks Run inside reloadWithRestart so the caller is
-		// observably parked in the post-send select. synctest.Wait() returns
-		// once the bubble is quiescent — the only path to quiescence after
-		// Reload runs through this <-slowStop park.
+		// Slow-stop child blocks Run inside reloadWithRestart, parking the
+		// Reload caller on req.done. The caller's ctx is cancelled while
+		// parked — Reload MUST keep waiting until close(slowStop).
 		slowStop := make(chan struct{})
 		mockRunnable1 := mocks.NewMockRunnable()
 		mockRunnable1.On("String").Return("slow").Maybe()
@@ -1647,23 +1444,36 @@ func TestCompositeRunner_ReloadCancelMidFlight(t *testing.T) {
 
 		useSwapped.Store(true)
 		reloadCtx, reloadCancel := context.WithCancel(context.Background())
+		reloadReturned := atomic.Bool{}
 		reloadDone := make(chan struct{})
 		go func() {
 			defer close(reloadDone)
 			runner.Reload(reloadCtx)
+			reloadReturned.Store(true)
 		}()
 
+		// Wait until Reload is parked on req.done (synctest quiescence proves
+		// the bubble has nothing to schedule — Reload's blocked goroutine is
+		// the only suspension).
 		synctest.Wait()
 
+		// Cancel the caller's ctx mid-flight. Reload must NOT return.
 		reloadCancel()
+		synctest.Wait()
+		require.False(t, reloadReturned.Load(),
+			"Reload must wait for completion even after caller ctx cancel")
+
+		// Release the slow child. Run finishes the membership-change reload,
+		// transitions FSM Reloading→Running, closes req.done. Reload returns.
+		close(slowStop)
 		select {
 		case <-reloadDone:
 		case <-time.After(2 * time.Second):
-			t.Fatal("Reload did not return after caller ctx cancel")
+			t.Fatal("Reload did not return after work completed")
 		}
+		require.Equal(t, finitestate.StatusRunning, runner.GetState(),
+			"FSM must be Running after Reload returns — never Reloading")
 
-		// Release the slow child so the runner can shut down cleanly.
-		close(slowStop)
 		runCancel()
 		select {
 		case <-runErr:
@@ -1673,88 +1483,13 @@ func TestCompositeRunner_ReloadCancelMidFlight(t *testing.T) {
 	})
 }
 
-// TestCompositeRunner_AbandonedReloadIsSkipped verifies that a membership-change
-// reload request whose caller has signalled abandonment (cancel chan closed)
-// does NOT execute its side effects (no Stop, no config swap, no boot of new
-// entries) when Run's event loop picks it up. White-box: builds a
-// reloadRequest directly with a pre-closed cancel signal and sends it into
-// the unexported reloadCh, since the public-API path can't reliably wedge
-// between send-success and consumer-read.
-func TestCompositeRunner_AbandonedReloadIsSkipped(t *testing.T) {
-	t.Parallel()
-
-	mockChild := mocks.NewMockRunnable()
-	mockChild.On("String").Return("child").Maybe()
-	mockChild.On("Run", mock.Anything).Run(func(args mock.Arguments) {
-		<-args.Get(0).(context.Context).Done()
-	}).Return(context.Canceled).Maybe()
-	mockChild.On("Stop").Return().Maybe()
-
-	altChild := mocks.NewMockRunnable()
-	altChild.On("String").Return("alt").Maybe()
-	altChild.On("Run", mock.Anything).Run(func(args mock.Arguments) {
-		<-args.Get(0).(context.Context).Done()
-	}).Return(context.Canceled).Maybe()
-	altChild.On("Stop").Return().Maybe()
-
-	initial := []RunnableEntry[*mocks.Runnable]{{Runnable: mockChild}}
-	cb := func() (*Config[*mocks.Runnable], error) {
-		return NewConfig("initial", initial)
-	}
-
-	runner, err := NewRunner(cb)
-	require.NoError(t, err)
-
-	runCtx, runCancel := context.WithCancel(t.Context())
-	defer runCancel()
-	runErr := make(chan error, 1)
-	go func() { runErr <- runner.Run(runCtx) }()
-
-	require.Eventually(
-		t, runner.IsRunning, 2*time.Second, 10*time.Millisecond,
-	)
-
-	originalCfg := runner.getConfig()
-	require.NotNil(t, originalCfg)
-
-	swapped := []RunnableEntry[*mocks.Runnable]{{Runnable: altChild}}
-	newCfg, err := NewConfig("swapped", swapped)
-	require.NoError(t, err)
-
-	cancel := make(chan struct{})
-	close(cancel)
-	req := newReloadRequest(newCfg, cancel)
-	runner.reloadCh <- req
-
-	var doneErr error
-	select {
-	case doneErr = <-req.done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for waitForEvent to consume reloadCh")
-	}
-	require.Error(t, doneErr)
-	require.ErrorIs(t, doneErr, ErrReloadAborted)
-	require.Contains(t, doneErr.Error(), "abandoned by caller")
-
-	// Critical: side effects must NOT have happened.
-	mockChild.AssertNotCalled(t, "Stop")
-	require.Same(t, originalCfg, runner.getConfig(),
-		"config must not have been swapped for an abandoned request")
-	altChild.AssertNotCalled(t, "Run")
-
-	runCancel()
-	select {
-	case <-runErr:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Run did not return after ctx cancel")
-	}
-}
-
-// TestCompositeRunner_AbandonedReloadIsSkipped_PublicAPI exercises the same
-// abandonment path as the white-box test above, but through the public
-// Reload(ctx) API. ctx is pre-cancelled so dispatchMembershipReload's outer
-// select sees ctx.Done() and returns ErrReloadAborted without enqueueing.
-func TestCompositeRunner_AbandonedReloadIsSkipped_PublicAPI(t *testing.T) {
+// TestCompositeRunner_PreCancelledReloadCtx verifies that calling Reload with
+// a pre-cancelled ctx is a clean no-op: the FSM gate succeeds (Running →
+// Reloading), dispatchReload's outer select fires ctx.Done() before sending,
+// and the deferred FSM cleanup transitions Reloading → Running. No side
+// effects (no Stop, no config swap, no boot of new entries) and the FSM is
+// NOT in Error.
+func TestCompositeRunner_PreCancelledReloadCtx(t *testing.T) {
 	t.Parallel()
 
 	mockChild := mocks.NewMockRunnable()
@@ -1963,11 +1698,10 @@ func TestCompositeRunner_DrainReloadCh_OnShutdown(t *testing.T) {
 		"runner did not reach Stopping — slow-stop wedge failed")
 
 	// Now send the stale request. waitForEvent is gone; only deferred
-	// drainReloadCh can clear this.
-	cancel := make(chan struct{})
+	// drainReloadCh can clear this and close req.done.
 	staleCfg, err := NewConfig("stale", []RunnableEntry[*mocks.Runnable]{{Runnable: altChild}})
 	require.NoError(t, err)
-	stale := newReloadRequest(staleCfg, cancel)
+	stale := &reloadReq[*mocks.Runnable]{cfg: staleCfg, done: make(chan struct{})}
 	runner.reloadCh <- stale
 	require.Len(t, runner.reloadCh, 1, "stale request must land in buffer")
 
@@ -1985,9 +1719,16 @@ func TestCompositeRunner_DrainReloadCh_OnShutdown(t *testing.T) {
 	require.Empty(t, runner.reloadCh,
 		"deferred drainReloadCh must have cleared the stale request")
 
+	// drainReloadCh closes req.done so any caller blocked on it unblocks
+	// deterministically rather than relying on a separate signal.
+	select {
+	case <-stale.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("drainReloadCh must close req.done so callers unblock")
+	}
+
 	// Side effects from the stale request must NOT have fired — altChild
-	// was never started, and we don't see RunReload's "abandoned" message
-	// on req.done because drainReloadCh discards silently.
+	// was never started; drainReloadCh closes done without running apply.
 	altChild.AssertNotCalled(t, "Run")
 	altChild.AssertNotCalled(t, "Stop")
 

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -1753,6 +1753,12 @@ func TestCompositeRunner_ConcurrentReload_DropsOnBusy(t *testing.T) {
 	t.Parallel()
 
 	releaseReload := make(chan struct{})
+	// Always release on test exit, even on assertion failure: if the test
+	// fails before the happy-path close(releaseReload) below, the in-flight
+	// reload (and its mocked child.Reload) would otherwise block forever,
+	// leaking a goroutine and obscuring the real failure.
+	releaseOnce := sync.OnceFunc(func() { close(releaseReload) })
+	t.Cleanup(releaseOnce)
 
 	mockChild := mocks.NewMockRunnable()
 	mockChild.On("String").Return("slow-reloader").Maybe()
@@ -1819,7 +1825,7 @@ func TestCompositeRunner_ConcurrentReload_DropsOnBusy(t *testing.T) {
 	assert.Equal(t, finitestate.StatusReloading, runner.GetState())
 
 	// Release the in-flight reload so the runner returns to Running.
-	close(releaseReload)
+	releaseOnce()
 	first.Wait()
 	require.Eventually(t, runner.IsRunning, 2*time.Second, 5*time.Millisecond,
 		"runner should return to Running after the in-flight reload completes")

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -558,7 +558,8 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 		// the Error state — it's "wrong state for reload" control flow,
 		// not a runner failure.
 		mockFSM := new(MockStateMachine)
-		mockFSM.On("Transition", finitestate.StatusReloading).
+		mockFSM.On("TransitionIfCurrentState",
+			finitestate.StatusRunning, finitestate.StatusReloading).
 			Return(errors.New("transition error")).
 			Once()
 		mockFSM.On("GetState").Return(finitestate.StatusStopped).Maybe()
@@ -588,7 +589,9 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 	t.Run("config callback error during reload", func(t *testing.T) {
 		// Setup mock FSM with expected transitions
 		mockFSM := new(MockStateMachine)
-		mockFSM.On("Transition", finitestate.StatusReloading).Return(nil).Once()
+		mockFSM.On("TransitionIfCurrentState",
+			finitestate.StatusRunning, finitestate.StatusReloading).
+			Return(nil).Once()
 		mockFSM.On("SetState", finitestate.StatusError).Return(nil).Once()
 		mockFSM.On("GetState").Return(finitestate.StatusError).Maybe()
 		// Must not expect Transition to Running since error path should prevent that
@@ -619,7 +622,9 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 	t.Run("config callback returns nil config", func(t *testing.T) {
 		// Setup mock FSM with expected transitions
 		mockFSM := new(MockStateMachine)
-		mockFSM.On("Transition", finitestate.StatusReloading).Return(nil).Once()
+		mockFSM.On("TransitionIfCurrentState",
+			finitestate.StatusRunning, finitestate.StatusReloading).
+			Return(nil).Once()
 		mockFSM.On("SetState", finitestate.StatusError).Return(nil).Once()
 		mockFSM.On("GetState").Return(finitestate.StatusError).Maybe()
 		// Must not expect Transition to Running since error path should prevent that
@@ -651,7 +656,9 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 	t.Run("reloadable runnable fails", func(t *testing.T) {
 		// Setup mock FSM with expected transitions
 		mockFSM := new(MockStateMachine)
-		mockFSM.On("Transition", finitestate.StatusReloading).Return(nil).Once()
+		mockFSM.On("TransitionIfCurrentState",
+			finitestate.StatusRunning, finitestate.StatusReloading).
+			Return(nil).Once()
 		// Do NOT expect SetState(StatusError) since the panic will interrupt execution
 		mockFSM.On("GetState").Return(finitestate.StatusReloading).Maybe()
 
@@ -706,7 +713,8 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 			"Panic message should contain the original panic reason")
 
 		// Since execution was interrupted by panic, only the first mock expectation should be met
-		mockFSM.AssertCalled(t, "Transition", finitestate.StatusReloading)
+		mockFSM.AssertCalled(t, "TransitionIfCurrentState",
+			finitestate.StatusRunning, finitestate.StatusReloading)
 
 		// Verify our mock expectations
 		mockRunnable.AssertExpectations(t)
@@ -715,7 +723,9 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 	t.Run("reload with ReloadableWithConfig that panics", func(t *testing.T) {
 		// Setup mock FSM with expected transitions
 		mockFSM := new(MockStateMachine)
-		mockFSM.On("Transition", finitestate.StatusReloading).Return(nil).Once()
+		mockFSM.On("TransitionIfCurrentState",
+			finitestate.StatusRunning, finitestate.StatusReloading).
+			Return(nil).Once()
 		// No SetState error expectation since we won't reach that code due to panic
 		mockFSM.On("GetState").Return(finitestate.StatusReloading).Maybe()
 
@@ -794,7 +804,8 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 			"Panic message should contain the original panic reason")
 
 		// Since execution was interrupted by panic, only the first mock expectation should be met
-		mockFSM.AssertCalled(t, "Transition", finitestate.StatusReloading)
+		mockFSM.AssertCalled(t, "TransitionIfCurrentState",
+			finitestate.StatusRunning, finitestate.StatusReloading)
 
 		// We shouldn't have reached the error state since panic interrupted execution
 		mockReloadable.AssertExpectations(t)
@@ -803,7 +814,9 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 	t.Run("reloadable runnable fails with Panic", func(t *testing.T) {
 		// Setup mock FSM with expected transitions
 		mockFSM := new(MockStateMachine)
-		mockFSM.On("Transition", finitestate.StatusReloading).Return(nil).Once()
+		mockFSM.On("TransitionIfCurrentState",
+			finitestate.StatusRunning, finitestate.StatusReloading).
+			Return(nil).Once()
 		// We don't expect SetState to be called since panic will interrupt execution
 		mockFSM.On("GetState").Return(finitestate.StatusReloading).Maybe()
 
@@ -855,7 +868,8 @@ func TestCompositeRunner_Reload_Errors(t *testing.T) {
 			"Panic message should contain the original panic reason")
 
 		// Since execution was interrupted by panic, only the first mock expectation should be met
-		mockFSM.AssertCalled(t, "Transition", finitestate.StatusReloading)
+		mockFSM.AssertCalled(t, "TransitionIfCurrentState",
+			finitestate.StatusRunning, finitestate.StatusReloading)
 	})
 }
 
@@ -1983,6 +1997,105 @@ func TestCompositeRunner_DrainReloadCh_OnShutdown(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Run did not return after ctx cancel")
 	}
+}
+
+// TestCompositeRunner_ConcurrentReload_DropsOnBusy verifies the FSM
+// admission gate's drop-on-busy semantics: while one Reload is in flight (the
+// FSM is in Reloading), concurrent Reload callers fail the
+// TransitionIfCurrentState gate, return immediately without queueing, and do
+// NOT trigger a second pass through the child's Reload.
+//
+// This is the contract that replaced the prior reloadMu-based queueing: a
+// reload pulls the latest config; if a reload is already in flight, the new
+// caller's request is redundant and is dropped.
+func TestCompositeRunner_ConcurrentReload_DropsOnBusy(t *testing.T) {
+	t.Parallel()
+
+	releaseReload := make(chan struct{})
+
+	mockChild := mocks.NewMockRunnable()
+	mockChild.On("String").Return("slow-reloader").Maybe()
+	mockChild.On("Run", mock.Anything).Run(func(args mock.Arguments) {
+		<-args.Get(0).(context.Context).Done()
+	}).Return(context.Canceled).Maybe()
+	mockChild.On("Stop").Return().Maybe()
+	// Reload blocks on releaseReload, holding the parent FSM in Reloading.
+	// .Once() asserts that exactly one Reload reaches the child — concurrent
+	// callers must be dropped at the FSM admission gate.
+	mockChild.On("Reload", mock.Anything).Run(func(_ mock.Arguments) {
+		<-releaseReload
+	}).Return().Once()
+
+	entries := []RunnableEntry[*mocks.Runnable]{
+		{Runnable: mockChild, Config: nil},
+	}
+	configCallback := func() (*Config[*mocks.Runnable], error) {
+		return NewConfig("test", entries)
+	}
+
+	runner, err := NewRunner(configCallback)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- runner.Run(ctx) }()
+	require.Eventually(t, runner.IsRunning, 2*time.Second, 5*time.Millisecond)
+
+	// First reload: blocks inside child.Reload, parent FSM held in Reloading.
+	var first sync.WaitGroup
+	first.Go(func() {
+		runner.Reload(t.Context())
+	})
+	require.Eventually(t, func() bool {
+		return runner.GetState() == finitestate.StatusReloading
+	}, 2*time.Second, 5*time.Millisecond, "first reload must enter Reloading")
+
+	// Spawn N concurrent reloads — each must hit the FSM gate, fail, and
+	// return immediately. They MUST NOT queue and MUST NOT call child.Reload.
+	const concurrent = 10
+	var others sync.WaitGroup
+	for range concurrent {
+		others.Go(func() {
+			runner.Reload(t.Context())
+		})
+	}
+	// All N must return promptly (they bail at admission). If they queue on a
+	// hypothetical mutex, they'd block until releaseReload closes.
+	done := make(chan struct{})
+	go func() {
+		others.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("concurrent Reload callers did not return promptly — they appear to be queueing instead of dropping")
+	}
+
+	// FSM still pinned in Reloading by the in-flight first call.
+	assert.Equal(t, finitestate.StatusReloading, runner.GetState())
+
+	// Release the in-flight reload so the runner returns to Running.
+	close(releaseReload)
+	first.Wait()
+	require.Eventually(t, runner.IsRunning, 2*time.Second, 5*time.Millisecond,
+		"runner should return to Running after the in-flight reload completes")
+
+	// .Once() on Reload asserts exactly one call reached the child.
+	mockChild.AssertExpectations(t)
+
+	cancel()
+	require.Eventually(t, func() bool {
+		select {
+		case err := <-runErr:
+			assert.NoError(t, err)
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond, "runner should shut down cleanly")
 }
 
 func TestCompositeRunner_ConcurrentReload(t *testing.T) {

--- a/runnables/composite/runner.go
+++ b/runnables/composite/runner.go
@@ -34,57 +34,23 @@ type Runner[T runnable] struct {
 
 	runnablesMu sync.Mutex
 
-	reloadCh     chan *reloadRequest[T]
+	reloadCh     chan *reloadReq[T]
 	serverErrors chan error
 	logger       *slog.Logger
 }
 
-// reloadRequest carries a membership-change reload from Reload() into Run's
-// event loop so new children boot into runCtx's cancellation tree. The cancel
-// signal lets the caller revoke the request if its own ctx fired before Run
-// picked the request up — without that, RunReload would apply side effects
-// (stop, swap, reboot) that the caller already gave up waiting for.
+// reloadReq carries an accepted reload from Reload(ctx) into Run's event
+// loop so all FSM transitions (Reloading→Running, Reloading→Error) and any
+// child work happen single-threaded alongside Run's lifecycle transitions —
+// eliminating the Run-vs-Reload race where Run's shutdown sequence would
+// otherwise observe FSM=Reloading and trip on Reloading→Stopped (an invalid
+// transition per transitions.Typical).
 //
-// The struct is a pure message — no back-reference to the runner. The
-// consumer hands RunReload the restart function it should call, which keeps
-// reloadRequest unit-testable in isolation and avoids the Runner ↔
-// reloadRequest cycle.
-type reloadRequest[T runnable] struct {
-	newConfig *Config[T]
-	done      chan error
-	cancel    <-chan struct{}
-}
-
-// newReloadRequest builds a reloadRequest with a buffered done channel. cancel
-// is the caller's "I gave up" signal; close it to ask the consumer to skip
-// the work.
-func newReloadRequest[T runnable](
-	newConfig *Config[T], cancel <-chan struct{},
-) *reloadRequest[T] {
-	return &reloadRequest[T]{
-		newConfig: newConfig,
-		done:      make(chan error, 1),
-		cancel:    cancel,
-	}
-}
-
-// RunReload is the consumer-side entry point. It checks whether the caller
-// has abandoned the request and, if not, calls restart with ctx (Run's
-// runCtx) so new children inherit the runner's lifetime rather than the
-// caller's. restart is supplied by the caller (typically
-// Runner.reloadWithRestart) so reloadRequest stays a pure message with no
-// back-reference to the runner.
-func (req *reloadRequest[T]) RunReload(
-	ctx context.Context,
-	restart func(context.Context, *Config[T]) error,
-) {
-	select {
-	case <-req.cancel:
-		req.done <- fmt.Errorf("%w: abandoned by caller", ErrReloadAborted)
-		return
-	default:
-	}
-	req.done <- restart(ctx, req.newConfig)
+// done is closed by Run after handleReload finishes — including from
+// drainReloadCh on Run exit — so a caller blocked on done always unblocks.
+type reloadReq[T runnable] struct {
+	cfg  *Config[T]
+	done chan struct{}
 }
 
 // NewRunner creates a new CompositeRunner instance with the provided configuration callback and options.
@@ -102,7 +68,7 @@ func NewRunner[T runnable](
 		lc:             lifecycle.New(),
 		currentConfig:  atomic.Pointer[Config[T]]{},
 		configCallback: configCallback,
-		reloadCh:       make(chan *reloadRequest[T], 1),
+		reloadCh:       make(chan *reloadReq[T], 1),
 		serverErrors:   make(chan error, 1),
 		logger:         logger,
 	}
@@ -204,8 +170,9 @@ func (r *Runner[T]) Stop() {
 }
 
 // waitForEvent blocks until context cancellation, stop signal, or a child error.
-// Membership-change reloads are processed inline via reloadCh so new children
-// boot into ctx's cancellation tree.
+// Reload requests are processed inline via reloadCh so the FSM transition
+// Reloading→Running and any child work happen on Run's goroutine, single-
+// threaded with Run's lifecycle transitions.
 func (r *Runner[T]) waitForEvent(ctx context.Context) error {
 	for {
 		select {
@@ -221,19 +188,56 @@ func (r *Runner[T]) waitForEvent(ctx context.Context) error {
 			stopErr := r.stopAllRunnables()
 			return fmt.Errorf("%w: %w", ErrRunnableFailed, errors.Join(err, stopErr))
 		case req := <-r.reloadCh:
-			req.RunReload(ctx, r.reloadWithRestart)
+			r.handleReload(ctx, req)
 		}
 	}
 }
 
-// drainReloadCh discards any pending reload requests queued after Run's
-// select loop exits. The caller's inner select observes lc.DoneCh() and
-// returns "runner stopped while reload pending" on its own — drain is just
-// for clearing the buffer so a restarted runner doesn't see stale entries.
+// handleReload runs an accepted reload request inside Run's goroutine. Reload
+// has already moved the FSM Running→Reloading; this completes the work and
+// transitions the FSM back to Running (or sets Error on failure). The
+// membership-change vs in-place decision is made here, against the runner's
+// current config — keeping that decision on Run's side guarantees it sees a
+// consistent old/new pair.
+func (r *Runner[T]) handleReload(ctx context.Context, req *reloadReq[T]) {
+	defer close(req.done)
+
+	oldConfig := r.getConfig()
+	if oldConfig == nil {
+		r.logger.Warn("No current config during reload, treating as empty")
+		oldConfig = &Config[T]{}
+	}
+
+	var err error
+	if hasMembershipChanged(oldConfig, req.cfg) {
+		err = r.reloadWithRestart(ctx, req.cfg)
+	} else {
+		err = r.reloadSkipRestart(ctx, req.cfg)
+	}
+
+	if err != nil {
+		r.logger.Error("Reload failed", "error", err)
+		r.setStateError()
+		return
+	}
+
+	if transErr := r.fsm.Transition(finitestate.StatusRunning); transErr != nil {
+		r.logger.Error("Failed to transition Reloading→Running", "error", transErr)
+		r.setStateError()
+	}
+}
+
+// drainReloadCh closes done on any reload request still buffered in reloadCh
+// after Run's select loop exits. Without this, a Reload caller blocked on
+// done would only unblock via lc.DoneCh() in its outer select — closing done
+// makes the protocol explicit and unblocks the caller's done branch
+// deterministically. The Reload caller's deferred FSM cleanup transitions
+// any leftover Reloading state back to Running.
 func (r *Runner[T]) drainReloadCh() {
 	for {
 		select {
-		case <-r.reloadCh:
+		case req := <-r.reloadCh:
+			close(req.done)
 		default:
 			return
 		}

--- a/runnables/composite/runner.go
+++ b/runnables/composite/runner.go
@@ -32,7 +32,6 @@ type Runner[T runnable] struct {
 	currentConfig  atomic.Pointer[Config[T]]
 	configCallback ConfigCallback[T]
 
-	reloadMu    sync.Mutex
 	runnablesMu sync.Mutex
 
 	reloadCh     chan *reloadRequest[T]

--- a/runnables/composite/runner.go
+++ b/runnables/composite/runner.go
@@ -231,12 +231,22 @@ func (r *Runner[T]) handleReload(ctx context.Context, req *reloadReq[T]) {
 // after Run's select loop exits. Without this, a Reload caller blocked on
 // done would only unblock via lc.DoneCh() in its outer select — closing done
 // makes the protocol explicit and unblocks the caller's done branch
-// deterministically. The Reload caller's deferred FSM cleanup transitions
-// any leftover Reloading state back to Running.
+// deterministically.
+//
+// Also transitions the FSM Reloading→Running before closing done. Run is the
+// single FSM mutator during reload, so this best-effort transition (a no-op
+// if FSM isn't Reloading) keeps the runner's subsequent Stopping/Stopped
+// transitions valid: Reloading→Stopped is not a legal transition per the FSM
+// table, but Running→Stopping→Stopped is.
 func (r *Runner[T]) drainReloadCh() {
 	for {
 		select {
 		case req := <-r.reloadCh:
+			if err := r.fsm.TransitionIfCurrentState(
+				finitestate.StatusReloading, finitestate.StatusRunning,
+			); err != nil {
+				r.logger.Debug("drainReloadCh: FSM not in Reloading", "error", err)
+			}
 			close(req.done)
 		default:
 			return

--- a/runnables/composite/runner_test.go
+++ b/runnables/composite/runner_test.go
@@ -740,7 +740,7 @@ func TestCompositeRunner_StopDuringReload(t *testing.T) {
 		return runner.IsRunning()
 	}, 1*time.Second, 5*time.Millisecond)
 
-	// Start reload in background (the mock's Reload .After() keeps reloadMu held)
+	// Start reload in background (the mock's Reload .After() keeps the FSM in Reloading)
 	go runner.Reload(t.Context())
 	require.Eventually(t, func() bool {
 		return runner.GetState() == finitestate.StatusReloading


### PR DESCRIPTION
## Summary

Composite's `Reload` had two-layer serialization — `reloadMu` queued concurrent callers, then `fsm.Transition(Reloading)` advertised state. The mutex was structurally redundant: a single `TransitionIfCurrentState(Running, Reloading)` is both an atomic single-flight gate AND the state advertisement.

Composite now follows httpserver's pattern (introduced in PR #95): the FSM is the only serialization primitive. Behavior shifts from **"queue concurrent reloads"** to **"first writer wins, drop redundant reloads"** — which is the idiomatic shape for reload-the-latest-config: an in-flight reload is about to load whatever a queued caller would also load, so the queued caller is redundant.

- `runnables/composite/runner.go`: drop `reloadMu sync.Mutex`.
- `runnables/composite/reload.go`: replace `Lock + Transition(Reloading)` with `TransitionIfCurrentState(Running, Reloading)`. Updated godoc to spell out the drop-on-busy contract.
- `runnables/composite/reload_test.go`: new `TestCompositeRunner_ConcurrentReload_DropsOnBusy` locks in the contract — while one Reload is parked in the child via a gate channel (FSM in Reloading), N concurrent Reload calls must return promptly without queueing, and the child's `Reload` must be invoked exactly once. Mock-FSM expectations updated from `On("Transition", StatusReloading)` to `On("TransitionIfCurrentState", StatusRunning, StatusReloading)`.
- `runnables/composite/runner_test.go`: comment update referencing `reloadMu` is now FSM-based.

## Caller-visible change

If anything outside this repo calls `composite.Runner.Reload(ctx)` and relies on every call producing an effect even when concurrent, that contract is no longer honored. Searching the repo, the only caller is the supervisor's reload manager, which is fire-and-forget on SIGHUP — unaffected.