### PR TITLE
Drop ReloadAll() send when supervisor ctx is done

### DIFF
--- a/supervisor/reload.go
+++ b/supervisor/reload.go
@@ -18,11 +18,17 @@ package supervisor
 
 import "sync"
 
-// ReloadAll triggers a reload of all runnables that implement the Reloadable interface.
-// This call blocks until the reload manager accepts the signal. Callers that need
-// non-blocking behavior should invoke this in a goroutine.
+// ReloadAll triggers a reload of all runnables that implement the Reloadable
+// interface. Blocks until the reload manager accepts the signal OR the
+// supervisor's context is done — once shutdown begins, startReloadManager
+// returns and stops draining reloadListener, so the send must abort instead
+// of wedging. Callers that need non-blocking behavior should invoke this in
+// a goroutine.
 func (p *PIDZero) ReloadAll() {
-	p.reloadListener <- struct{}{}
+	select {
+	case p.reloadListener <- struct{}{}:
+	case <-p.ctx.Done():
+	}
 }
 
 // startReloadManager starts a goroutine that listens for reload notifications

--- a/supervisor/reload_test.go
+++ b/supervisor/reload_test.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"syscall"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/robbyt/go-supervisor/runnables/mocks"
@@ -311,5 +312,39 @@ func TestPIDZero_ReloadManager(t *testing.T) {
 				return false
 			}
 		}, 2*time.Second, 10*time.Millisecond, "shutdown timed out")
+	})
+
+	// Once the supervisor's ctx is cancelled, startReloadManager exits and stops
+	// draining reloadListener. Without the ctx-aware select in ReloadAll, an
+	// unbuffered send into the dead channel wedges forever — SIGHUP-bombing
+	// during shutdown (`go p.ReloadAll()` on each SIGHUP) leaks goroutines.
+	// Drives startReloadManager directly inside synctest because Run() uses
+	// signal.Notify, which isn't synctest-compatible.
+	t.Run("ReloadAll returns after ctx cancel without wedging", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			mockService := mocks.NewMockRunnable()
+
+			pidZero := newTestPIDZero(t, WithContext(ctx), WithRunnables(mockService))
+			pidZero.wg.Go(pidZero.startReloadManager)
+
+			cancel()
+			synctest.Wait()
+
+			reloadDone := make(chan struct{})
+			go func() {
+				pidZero.ReloadAll()
+				close(reloadDone)
+			}()
+			synctest.Wait()
+
+			select {
+			case <-reloadDone:
+			default:
+				t.Fatal("ReloadAll wedged after ctx cancel — unbuffered send with no drainer")
+			}
+		})
 	})
 }


### PR DESCRIPTION
## Summary

- Public `ReloadAll()` had an unbuffered send into `p.reloadListener` with no `<-p.ctx.Done()` case. Once `startReloadManager` exits on shutdown, the send wedges forever — `reap()` dispatches `go p.ReloadAll()` per SIGHUP, so SIGHUP-bombing during shutdown leaks goroutines holding refs to `PIDZero`. External direct callers face the same wedge after `Shutdown()`.
- Adds a select on `p.ctx.Done()` so the send drops once shutdown has begun. Mirrors the pattern already used by the internal ReloadSender forwarder loop (`reload.go:44–49`).
- Contract: `ReloadAll()` now blocks until accepted **OR** ctx done. Live-supervisor callers are unaffected (existing concurrent-ReloadAll test still passes).

Tracks Codex stability finding #3 / plan T1.5.

## Test plan

- [x] `go test -race ./supervisor/...` — all green; new `ReloadAll returns after ctx cancel without wedging` synctest subtest in `TestPIDZero_ReloadManager` reproduces the wedge before the fix and passes after.
- [x] Sanity-check: reverted the select, ran the new subtest — fails with `goroutine [chan send (durable), synctest bubble 1]`. Restored.
- [x] 50× stress on the new subtest — green.
- [x] Full `go test -race ./...` — green.
- [x] `make lint` — 0 issues.