### PR TITLE
Add regression coverage for ShutdownSender during reload + SIGTERM during boot

### DIFF
--- a/supervisor/shutdown_test.go
+++ b/supervisor/shutdown_test.go
@@ -423,6 +423,78 @@ func TestPIDZero_Shutdown(t *testing.T) {
 	})
 }
 
+// TestPIDZero_ShutdownSender_DuringReload covers Codex stability gap #7: a
+// ShutdownSender trigger fires while a reload is in flight. With the T1.3
+// channel-dispatch fix the listener cancels p.ctx and reap's existing
+// <-p.ctx.Done() arm invokes Shutdown — so an in-flight Reload doesn't wedge
+// the shutdown handoff. Pre-T1.3, the listener called Shutdown() inline,
+// which created a circular wait (listener inside Shutdown's p.wg.Wait while
+// startShutdownManager waited on the listener via shutdownWg.Wait); T1.2's
+// shutdownTimeout bounded that wedge but logged "Shutdown timeout exceeded".
+// We pin the post-T1.3 contract — Shutdown must complete promptly, not
+// burn the full shutdownTimeout — by making the configured budget small and
+// asserting Run returns well within it.
+//
+// Cannot use synctest: this calls pidZero.Run(), which uses signal.Notify.
+func TestPIDZero_ShutdownSender_DuringReload(t *testing.T) {
+	t.Parallel()
+
+	const shutdownBudget = 500 * time.Millisecond
+
+	runnable := mocks.NewMockRunnableWithShutdownSender()
+	shutdownChan := make(chan struct{}, 1)
+	runStarted := make(chan struct{})
+	reloadStarted := make(chan struct{})
+	releaseReload := make(chan struct{})
+
+	runnable.On("GetShutdownTrigger").Return(shutdownChan).Once()
+	runnable.On("String").Return("shutdownReloadRunnable").Maybe()
+	runnable.On("Run", mock.Anything).Return(nil).Once().Run(func(args mock.Arguments) {
+		ctx := args.Get(0).(context.Context)
+		close(runStarted)
+		<-ctx.Done()
+	})
+	runnable.On("Reload", mock.Anything).Return().Once().Run(func(args mock.Arguments) {
+		close(reloadStarted)
+		<-releaseReload
+	})
+	runnable.On("Stop").Once()
+
+	pidZero := newTestPIDZero(t,
+		WithRunnables(runnable),
+		WithShutdownTimeout(shutdownBudget),
+	)
+
+	execDone := startPIDZeroRun(t, pidZero)
+	eventuallyClosed(t, runStarted, "Run did not start in time")
+
+	// Kick off a reload and wait until the mock confirms it's actually
+	// inside Reload (not just queued by the manager). At that point the
+	// reload-manager goroutine is blocked on releaseReload.
+	go pidZero.ReloadAll()
+	eventuallyClosed(t, reloadStarted, "Reload did not start in time")
+
+	// Fire the shutdown trigger while Reload is mid-call. The listener
+	// cancels p.ctx; reap's <-p.ctx.Done() arm dispatches Shutdown.
+	shutdownStart := time.Now()
+	shutdownChan <- struct{}{}
+
+	// Release the reload so the reload-manager goroutine can return and
+	// observe its own ctx.Done(). Shutdown's wg.Wait must not wedge.
+	close(releaseReload)
+
+	requirePIDZeroRunDone(t, execDone, time.Second)
+	shutdownDuration := time.Since(shutdownStart)
+
+	// With T1.3 shutdown should complete promptly — well inside the
+	// configured budget. A regression that re-introduces the circular wait
+	// would push this near or past the budget (bounded by T1.2's deadline).
+	require.Less(t, shutdownDuration, shutdownBudget/2,
+		"Shutdown took %v of %v budget — circular wait between listener and shutdown manager?",
+		shutdownDuration, shutdownBudget)
+	runnable.AssertExpectations(t)
+}
+
 func newTestPIDZero(t *testing.T, opts ...Option) *PIDZero {
 	t.Helper()
 

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -1039,8 +1039,11 @@ func TestPIDZero_Run_SIGTERMDuringBoot(t *testing.T) {
 	execDone := startPIDZeroRun(t, pidZero)
 	eventuallyClosed(t, runStarted, "Run did not start in time")
 
-	// Inject SIGTERM while the startup loop is still polling IsRunning() —
-	// the signal queues in p.signalChan; nothing drains it yet.
+	// Inject SIGTERM while Run is still in its startup phase —
+	// blockUntilRunnableReady is either in its initial time.Sleep
+	// (p.startupInitial, default 50ms) or polling IsRunning() afterwards.
+	// Either way reap hasn't started, so the signal queues in p.signalChan
+	// and nothing drains it yet.
 	pidZero.SendSignal(syscall.SIGTERM)
 
 	// Release the startup gate so blockUntilRunnableReady returns and Run's

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -985,6 +985,73 @@ func TestPIDZero_Run_PreCancelledCtxStopsAtFirst(t *testing.T) {
 		"C's Run must not be called when parent ctx is pre-cancelled (iter > 0)")
 }
 
+// slowBootRunnable wraps MockRunnableWithStateable so the test can gate
+// IsRunning() on a channel rather than testify's count-based mock returns.
+// This holds the supervisor's startup loop in blockUntilRunnableReady until
+// the gate is closed, giving the test a deterministic window to inject a
+// signal mid-boot.
+type slowBootRunnable struct {
+	*mocks.MockRunnableWithStateable
+	ready chan struct{}
+}
+
+func (s *slowBootRunnable) IsRunning() bool {
+	select {
+	case <-s.ready:
+		return true
+	default:
+		return false
+	}
+}
+
+// TestPIDZero_Run_SIGTERMDuringBoot covers Codex stability gap #8: SIGTERM
+// arriving during the startup loop, before all Stateable runnables have
+// transitioned to Running. signal.Notify's buffered channel queues the
+// signal; the startup loop doesn't drain it (only reap does). Once boot
+// completes the queued SIGTERM is processed and Shutdown runs cleanly.
+//
+// Cannot use synctest: this calls pidZero.Run(), which uses signal.Notify.
+func TestPIDZero_Run_SIGTERMDuringBoot(t *testing.T) {
+	t.Parallel()
+
+	runStarted := make(chan struct{})
+	ready := make(chan struct{})
+
+	base := mocks.NewMockRunnableWithStateable()
+	base.On("String").Return("slowBootRunnable").Maybe()
+	base.On("Run", mock.Anything).Return(nil).Once().Run(func(args mock.Arguments) {
+		ctx := args.Get(0).(context.Context)
+		close(runStarted)
+		<-ctx.Done()
+	})
+	base.On("GetState").Return("Booting").Maybe()
+	base.On("GetStateChan", mock.Anything).Return(make(chan string)).Maybe()
+	base.On("Stop").Once()
+
+	runnable := &slowBootRunnable{MockRunnableWithStateable: base, ready: ready}
+
+	pidZero := newTestPIDZero(t,
+		WithRunnables(runnable),
+		WithStartupTimeout(2*time.Second),
+		WithShutdownTimeout(time.Second),
+	)
+
+	execDone := startPIDZeroRun(t, pidZero)
+	eventuallyClosed(t, runStarted, "Run did not start in time")
+
+	// Inject SIGTERM while the startup loop is still polling IsRunning() —
+	// the signal queues in p.signalChan; nothing drains it yet.
+	pidZero.SendSignal(syscall.SIGTERM)
+
+	// Release the startup gate so blockUntilRunnableReady returns and Run's
+	// startup loop falls through into reap, which drains the buffered
+	// SIGTERM and triggers Shutdown.
+	close(ready)
+
+	requirePIDZeroRunDone(t, execDone, 3*time.Second)
+	base.AssertExpectations(t)
+}
+
 // TestPIDZero_Reap_UnhandledSignal tests the default case in signal handling.
 func TestPIDZero_Reap_UnhandledSignal(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Two NIT regression tests covering coverage gaps Codex flagged after the audit. Tests-only — no production code changes. These pin down behavior introduced by T1.3 (PR #97) and T1.6 (PR #98) so future refactors can't silently regress.

- **`TestPIDZero_ShutdownSender_DuringReload` (Codex stability #7)** — drives a ShutdownSender trigger while a Reload is mid-call. With the T1.3 channel-dispatch fix, the listener cancels `p.ctx` and `reap`'s existing `<-p.ctx.Done()` arm invokes Shutdown; pre-T1.3, the listener called `Shutdown()` inline, creating a circular wait. The test sets `shutdownTimeout=500ms` and asserts shutdown finishes in `<250ms` — sanity-checked locally by reverting T1.3, which made the test fail at `501ms` (full circular-wait timeout).
- **`TestPIDZero_Run_SIGTERMDuringBoot` (Codex stability #8)** — gates `IsRunning()` on a channel via a small `slowBootRunnable` wrapper, holding the startup loop in `blockUntilRunnableReady`. Injects SIGTERM via `SendSignal` while the loop is still polling; the signal queues in `p.signalChan`. Once the gate releases, boot completes, `reap` drains the queued SIGTERM, and Shutdown runs cleanly. Documents the "buffered signal survives boot" guarantee that `signal.Notify` + the boot-then-reap sequence rely on.

Tracks plan items T4.1 + T4.2 — the last items in the master defects/ergonomics plan.

Both tests use the existing `newTestPIDZero` / `startPIDZeroRun` / `requirePIDZeroRunDone` / `eventuallyClosed` helpers and cannot use synctest (`Run()` calls `signal.Notify`, which isn't synctest-compatible — same constraint already documented at `shutdown_test.go:62-66`).

## Test plan

- [x] `go test -race ./supervisor/...` — green; both new tests pass.
- [x] 50× stress on each new test — green.
- [x] Sanity-check on T4.1: reverted T1.3 locally; test failed at 501ms (full circular-wait timeout) as expected. Restored.
- [x] T4.2 has no fix to revert — it documents existing behavior. Confirmed by reading the boot loop and signal pipeline that the assertion matches what the implementation does.
- [x] Full `go test -race ./...` — all green.
- [x] `make lint` — 0 issues.