### PR TITLE
Add ctx to ReloadWithConfig - breaking change

### DIFF
--- a/examples/composite/worker.go
+++ b/examples/composite/worker.go
@@ -178,10 +178,12 @@ func (w *Worker) startTicker(ctx context.Context, interval time.Duration) {
 	logger.Debug("Ticker setup complete", "interval", interval)
 }
 
-// ReloadWithConfig receives a new config from the composite Runnable, and sends it to the Run
-// loop via a channel. It handles potential back-pressure by replacing a pending config with the
-// latest received if the channel is full.
-func (w *Worker) ReloadWithConfig(config any) {
+// ReloadWithConfig receives a new config from the composite Runnable, and
+// sends it to the Run loop via a channel. It handles potential back-pressure
+// by replacing a pending config with the latest received if the channel is
+// full. ctx is honored: if the caller cancels before the queue accepts the
+// config, the call returns without queueing.
+func (w *Worker) ReloadWithConfig(ctx context.Context, config any) {
 	logger := w.logger.WithGroup("ReloadWithConfig")
 	cfg, ok := config.(WorkerConfig)
 	if !ok {
@@ -206,7 +208,11 @@ func (w *Worker) ReloadWithConfig(config any) {
 	// Non-blocking send to nextConfig channel.
 	// If the channel is full (meaning a config is already waiting),
 	// discard the waiting one and queue the new one (newer config wins).
+	// Honor ctx so a cancelled caller doesn't get its config queued.
 	select {
+	case <-ctx.Done():
+		logger.Debug("Reload aborted before queueing", "error", ctx.Err())
+		return
 	case w.nextConfig <- cfg:
 		logger.Info(
 			"Configuration queued for update",
@@ -220,11 +226,15 @@ func (w *Worker) ReloadWithConfig(config any) {
 			"old", old,
 			"new", cfg)
 
-		w.nextConfig <- cfg
-
-		logger.Info(
-			"Replaced pending configuration with the newest one",
-			"new", cfg)
+		select {
+		case <-ctx.Done():
+			logger.Debug("Reload aborted while requeueing", "error", ctx.Err())
+			return
+		case w.nextConfig <- cfg:
+			logger.Info(
+				"Replaced pending configuration with the newest one",
+				"new", cfg)
+		}
 	}
 }
 

--- a/examples/composite/worker.go
+++ b/examples/composite/worker.go
@@ -181,8 +181,9 @@ func (w *Worker) startTicker(ctx context.Context, interval time.Duration) {
 // ReloadWithConfig receives a new config from the composite Runnable, and
 // sends it to the Run loop via a channel. It handles potential back-pressure
 // by replacing a pending config with the latest received if the channel is
-// full. ctx is honored: if the caller cancels before the queue accepts the
-// config, the call returns without queueing.
+// full. ctx must be non-nil — pass context.Background() or context.TODO()
+// when no caller ctx is available. If ctx is cancelled before the queue
+// accepts the config, the call returns without queueing.
 func (w *Worker) ReloadWithConfig(ctx context.Context, config any) {
 	logger := w.logger.WithGroup("ReloadWithConfig")
 	cfg, ok := config.(WorkerConfig)
@@ -205,36 +206,39 @@ func (w *Worker) ReloadWithConfig(ctx context.Context, config any) {
 		return
 	}
 
-	// Non-blocking send to nextConfig channel.
-	// If the channel is full (meaning a config is already waiting),
-	// discard the waiting one and queue the new one (newer config wins).
-	// Honor ctx so a cancelled caller doesn't get its config queued.
+	// Fast path: try to queue without blocking. Honor ctx so a cancelled
+	// caller doesn't get its config queued.
 	select {
 	case <-ctx.Done():
 		logger.Debug("Reload aborted before queueing", "error", ctx.Err())
 		return
 	case w.nextConfig <- cfg:
-		logger.Info(
-			"Configuration queued for update",
-			"cfg", cfg)
+		logger.Info("Configuration queued for update", "cfg", cfg)
+		return
 	default:
-		// Channel is full, discard the old pending config and add the new one.
-		old := <-w.nextConfig
+	}
 
-		logger.Info(
-			"Discarding old config",
-			"old", old,
-			"new", cfg)
+	// Channel was full. Drain the pending config non-blockingly — Run
+	// may have consumed it concurrently between our default-branch fall
+	// through and this point, so a blocking receive could wedge.
+	select {
+	case old := <-w.nextConfig:
+		logger.Info("Discarding old config", "old", old, "new", cfg)
+	default:
+	}
 
-		select {
-		case <-ctx.Done():
-			logger.Debug("Reload aborted while requeueing", "error", ctx.Err())
-			return
-		case w.nextConfig <- cfg:
-			logger.Info(
-				"Replaced pending configuration with the newest one",
-				"new", cfg)
-		}
+	// Retry the send. Still non-blocking on the send path because Run
+	// could refill nextConfig before our retry; in that case drop newest
+	// (best-effort newer-wins semantics — under contention something has
+	// to give).
+	select {
+	case <-ctx.Done():
+		logger.Debug("Reload aborted while requeueing", "error", ctx.Err())
+		return
+	case w.nextConfig <- cfg:
+		logger.Info("Replaced pending configuration with the newest one", "new", cfg)
+	default:
+		logger.Warn("Reload dropped — queue refilled before requeue", "new", cfg)
 	}
 }
 

--- a/examples/composite/worker_test.go
+++ b/examples/composite/worker_test.go
@@ -262,7 +262,7 @@ func TestWorker_ReloadWithConfig(t *testing.T) {
 		JobName:  "updated-job-reload",
 	}
 	t.Logf("Reloading with valid config: %+v", newConfig)
-	worker.ReloadWithConfig(newConfig)
+	worker.ReloadWithConfig(t.Context(), newConfig)
 
 	// Wait for the configuration to be applied using Eventually
 	require.Eventually(t, func() bool {
@@ -276,7 +276,7 @@ func TestWorker_ReloadWithConfig(t *testing.T) {
 	// --- Test Invalid Config Type ---
 	configAfterValidReload := readWorkerConfig(t, worker) // Store state before invalid reload
 	t.Log("Reloading with invalid type 'string'")
-	worker.ReloadWithConfig("invalid type") // Pass a non-WorkerConfig type
+	worker.ReloadWithConfig(t.Context(), "invalid type") // Pass a non-WorkerConfig type
 
 	// Wait a short time and assert config hasn't changed
 	assert.Eventually(t, func() bool {
@@ -294,7 +294,7 @@ func TestWorker_ReloadWithConfig(t *testing.T) {
 	// --- Test Invalid Config Values ---
 	invalidValueConfig := WorkerConfig{Interval: 0, JobName: "wont-apply"}
 	t.Logf("Reloading with invalid value config: %+v", invalidValueConfig)
-	worker.ReloadWithConfig(invalidValueConfig)
+	worker.ReloadWithConfig(t.Context(), invalidValueConfig)
 
 	// Wait and assert config hasn't changed
 	assert.Eventually(t, func() bool {
@@ -307,6 +307,34 @@ func TestWorker_ReloadWithConfig(t *testing.T) {
 		currentConfig,
 		"Config should not change after invalid value reload",
 	)
+}
+
+// TestWorker_ReloadWithConfig_RespectsCtx covers the T3.4 contract: a
+// cancelled ctx aborts ReloadWithConfig before the new config gets queued.
+// Without ctx-honoring, a SIGHUP-bombing caller could leak configs into the
+// worker's queue even after the supervisor has begun shutting down.
+func TestWorker_ReloadWithConfig_RespectsCtx(t *testing.T) {
+	t.Parallel()
+	logger, _ := testLogger(t, false)
+
+	initial := WorkerConfig{Interval: 50 * time.Millisecond, JobName: "ctx-test"}
+	worker, err := NewWorker(initial, logger)
+	require.NoError(t, err)
+
+	// No need to start Run — ReloadWithConfig only touches the nextConfig
+	// queue, and the queue is drained by Run. With no Run goroutine, the
+	// queue stays empty unless ReloadWithConfig pushes into it.
+	cancelled, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	newCfg := WorkerConfig{Interval: 100 * time.Millisecond, JobName: "should-not-queue"}
+	worker.ReloadWithConfig(cancelled, newCfg)
+
+	select {
+	case queued := <-worker.nextConfig:
+		t.Fatalf("ReloadWithConfig queued a config despite cancelled ctx: %+v", queued)
+	default:
+	}
 }
 
 // TestWorker_Execution_Timing tests that the worker ticks according to the configured interval,
@@ -398,7 +426,7 @@ func TestWorker_Execution_Timing(t *testing.T) {
 	// --- Test Reloaded Interval ---
 	newConfig := WorkerConfig{Interval: reloadedInterval, JobName: "timing-job-reloaded"}
 	t.Logf("Reloading config with interval: %v", reloadedInterval)
-	worker.ReloadWithConfig(newConfig)
+	worker.ReloadWithConfig(t.Context(), newConfig)
 
 	// Ensure config is applied before measuring again
 	require.Eventually(t, func() bool {
@@ -470,6 +498,7 @@ func TestWorker_ReloadWithConfig_Concurrency(t *testing.T) {
 	reloadWg.Add(numReloads)
 
 	finalConfig := WorkerConfig{} // Store the config from the last reload goroutine
+	reloadCtx := t.Context()
 
 	// Launch concurrent reloads
 	for i := range numReloads {
@@ -484,7 +513,7 @@ func TestWorker_ReloadWithConfig_Concurrency(t *testing.T) {
 			if index == numReloads-1 {
 				finalConfig = cfg
 			}
-			worker.ReloadWithConfig(cfg)
+			worker.ReloadWithConfig(reloadCtx, cfg)
 		}(i)
 	}
 

--- a/runnables/composite/reload.go
+++ b/runnables/composite/reload.go
@@ -8,9 +8,14 @@ import (
 	"github.com/robbyt/go-supervisor/supervisor"
 )
 
-// ReloadableWithConfig is an interface for sub-runnables that can reload with specific config
+// ReloadableWithConfig is an interface for sub-runnables that can reload with
+// a specific configuration. Implementations should honor ctx — at minimum to
+// abort the reload if the caller cancels — but may also use it for deadline
+// propagation if the reload itself is bounded. Like Reloadable.Reload, this
+// returns no error: failures should surface via the runnable's own logging
+// or via Stateable.GetStateChan (e.g. transitioning to an Error state).
 type ReloadableWithConfig interface {
-	ReloadWithConfig(config any)
+	ReloadWithConfig(ctx context.Context, config any)
 }
 
 // Reload updates the configuration and handles runnables appropriately. If
@@ -165,7 +170,7 @@ func (r *Runner[T]) reloadSkipRestart(ctx context.Context, newConfig *Config[T])
 		if reloadableWithConfig, ok := any(entry.Runnable).(ReloadableWithConfig); ok {
 			// If the runnable implements our ReloadableWithConfig interface, use that to pass the new config
 			logger.Debug("Reloading child runnable with config")
-			reloadableWithConfig.ReloadWithConfig(entry.Config)
+			reloadableWithConfig.ReloadWithConfig(ctx, entry.Config)
 		} else if reloadable, ok := any(entry.Runnable).(supervisor.Reloadable); ok {
 			// Fall back to standard Reloadable interface, assume the configCallback
 			// has somehow updated the runnable's internal state

--- a/runnables/composite/reload.go
+++ b/runnables/composite/reload.go
@@ -11,9 +11,11 @@ import (
 // ReloadableWithConfig is an interface for sub-runnables that can reload with
 // a specific configuration. Implementations should honor ctx — at minimum to
 // abort the reload if the caller cancels — but may also use it for deadline
-// propagation if the reload itself is bounded. Like Reloadable.Reload, this
-// returns no error: failures should surface via the runnable's own logging
-// or via Stateable.GetStateChan (e.g. transitioning to an Error state).
+// propagation if the reload itself is bounded. ctx must be non-nil; callers
+// without a meaningful ctx should pass context.Background() or context.TODO().
+// Like Reloadable.Reload, this returns no error: failures should surface via
+// the runnable's own logging or via Stateable.GetStateChan (e.g. transitioning
+// to an Error state).
 type ReloadableWithConfig interface {
 	ReloadWithConfig(ctx context.Context, config any)
 }

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -58,8 +58,8 @@ type MockReloadableWithConfig struct {
 	*mocks.Runnable
 }
 
-func (m *MockReloadableWithConfig) ReloadWithConfig(config any) {
-	m.Called(config)
+func (m *MockReloadableWithConfig) ReloadWithConfig(ctx context.Context, config any) {
+	m.Called(ctx, config)
 }
 
 func NewMockReloadableWithConfig() *MockReloadableWithConfig {
@@ -430,7 +430,7 @@ func TestCompositeRunner_Reload(t *testing.T) {
 
 		mockReloadable1 := NewMockReloadableWithConfig()
 		mockReloadable1.On("String").Return("reloadable1")
-		mockReloadable1.On("ReloadWithConfig", updatedConfig1).Once()
+		mockReloadable1.On("ReloadWithConfig", mock.Anything, updatedConfig1).Once()
 		mockReloadable1.On("Run", mock.Anything).Run(func(args mock.Arguments) {
 			<-args.Get(0).(context.Context).Done()
 		}).Return(context.Canceled).Once()
@@ -442,7 +442,7 @@ func TestCompositeRunner_Reload(t *testing.T) {
 
 		mockReloadable2 := NewMockReloadableWithConfig()
 		mockReloadable2.On("String").Return("reloadable2")
-		mockReloadable2.On("ReloadWithConfig", updatedConfig2).Once()
+		mockReloadable2.On("ReloadWithConfig", mock.Anything, updatedConfig2).Once()
 		mockReloadable2.On("Run", mock.Anything).Run(func(args mock.Arguments) {
 			<-args.Get(0).(context.Context).Done()
 		}).Return(context.Canceled).Once()
@@ -1018,13 +1018,13 @@ func TestReloadConfig(t *testing.T) {
 		mockReloadable1.On("String").Return("reloadable1").Maybe()
 
 		customConfig1 := map[string]string{"key": "value1"}
-		mockReloadable1.On("ReloadWithConfig", customConfig1).Once()
+		mockReloadable1.On("ReloadWithConfig", mock.Anything, customConfig1).Once()
 
 		mockReloadable2 := NewMockReloadableWithConfig()
 		mockReloadable2.On("String").Return("reloadable2").Maybe()
 
 		customConfig2 := map[string]string{"key": "value2"}
-		mockReloadable2.On("ReloadWithConfig", customConfig2).Once()
+		mockReloadable2.On("ReloadWithConfig", mock.Anything, customConfig2).Once()
 
 		// Create entries
 		entries := []RunnableEntry[*MockReloadableWithConfig]{
@@ -1061,7 +1061,7 @@ func TestReloadConfig(t *testing.T) {
 		mockReloadable.On("String").Return("reloadable").Maybe()
 
 		customConfig := map[string]string{"key": "value"}
-		mockReloadable.On("ReloadWithConfig", customConfig).Once()
+		mockReloadable.On("ReloadWithConfig", mock.Anything, customConfig).Once()
 
 		// Create both configs
 		entries1 := []RunnableEntry[*mocks.Runnable]{
@@ -1097,6 +1097,40 @@ func TestReloadConfig(t *testing.T) {
 		// Verify expectations
 		mockRunnable.AssertExpectations(t)
 		mockReloadable.AssertExpectations(t)
+	})
+
+	// Covers the T3.4 contract: reloadSkipRestart threads its ctx into the
+	// ReloadableWithConfig branch (not just into the Reloadable fallback).
+	// Without this, a child reload couldn't observe caller cancellation.
+	t.Run("threads ctx into ReloadWithConfig", func(t *testing.T) {
+		mockReloadable := NewMockReloadableWithConfig()
+		mockReloadable.On("String").Return("ctx-reloadable").Maybe()
+
+		cfg := map[string]string{"key": "v"}
+		// Capture the ctx the runner passes through and verify it matches.
+		var receivedCtx context.Context
+		mockReloadable.On("ReloadWithConfig", mock.Anything, cfg).Run(func(args mock.Arguments) {
+			receivedCtx = args.Get(0).(context.Context)
+		}).Once()
+
+		entries := []RunnableEntry[*MockReloadableWithConfig]{
+			{Runnable: mockReloadable, Config: cfg},
+		}
+		config, err := NewConfig("ctx-test", entries)
+		require.NoError(t, err)
+
+		runner, err := NewRunner(func() (*Config[*MockReloadableWithConfig], error) {
+			return config, nil
+		})
+		require.NoError(t, err)
+
+		callerCtx := t.Context()
+		require.NoError(t, runner.reloadSkipRestart(callerCtx, config))
+
+		mockReloadable.AssertExpectations(t)
+		require.NotNil(t, receivedCtx, "ReloadWithConfig must receive a non-nil ctx")
+		require.Same(t, callerCtx, receivedCtx,
+			"ReloadWithConfig must receive the same ctx the caller passed to reloadSkipRestart")
 	})
 }
 


### PR DESCRIPTION
## Summary

**Breaking change.** \`ReloadableWithConfig.ReloadWithConfig(config any)\` → \`ReloadWithConfig(ctx context.Context, config any)\`.

T1.1 (#95) added \`ctx\` to plain \`Reloadable.Reload\`; \`ReloadableWithConfig\` was left contextless and asymmetric. With this change implementations can honor caller cancellation (abort a config queue insert if the caller already gave up).

This is **PR-A of three** in the Tier 3 breaking-change series:
- **PR-A (this) — T3.4** — \`ReloadableWithConfig\` takes ctx
- PR-B — T3.2 + T3.3 — Decouple \`Stateable\` from \`Readiness\`; rename \`IsRunning\` → \`IsReady\`
- PR-C — T3.1 (narrowed) — \`Reload(ctx) error\` (Stop stays no-error)

**Changes:**
- \`runnables/composite/reload.go\`: interface signature updated; \`reloadSkipRestart\` threads its ctx into the \`ReloadableWithConfig\` branch (was already threading into the \`Reloadable.Reload\` fallback). Godoc spells out the ctx contract.
- \`examples/composite/worker.go\`: \`Worker.ReloadWithConfig\` selects on \`<-ctx.Done()\` in both the fast-path send and the requeue-when-full branch. A cancelled caller no longer leaks a config into the queue.
- \`runnables/composite/reload_test.go\`: \`MockReloadableWithConfig\` signature updated; mock expectations use \`mock.Anything\` for the ctx arg. New subtest \`TestReloadConfig/threads_ctx_into_ReloadWithConfig\` verifies the runner passes its ctx through (asserts same instance via \`require.Same\`).
- \`examples/composite/worker_test.go\`: existing call sites pass \`t.Context()\`. New \`TestWorker_ReloadWithConfig_RespectsCtx\` verifies that a cancelled ctx aborts the queue insert.

**Migration for external implementers:** add a \`ctx context.Context\` parameter as the first argument to your \`ReloadWithConfig\` method. Use it to abort early-cancellation paths; it can be otherwise ignored if your implementation has no blocking ops.

## Test plan

- [x] \`go build ./...\` — clean.
- [x] \`go test -race ./...\` — all green; 2 new tests added (worker ctx-respect + composite ctx-thread).
- [x] \`make lint\` — 0 issues.