### PR TITLE
Decouple Stateable from Readiness; rename IsRunning→IsReady (breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,17 +124,19 @@ type Reloadable interface {
     Reload(ctx context.Context)
 }
 
-// Stateable represents a service that can report its state.
-// Embeds Readiness so the supervisor can wait for startup completion.
+// Stateable represents a service that reports its current state.
+// Orthogonal to Readiness: implement Stateable for state-channel
+// observability, Readiness for the startup gate, or both.
 type Stateable interface {
-    Readiness
     GetState() string
     GetStateChan(context.Context) <-chan string
 }
 
 // Readiness reports whether the service has finished its startup phase.
+// The supervisor's Run() polls IsReady on every Readiness runnable before
+// proceeding to spawn the next.
 type Readiness interface {
-    IsRunning() bool
+    IsReady() bool
 }
 
 // ReloadSender lets a service trigger reloads from inside.
@@ -158,7 +160,7 @@ Capabilities are detected by interface assertion — implement only what you nee
 - `WithSignals(...)` — override the OS signals to listen for. Only `SIGINT`,
   `SIGTERM`, and `SIGHUP` are special-cased; other signals are logged and
   ignored.
-- `WithStartupTimeout(d)` — bound how long a runnable's `IsRunning()` may take
+- `WithStartupTimeout(d)` — bound how long a runnable's `IsReady()` may take
   to return true before the supervisor gives up on startup.
 - `WithShutdownTimeout(d)` — TOTAL wall-clock budget for graceful shutdown,
   shared between per-runnable `Stop()` calls and the final goroutine wait. A

--- a/examples/composite/reload_membership_test.go
+++ b/examples/composite/reload_membership_test.go
@@ -157,7 +157,7 @@ func TestMembershipChangesBasic(t *testing.T) {
 
 	// Wait for initial configuration to be applied
 	assert.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, 1*time.Second, 10*time.Millisecond)
 
 	// --- Test Step 1: Remove worker1, add worker3 ---

--- a/examples/composite/worker.go
+++ b/examples/composite/worker.go
@@ -206,8 +206,18 @@ func (w *Worker) ReloadWithConfig(ctx context.Context, config any) {
 		return
 	}
 
-	// Fast path: try to queue without blocking. Honor ctx so a cancelled
-	// caller doesn't get its config queued.
+	// Fast-fail on an already-cancelled ctx so we don't race the queue
+	// send. If we entered the select directly, both <-ctx.Done() and
+	// w.nextConfig <- cfg can be immediately ready and select picks
+	// pseudo-randomly — the queue could win and a cancelled config gets
+	// enqueued.
+	if err := ctx.Err(); err != nil {
+		logger.Debug("Reload aborted before queueing", "error", err)
+		return
+	}
+
+	// Fast path: try to queue without blocking. Honor ctx so a caller
+	// cancelled mid-flight doesn't get its config queued.
 	select {
 	case <-ctx.Done():
 		logger.Debug("Reload aborted before queueing", "error", ctx.Err())

--- a/runnables/composite/integration_race_test.go
+++ b/runnables/composite/integration_race_test.go
@@ -45,7 +45,7 @@ func testCompositeRaceCondition(t *testing.T) {
 			<-ctx.Done()
 		})
 		mock1.On("Stop").Return()
-		mock1.On("IsRunning").Return(true)
+		mock1.On("IsReady").Return(true)
 		mock1.On("GetState").Return("Running")
 
 		mock2.On("String").Return("service2")
@@ -55,7 +55,7 @@ func testCompositeRaceCondition(t *testing.T) {
 			<-ctx.Done()
 		})
 		mock2.On("Stop").Return()
-		mock2.On("IsRunning").Return(true)
+		mock2.On("IsReady").Return(true)
 		mock2.On("GetState").Return("Running")
 
 		mock3.On("String").Return("service3")
@@ -65,7 +65,7 @@ func testCompositeRaceCondition(t *testing.T) {
 			<-ctx.Done()
 		})
 		mock3.On("Stop").Return()
-		mock3.On("IsRunning").Return(true)
+		mock3.On("IsReady").Return(true)
 		mock3.On("GetState").Return("Running")
 
 		callback := func() (*Config[*mocks.MockRunnableWithStateable], error) {
@@ -89,14 +89,14 @@ func testCompositeRaceCondition(t *testing.T) {
 
 		synctest.Wait()
 
-		assert.True(t, runner.IsRunning(), "Composite should report as running")
+		assert.True(t, runner.IsReady(), "Composite should report as running")
 		assert.Len(t, runCalled, 3, "All 3 Run() methods should have been called")
 
-		assert.True(t, mock1.IsRunning(),
+		assert.True(t, mock1.IsReady(),
 			"RACE CONDITION: Composite reports running but child 1 not running")
-		assert.True(t, mock2.IsRunning(),
+		assert.True(t, mock2.IsReady(),
 			"RACE CONDITION: Composite reports running but child 2 not running")
-		assert.True(t, mock3.IsRunning(),
+		assert.True(t, mock3.IsReady(),
 			"RACE CONDITION: Composite reports running but child 3 not running")
 
 		childStates := runner.GetChildStates()
@@ -161,7 +161,7 @@ func TestIntegration_CompositeFullLifecycle(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "New", runner.GetState())
-		assert.False(t, runner.IsRunning())
+		assert.False(t, runner.IsReady())
 
 		ctx, cancel := context.WithCancel(t.Context())
 
@@ -172,7 +172,7 @@ func TestIntegration_CompositeFullLifecycle(t *testing.T) {
 
 		synctest.Wait()
 
-		assert.True(t, runner.IsRunning(), "Should be Running")
+		assert.True(t, runner.IsReady(), "Should be Running")
 		assert.Equal(t, "Running", runner.GetState())
 
 		mock1.AssertCalled(t, "Run", mock.Anything)
@@ -194,7 +194,7 @@ func TestIntegration_CompositeFullLifecycle(t *testing.T) {
 		}
 
 		assert.Equal(t, "Stopped", runner.GetState())
-		assert.False(t, runner.IsRunning())
+		assert.False(t, runner.IsReady())
 
 		mock1.AssertCalled(t, "Stop")
 		mock2.AssertCalled(t, "Stop")

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -120,14 +120,14 @@ func TestCompositeRunner_Reload(t *testing.T) {
 		}()
 
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, 2*time.Second, 10*time.Millisecond)
 		assert.Equal(t, 1, callbackCalls)
 
 		runner.Reload(t.Context())
 		assert.Equal(t, len(entries), callbackCalls)
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, 1*time.Second, 100*time.Millisecond)
 
 		// Cancel the context and wait for shutdown before verifying expectations
@@ -1584,7 +1584,7 @@ func TestCompositeRunner_ReloadAfterStop(t *testing.T) {
 	go func() { runErr <- runner.Run(ctx) }()
 
 	require.Eventually(
-		t, runner.IsRunning, 2*time.Second, 10*time.Millisecond,
+		t, runner.IsReady, 2*time.Second, 10*time.Millisecond,
 	)
 
 	runner.Stop()
@@ -1664,7 +1664,7 @@ func TestCompositeRunner_ReloadWaitsThroughCallerCtxCancel(t *testing.T) {
 		go func() { runErr <- runner.Run(runCtx) }()
 
 		synctest.Wait()
-		require.True(t, runner.IsRunning())
+		require.True(t, runner.IsReady())
 
 		useSwapped.Store(true)
 		reloadCtx, reloadCancel := context.WithCancel(context.Background())
@@ -1745,7 +1745,7 @@ func TestCompositeRunner_PreCancelledReloadCtx(t *testing.T) {
 	defer runCancel()
 	runErr := make(chan error, 1)
 	go func() { runErr <- runner.Run(runCtx) }()
-	require.Eventually(t, runner.IsRunning, 2*time.Second, 10*time.Millisecond)
+	require.Eventually(t, runner.IsReady, 2*time.Second, 10*time.Millisecond)
 
 	originalCfg := runner.getConfig()
 	useSwapped.Store(true)
@@ -1801,7 +1801,7 @@ func TestCompositeRunner_CancelledReloadDoesNotErrorState(t *testing.T) {
 	defer runCancel()
 	runErr := make(chan error, 1)
 	go func() { runErr <- runner.Run(runCtx) }()
-	require.Eventually(t, runner.IsRunning, 2*time.Second, 10*time.Millisecond)
+	require.Eventually(t, runner.IsReady, 2*time.Second, 10*time.Millisecond)
 
 	useSwapped.Store(true)
 	cancelledCtx, cancel := context.WithCancel(context.Background())
@@ -1844,7 +1844,7 @@ func TestCompositeRunner_ReloadAfterStopDoesNotErrorState(t *testing.T) {
 	defer runCancel()
 	runErr := make(chan error, 1)
 	go func() { runErr <- runner.Run(runCtx) }()
-	require.Eventually(t, runner.IsRunning, 2*time.Second, 10*time.Millisecond)
+	require.Eventually(t, runner.IsReady, 2*time.Second, 10*time.Millisecond)
 
 	runner.Stop()
 	require.Eventually(t,
@@ -1904,7 +1904,7 @@ func TestCompositeRunner_DrainReloadCh_OnShutdown(t *testing.T) {
 	defer runCancel()
 	runErr := make(chan error, 1)
 	go func() { runErr <- runner.Run(runCtx) }()
-	require.Eventually(t, runner.IsRunning, 2*time.Second, 10*time.Millisecond)
+	require.Eventually(t, runner.IsReady, 2*time.Second, 10*time.Millisecond)
 
 	// Trigger Stop in a goroutine — it'll block in stopAllRunnables on slowStop.
 	stopReturned := make(chan struct{})
@@ -2012,7 +2012,7 @@ func TestCompositeRunner_ConcurrentReload_DropsOnBusy(t *testing.T) {
 
 	runErr := make(chan error, 1)
 	go func() { runErr <- runner.Run(ctx) }()
-	require.Eventually(t, runner.IsRunning, 2*time.Second, 5*time.Millisecond)
+	require.Eventually(t, runner.IsReady, 2*time.Second, 5*time.Millisecond)
 
 	// First reload: blocks inside child.Reload, parent FSM held in Reloading.
 	var first sync.WaitGroup
@@ -2051,7 +2051,7 @@ func TestCompositeRunner_ConcurrentReload_DropsOnBusy(t *testing.T) {
 	// Release the in-flight reload so the runner returns to Running.
 	releaseOnce()
 	first.Wait()
-	require.Eventually(t, runner.IsRunning, 2*time.Second, 5*time.Millisecond,
+	require.Eventually(t, runner.IsReady, 2*time.Second, 5*time.Millisecond,
 		"runner should return to Running after the in-flight reload completes")
 
 	// .Once() on Reload asserts exactly one call reached the child.
@@ -2109,7 +2109,7 @@ func TestCompositeRunner_ConcurrentReload(t *testing.T) {
 		}()
 
 		synctest.Wait()
-		require.True(t, runner.IsRunning())
+		require.True(t, runner.IsReady())
 
 		// Fan out 10 concurrent Reload callers. The FSM admission gate
 		// (TIC(Running, Reloading)) admits one at a time; the rest fail the

--- a/runnables/composite/runner_test.go
+++ b/runnables/composite/runner_test.go
@@ -737,7 +737,7 @@ func TestCompositeRunner_StopDuringReload(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, 1*time.Second, 5*time.Millisecond)
 
 	// Start reload in background (the mock's Reload .After() keeps the FSM in Reloading)

--- a/runnables/composite/state.go
+++ b/runnables/composite/state.go
@@ -23,8 +23,9 @@ func (r *Runner[T]) GetStateChanWithTimeout(ctx context.Context) <-chan string {
 	return r.fsm.GetStateChan(ctx)
 }
 
-// IsRunning returns true if the runner is in the Running state.
-func (r *Runner[T]) IsRunning() bool {
+// IsReady reports whether the composite runner has finished its startup
+// phase. Returns true once the FSM has reached the Running state.
+func (r *Runner[T]) IsReady() bool {
 	return r.fsm.GetState() == finitestate.StatusRunning
 }
 

--- a/runnables/httpcluster/integration_race_test.go
+++ b/runnables/httpcluster/integration_race_test.go
@@ -46,7 +46,7 @@ func testHttpClusterRaceCondition(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return cluster.IsRunning()
+		return cluster.IsReady()
 	}, 5*time.Second, 50*time.Millisecond, "Cluster should be running")
 	route, err := httpserver.NewRouteFromHandlerFunc(
 		"test",
@@ -152,7 +152,7 @@ func TestIntegration_HttpClusterFullLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "New", cluster.GetState())
-	assert.False(t, cluster.IsRunning())
+	assert.False(t, cluster.IsReady())
 	assert.Equal(t, 0, cluster.GetServerCount())
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -167,7 +167,7 @@ func TestIntegration_HttpClusterFullLifecycle(t *testing.T) {
 	}, 2*time.Second, 50*time.Millisecond, "Should transition to Booting")
 
 	assert.Eventually(t, func() bool {
-		return cluster.IsRunning() && cluster.GetState() == "Running"
+		return cluster.IsReady() && cluster.GetState() == "Running"
 	}, 5*time.Second, 50*time.Millisecond, "Should transition to Running")
 	route1, err := httpserver.NewRouteFromHandlerFunc("svc1", "/svc1",
 		func(w http.ResponseWriter, r *http.Request) {
@@ -260,10 +260,10 @@ func TestIntegration_HttpClusterFullLifecycle(t *testing.T) {
 		return cluster.GetState() == "Stopped"
 	}, 1*time.Second, 10*time.Millisecond, "Should be Stopped")
 
-	assert.False(t, cluster.IsRunning())
+	assert.False(t, cluster.IsReady())
 }
 
-// TestHTTPClusterReadinessRaceCondition verifies that cluster.IsRunning() returns true
+// TestHTTPClusterReadinessRaceCondition verifies that cluster.IsReady() returns true
 // only when servers are actually ready to accept TCP connections.
 func TestHTTPClusterReadinessRaceCondition(t *testing.T) {
 	t.Parallel()
@@ -284,7 +284,7 @@ func TestHTTPClusterReadinessRaceCondition(t *testing.T) {
 	}()
 
 	assert.Eventually(t, func() bool {
-		return cluster.IsRunning()
+		return cluster.IsReady()
 	}, 5*time.Second, 10*time.Millisecond, "Cluster should be running")
 
 	route, err := httpserver.NewRouteFromHandlerFunc(
@@ -311,7 +311,7 @@ func TestHTTPClusterReadinessRaceCondition(t *testing.T) {
 	}
 
 	assert.Eventually(t, func() bool {
-		return cluster.IsRunning() && cluster.GetServerCount() == 1
+		return cluster.IsReady() && cluster.GetServerCount() == 1
 	}, 10*time.Second, 50*time.Millisecond, "Server should be reported as running")
 
 	conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)

--- a/runnables/httpcluster/integration_test.go
+++ b/runnables/httpcluster/integration_test.go
@@ -33,7 +33,7 @@ func TestIntegration_BasicServerLifecycle(t *testing.T) {
 
 	// Wait for running
 	require.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Add a server
@@ -116,7 +116,7 @@ func TestIntegration_ConfigurationChanges(t *testing.T) {
 
 	// Wait for running
 	require.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Create initial config
@@ -261,7 +261,7 @@ func TestIntegration_StateReporting(t *testing.T) {
 
 	// Wait for running state
 	require.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Send config to trigger reload
@@ -293,7 +293,7 @@ func TestIntegration_StateReporting(t *testing.T) {
 
 	// Wait for reload to complete
 	require.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, time.Second, 10*time.Millisecond, "Runner should be back to running after reload")
 
 	// Stop runner
@@ -353,7 +353,7 @@ func TestIntegration_ErrorHandling(t *testing.T) {
 
 	// Wait for running
 	require.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Send invalid config (this should not crash the runner)
@@ -370,7 +370,7 @@ func TestIntegration_ErrorHandling(t *testing.T) {
 
 	// Wait for invalid config to be processed (should not create any servers)
 	assert.Eventually(t, func() bool {
-		return runner.GetServerCount() == 0 && runner.IsRunning()
+		return runner.GetServerCount() == 0 && runner.IsReady()
 	}, time.Second, 10*time.Millisecond, "Invalid config should not create servers but runner should continue")
 
 	// Send multiple rapid config updates
@@ -405,7 +405,7 @@ func TestIntegration_ErrorHandling(t *testing.T) {
 	}
 
 	assert.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Stop runner
@@ -438,7 +438,7 @@ func TestIntegration_IdenticalConfigPreservesServerInstance(t *testing.T) {
 
 	// Wait for running
 	require.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, time.Second, 10*time.Millisecond)
 
 	// Create initial configuration
@@ -487,7 +487,7 @@ func TestIntegration_IdenticalConfigPreservesServerInstance(t *testing.T) {
 
 	// Wait for server to be fully ready
 	require.Eventually(t, func() bool {
-		return originalRunner.IsRunning()
+		return originalRunner.IsReady()
 	}, time.Second, 10*time.Millisecond, "Server should be running")
 
 	// Apply the exact same configuration again
@@ -500,7 +500,7 @@ func TestIntegration_IdenticalConfigPreservesServerInstance(t *testing.T) {
 
 	// Wait for configuration processing to complete
 	require.Eventually(t, func() bool {
-		return runner.IsRunning() // Cluster should be back to running state
+		return runner.IsReady() // Cluster should be back to running state
 	}, time.Second, 10*time.Millisecond, "Cluster should return to running state")
 
 	// Verify server count is still 1
@@ -528,7 +528,7 @@ func TestIntegration_IdenticalConfigPreservesServerInstance(t *testing.T) {
 
 	// Wait for configuration processing to complete
 	require.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, time.Second, 10*time.Millisecond, "Cluster should remain running")
 
 	// Verify everything is still the same
@@ -595,7 +595,7 @@ func TestIntegration_IdenticalConfigDoesNotTriggerActions(t *testing.T) {
 	entry := entries1.get("test-server")
 	require.NotNil(t, entry)
 	mockRunner := mocks.NewMockRunnableWithStateable()
-	mockRunner.On("IsRunning").Return(true)
+	mockRunner.On("IsReady").Return(true)
 	mockRunner.On("GetState").Return("Running")
 	entry.runner = mockRunner
 	entry.action = actionNone // Clear action after "starting"

--- a/runnables/httpcluster/interfaces.go
+++ b/runnables/httpcluster/interfaces.go
@@ -50,7 +50,11 @@ type entriesManager interface {
 }
 
 // httpServerRunner defines the interface for running an HTTP server.
+// Stateable is needed for the cluster's state observation; Readiness is
+// needed for waitForReady's startup polling. Now that Stateable and
+// Readiness are orthogonal, both must be listed explicitly.
 type httpServerRunner interface {
 	supervisor.Runnable
 	supervisor.Stateable
+	supervisor.Readiness
 }

--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -119,10 +119,11 @@ func (r *Runner) GetServerCount() int {
 	return r.currentEntries.count()
 }
 
-// waitForIsRunning waits for an httpserver to reach Running state.
-// It returns true if the server was ready within the timeout deadline.
-// If the server is in error state, it returns false.
-func (r *Runner) waitForIsRunning(
+// waitForReady waits for an httpserver to finish its startup phase
+// (IsReady returns true). Returns true if the server was ready within the
+// timeout deadline. If the server reports Error or Stopped state, returns
+// false immediately.
+func (r *Runner) waitForReady(
 	ctx context.Context,
 	timeout time.Duration,
 	server httpServerRunner,
@@ -140,7 +141,7 @@ func (r *Runner) waitForIsRunning(
 		case <-ctx.Done():
 			return false
 		case <-timer.C:
-			if server.IsRunning() {
+			if server.IsReady() {
 				return true
 			}
 
@@ -428,7 +429,7 @@ func (r *Runner) startServers(
 		}
 
 		// Wait for server to be ready
-		if !r.waitForIsRunning(ctx, r.deadlineServerStart, runner) {
+		if !r.waitForReady(ctx, r.deadlineServerStart, runner) {
 			// Distinguish parent-ctx cancellation (the cluster is being told
 			// to stop — not a server failure) from a real readiness failure
 			// (timeout elapsed or server reached Error/Stopped). Only the

--- a/runnables/httpcluster/runner_context_test.go
+++ b/runnables/httpcluster/runner_context_test.go
@@ -41,7 +41,7 @@ func TestRunnerContextPersistence(t *testing.T) {
 
 			mockServer.On("Stop").Return().Maybe()
 			mockServer.On("GetState").Return(finitestate.StatusRunning)
-			mockServer.On("IsRunning").Return(true)
+			mockServer.On("IsReady").Return(true)
 
 			stateChan := make(chan string, 1)
 			stateChan <- finitestate.StatusRunning
@@ -65,7 +65,7 @@ func TestRunnerContextPersistence(t *testing.T) {
 
 		// Wait for running
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		// Send config to create a server
@@ -129,7 +129,7 @@ func TestRunnerContextPersistence(t *testing.T) {
 			}).Return(nil)
 			mockServer.On("Stop").Return().Maybe()
 			mockServer.On("GetState").Return(finitestate.StatusRunning)
-			mockServer.On("IsRunning").Return(true)
+			mockServer.On("IsReady").Return(true)
 
 			stateChan := make(chan string, 1)
 			stateChan <- finitestate.StatusRunning
@@ -153,7 +153,7 @@ func TestRunnerContextPersistence(t *testing.T) {
 
 		// Wait for running
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		// Create a server

--- a/runnables/httpcluster/runner_failure_test.go
+++ b/runnables/httpcluster/runner_failure_test.go
@@ -34,7 +34,7 @@ func createCrashingMockServer(
 	}).Return(crashErr)
 	mockServer.On("Stop").Return().Maybe()
 	mockServer.On("GetState").Return(finitestate.StatusRunning).Maybe()
-	mockServer.On("IsRunning").Return(true).Maybe()
+	mockServer.On("IsReady").Return(true).Maybe()
 	stateChan := make(chan string, 1)
 	stateChan <- finitestate.StatusRunning
 	mockServer.On("GetStateChan", mock.Anything).Return(stateChan).Maybe()
@@ -42,7 +42,7 @@ func createCrashingMockServer(
 }
 
 // createErroredMockServer returns a mock whose GetState reports Error so
-// waitForIsRunning short-circuits via its `s == "Error"` branch. Used to
+// waitForReady short-circuits via its `s == "Error"` branch. Used to
 // simulate a child that fails to reach Running during a config update.
 func createErroredMockServer(ctx context.Context) *mocks.MockRunnableWithStateable {
 	mockServer := mocks.NewMockRunnableWithStateable()
@@ -51,7 +51,7 @@ func createErroredMockServer(ctx context.Context) *mocks.MockRunnableWithStateab
 	}).Return(nil)
 	mockServer.On("Stop").Return().Maybe()
 	mockServer.On("GetState").Return(finitestate.StatusError).Maybe()
-	mockServer.On("IsRunning").Return(false).Maybe()
+	mockServer.On("IsReady").Return(false).Maybe()
 	stateChan := make(chan string, 1)
 	stateChan <- finitestate.StatusError
 	mockServer.On("GetStateChan", mock.Anything).Return(stateChan).Maybe()
@@ -94,7 +94,7 @@ func TestRunner_ChildRuntimeError_TransitionsToError(t *testing.T) {
 	go func() {
 		runErr <- cluster.Run(ctx)
 	}()
-	require.Eventually(t, cluster.IsRunning, time.Second, 5*time.Millisecond)
+	require.Eventually(t, cluster.IsReady, time.Second, 5*time.Millisecond)
 
 	cluster.configSiphon <- map[string]*httpserver.Config{
 		failingServerID: createTestHTTPConfig(t, ":18001"),
@@ -151,7 +151,7 @@ func TestRunner_ConfigUpdateFailure_TransitionsToError(t *testing.T) {
 	go func() {
 		runErr <- cluster.Run(ctx)
 	}()
-	require.Eventually(t, cluster.IsRunning, time.Second, 5*time.Millisecond)
+	require.Eventually(t, cluster.IsReady, time.Second, 5*time.Millisecond)
 
 	cluster.configSiphon <- map[string]*httpserver.Config{
 		"broken": createTestHTTPConfig(t, ":18101"),
@@ -211,7 +211,7 @@ func TestRunner_PartialFailure_GoodSiblingsSurvive(t *testing.T) {
 	go func() {
 		runErr <- cluster.Run(ctx)
 	}()
-	require.Eventually(t, cluster.IsRunning, time.Second, 5*time.Millisecond)
+	require.Eventually(t, cluster.IsReady, time.Second, 5*time.Millisecond)
 
 	cluster.configSiphon <- map[string]*httpserver.Config{
 		brokenID:   createTestHTTPConfig(t, ":18201"),

--- a/runnables/httpcluster/runner_restart_test.go
+++ b/runnables/httpcluster/runner_restart_test.go
@@ -87,7 +87,7 @@ func TestPortBindingRaceCondition(t *testing.T) {
 			}()
 
 			require.Eventually(t, func() bool {
-				return runner.IsRunning()
+				return runner.IsReady()
 			}, 2*time.Second, 10*time.Millisecond)
 
 			// Use a fixed port to test rapid binding/unbinding
@@ -105,7 +105,7 @@ func TestPortBindingRaceCondition(t *testing.T) {
 				runner.mu.RLock()
 				defer runner.mu.RUnlock()
 				entry := runner.currentEntries.get(serverID)
-				return entry != nil && entry.runner != nil && entry.runner.IsRunning()
+				return entry != nil && entry.runner != nil && entry.runner.IsReady()
 			}, 5*time.Second, 10*time.Millisecond)
 
 			// Perform rapid stop/start cycles
@@ -132,7 +132,7 @@ func TestPortBindingRaceCondition(t *testing.T) {
 					runner.mu.RLock()
 					defer runner.mu.RUnlock()
 					entry := runner.currentEntries.get(serverID)
-					return entry != nil && entry.runner != nil && entry.runner.IsRunning()
+					return entry != nil && entry.runner != nil && entry.runner.IsReady()
 				}, 5*time.Second, 10*time.Millisecond) {
 					successCount++
 				}
@@ -176,7 +176,7 @@ func TestConcurrentServerManagement(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, 2*time.Second, 10*time.Millisecond)
 
 	// Create multiple servers
@@ -217,7 +217,7 @@ func TestConcurrentServerManagement(t *testing.T) {
 		for i := range numServers {
 			serverID := fmt.Sprintf("server%d", i)
 			entry := runner.currentEntries.get(serverID)
-			if entry != nil && entry.runner != nil && entry.runner.IsRunning() {
+			if entry != nil && entry.runner != nil && entry.runner.IsReady() {
 				runningCount++
 			}
 		}
@@ -261,7 +261,7 @@ func TestConcurrentRestartStress(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, 2*time.Second, 10*time.Millisecond)
 
 	// Create two servers with different ports
@@ -338,8 +338,8 @@ func TestConcurrentRestartStress(t *testing.T) {
 		entry1 := runner.currentEntries.get("server1")
 		entry2 := runner.currentEntries.get("server2")
 
-		return entry1 != nil && entry1.runner != nil && entry1.runner.IsRunning() &&
-			entry2 != nil && entry2.runner != nil && entry2.runner.IsRunning()
+		return entry1 != nil && entry1.runner != nil && entry1.runner.IsReady() &&
+			entry2 != nil && entry2.runner != nil && entry2.runner.IsReady()
 	}, 5*time.Second, 10*time.Millisecond, "Both servers should be running after concurrent restarts")
 }
 
@@ -367,7 +367,7 @@ func BenchmarkServerRestarts(b *testing.B) {
 
 			// Wait for runner to start
 			require.Eventually(b, func() bool {
-				return runner.IsRunning()
+				return runner.IsReady()
 			}, 2*time.Second, 100*time.Millisecond)
 
 			// Create server
@@ -384,7 +384,7 @@ func BenchmarkServerRestarts(b *testing.B) {
 				runner.mu.RLock()
 				defer runner.mu.RUnlock()
 				entry := runner.currentEntries.get(serverID)
-				return entry != nil && entry.runner != nil && entry.runner.IsRunning()
+				return entry != nil && entry.runner != nil && entry.runner.IsReady()
 			}, 5*time.Second, 100*time.Millisecond)
 
 			b.ResetTimer()
@@ -402,7 +402,7 @@ func BenchmarkServerRestarts(b *testing.B) {
 				for attempts := 0; attempts < 100; attempts++ {
 					runner.mu.RLock()
 					entry := runner.currentEntries.get(serverID)
-					if entry != nil && entry.runner != nil && entry.runner.IsRunning() {
+					if entry != nil && entry.runner != nil && entry.runner.IsReady() {
 						runner.mu.RUnlock()
 						restartSuccess = true
 						break
@@ -448,7 +448,7 @@ func BenchmarkServerRestartsNoDelay(b *testing.B) {
 
 	// Wait for runner to start
 	require.Eventually(b, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, 2*time.Second, 100*time.Millisecond)
 
 	// Create server
@@ -465,7 +465,7 @@ func BenchmarkServerRestartsNoDelay(b *testing.B) {
 		runner.mu.RLock()
 		defer runner.mu.RUnlock()
 		entry := runner.currentEntries.get(serverID)
-		return entry != nil && entry.runner != nil && entry.runner.IsRunning()
+		return entry != nil && entry.runner != nil && entry.runner.IsReady()
 	}, 5*time.Second, 100*time.Millisecond)
 
 	b.ResetTimer()
@@ -485,7 +485,7 @@ func BenchmarkServerRestartsNoDelay(b *testing.B) {
 
 		runner.mu.RLock()
 		entry := runner.currentEntries.get(serverID)
-		if entry != nil && entry.runner != nil && entry.runner.IsRunning() {
+		if entry != nil && entry.runner != nil && entry.runner.IsReady() {
 			successCount++
 		} else {
 			failureCount++
@@ -519,7 +519,7 @@ func BenchmarkConcurrentStateChecks(b *testing.B) {
 
 	// Wait for runner to start
 	require.Eventually(b, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, 2*time.Second, 10*time.Millisecond)
 
 	// Create multiple servers

--- a/runnables/httpcluster/runner_test.go
+++ b/runnables/httpcluster/runner_test.go
@@ -164,7 +164,7 @@ func TestRunnerBasicInterface(t *testing.T) {
 	t.Run("State interface", func(t *testing.T) {
 		// Initial state
 		assert.Equal(t, finitestate.StatusNew, runner.GetState())
-		assert.False(t, runner.IsRunning())
+		assert.False(t, runner.IsReady())
 
 		// GetStateChan
 		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
@@ -201,7 +201,7 @@ func TestRunnerRun(t *testing.T) {
 
 		// Wait for runner to reach running state
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		// Cancel context to stop
@@ -233,7 +233,7 @@ func TestRunnerRun(t *testing.T) {
 
 		// Wait for running
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		// Stop via method
@@ -292,7 +292,7 @@ func TestRunnerRun(t *testing.T) {
 
 		// Wait for running
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		// Close siphon
@@ -328,7 +328,7 @@ func TestRunnerConfigUpdate(t *testing.T) {
 
 		// Wait for running
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		// Send config update with dynamic port
@@ -352,7 +352,7 @@ func TestRunnerConfigUpdate(t *testing.T) {
 		}, time.Second, 10*time.Millisecond, "Server should be created")
 
 		// Verify runner continues running
-		assert.True(t, runner.IsRunning())
+		assert.True(t, runner.IsReady())
 
 		cancel()
 		stopCtx, stopCancel := context.WithTimeout(t.Context(), time.Second)
@@ -396,7 +396,7 @@ func TestRunnerConfigUpdate_TOCTOU(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, time.Second, 5*time.Millisecond)
 
 	addr := networking.GetRandomListeningPort(t)
@@ -405,7 +405,7 @@ func TestRunnerConfigUpdate_TOCTOU(t *testing.T) {
 	}
 
 	// Race: call processConfigUpdate directly (bypassing the single-goroutine
-	// event loop) while simultaneously stopping, to test whether the IsRunning()
+	// event loop) while simultaneously stopping, to test whether the IsReady()
 	// check outside the mutex causes a problem.
 	var wg sync.WaitGroup
 	wg.Go(func() {
@@ -461,7 +461,7 @@ func TestRunnerStateTransitions(t *testing.T) {
 
 		// Wait for running
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		// Stop
@@ -500,7 +500,7 @@ func TestRunnerStateTransitions(t *testing.T) {
 		runner.setStateError()
 
 		assert.Equal(t, finitestate.StatusError, runner.GetState())
-		assert.False(t, runner.IsRunning())
+		assert.False(t, runner.IsReady())
 	})
 }
 
@@ -521,7 +521,7 @@ func TestRunnerConcurrency(t *testing.T) {
 
 		// Wait for running
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		// Send multiple configs concurrently
@@ -554,7 +554,7 @@ func TestRunnerConcurrency(t *testing.T) {
 
 		// Verify runner continues running after concurrent updates
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond, "Runner did not continue running after concurrent updates")
 
 		cancel()
@@ -575,7 +575,7 @@ func TestRunnerConcurrency(t *testing.T) {
 
 		// Wait for running
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		// Read state concurrently
@@ -587,7 +587,7 @@ func TestRunnerConcurrency(t *testing.T) {
 				state := runner.GetState()
 				assert.NotEmpty(t, state)
 
-				isRunning := runner.IsRunning()
+				isRunning := runner.IsReady()
 				assert.True(t, isRunning)
 
 				str := runner.String()
@@ -613,7 +613,7 @@ func TestRunnerConcurrency(t *testing.T) {
 
 		// Wait for running
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		// Call Stop concurrently
@@ -710,7 +710,7 @@ func TestRunnerContextManagement(t *testing.T) {
 
 		// Wait for running
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		cancel()
@@ -730,7 +730,7 @@ func createMockServer(ctx context.Context) *mocks.MockRunnableWithStateable {
 
 	mockServer.On("Stop").Return()
 	mockServer.On("GetState").Return(finitestate.StatusRunning).Maybe()
-	mockServer.On("IsRunning").Return(true).Maybe()
+	mockServer.On("IsReady").Return(true).Maybe()
 
 	stateChan := make(chan string, 1)
 	stateChan <- finitestate.StatusRunning
@@ -749,7 +749,7 @@ func createNonReadyMockServer(ctx context.Context) *mocks.MockRunnableWithStatea
 
 	mockServer.On("Stop").Return()
 	mockServer.On("GetState").Return(finitestate.StatusNew).Maybe()
-	mockServer.On("IsRunning").Return(false).Maybe()
+	mockServer.On("IsReady").Return(false).Maybe()
 
 	stateChan := make(chan string, 1)
 	stateChan <- finitestate.StatusNew
@@ -786,7 +786,7 @@ func TestRunnerWithMockFactory(t *testing.T) {
 		}()
 
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		// Create two servers
@@ -835,7 +835,7 @@ func TestRunnerWithMockFactory(t *testing.T) {
 		}()
 
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		configs := map[string]*httpserver.Config{
@@ -874,7 +874,7 @@ func TestRunnerWithMockFactory(t *testing.T) {
 		}()
 
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		configs := map[string]*httpserver.Config{
@@ -918,7 +918,7 @@ func TestRunnerWithMockFactory(t *testing.T) {
 		}()
 
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		configs := map[string]*httpserver.Config{
@@ -965,7 +965,7 @@ func TestRunnerWithMockFactory(t *testing.T) {
 		}()
 
 		require.Eventually(t, func() bool {
-			return runner.IsRunning()
+			return runner.IsReady()
 		}, time.Second, 10*time.Millisecond)
 
 		testConfig := createTestHTTPConfig(t, ":8001")

--- a/runnables/httpcluster/state.go
+++ b/runnables/httpcluster/state.go
@@ -22,8 +22,9 @@ func (r *Runner) GetStateChanWithTimeout(ctx context.Context) <-chan string {
 	return r.fsm.GetStateChan(ctx)
 }
 
-// IsRunning returns true if the cluster is in the Running state.
-func (r *Runner) IsRunning() bool {
+// IsReady reports whether the cluster has finished its startup phase.
+// Returns true once the FSM has reached the Running state.
+func (r *Runner) IsReady() bool {
 	return r.fsm.GetState() == finitestate.StatusRunning
 }
 

--- a/runnables/httpcluster/state_test.go
+++ b/runnables/httpcluster/state_test.go
@@ -62,14 +62,14 @@ func TestGetStateChanWithTimeout(t *testing.T) {
 	}
 }
 
-func TestIsRunning(t *testing.T) {
+func TestIsReady(t *testing.T) {
 	t.Parallel()
 
 	runner, err := NewRunner()
 	require.NoError(t, err)
 
 	// Initially not running
-	assert.False(t, runner.IsRunning())
+	assert.False(t, runner.IsReady())
 
 	// Transition to running state
 	err = runner.fsm.Transition(finitestate.StatusBooting)
@@ -78,7 +78,7 @@ func TestIsRunning(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now should be running
-	assert.True(t, runner.IsRunning())
+	assert.True(t, runner.IsReady())
 }
 
 // MockFSMForStateError is a mock FSM that can simulate error conditions

--- a/runnables/httpserver/integration_race_test.go
+++ b/runnables/httpserver/integration_race_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestIntegration_NoRaceCondition verifies that when IsRunning() returns true,
+// TestIntegration_NoRaceCondition verifies that when IsReady() returns true,
 // the server is actually accepting TCP connections.
 func TestIntegration_NoRaceCondition(t *testing.T) {
 	if testing.Short() {
@@ -60,11 +60,11 @@ func testSingleRunnerRaceCondition(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return runner.IsRunning()
+		return runner.IsReady()
 	}, 5*time.Second, 10*time.Millisecond, "Server should report as running")
 
 	conn, err := net.DialTimeout("tcp", port, 100*time.Millisecond)
-	require.NoError(t, err, "TCP connection should succeed when IsRunning() returns true")
+	require.NoError(t, err, "TCP connection should succeed when IsReady() returns true")
 
 	if conn != nil {
 		require.NoError(t, conn.Close())
@@ -72,7 +72,7 @@ func testSingleRunnerRaceCondition(t *testing.T) {
 
 	client := &http.Client{Timeout: 1 * time.Second}
 	resp, err := client.Get("http://" + port + "/health")
-	require.NoError(t, err, "HTTP request should succeed when IsRunning()=true")
+	require.NoError(t, err, "HTTP request should succeed when IsReady()=true")
 
 	if resp != nil {
 		require.NoError(t, resp.Body.Close())
@@ -118,7 +118,7 @@ func TestIntegration_FullLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "New", runner.GetState())
-	assert.False(t, runner.IsRunning())
+	assert.False(t, runner.IsReady())
 
 	ctx, cancel := context.WithCancel(t.Context())
 	runErr := make(chan error, 1)
@@ -132,7 +132,7 @@ func TestIntegration_FullLifecycle(t *testing.T) {
 	}, 2*time.Second, 50*time.Millisecond, "Should transition to Booting")
 
 	assert.Eventually(t, func() bool {
-		return runner.IsRunning() && runner.GetState() == "Running"
+		return runner.IsReady() && runner.GetState() == "Running"
 	}, 5*time.Second, 50*time.Millisecond, "Should transition to Running")
 
 	conn, err := net.DialTimeout("tcp", port, 100*time.Millisecond)
@@ -164,5 +164,5 @@ func TestIntegration_FullLifecycle(t *testing.T) {
 		return runner.GetState() == "Stopped"
 	}, 1*time.Second, 10*time.Millisecond, "Should be Stopped")
 
-	assert.False(t, runner.IsRunning())
+	assert.False(t, runner.IsReady())
 }

--- a/runnables/httpserver/state.go
+++ b/runnables/httpserver/state.go
@@ -43,7 +43,8 @@ func (r *Runner) GetStateChanWithTimeout(ctx context.Context) <-chan string {
 	return r.fsm.GetStateChan(ctx)
 }
 
-// IsRunning returns true if the HTTP server is currently running.
-func (r *Runner) IsRunning() bool {
+// IsReady reports whether the HTTP server has finished its startup phase.
+// Returns true once the FSM has reached the Running state.
+func (r *Runner) IsReady() bool {
 	return r.fsm.GetState() == finitestate.StatusRunning
 }

--- a/runnables/httpserver/state_test.go
+++ b/runnables/httpserver/state_test.go
@@ -74,8 +74,8 @@ func TestGetStateChan(t *testing.T) {
 	}, 1*time.Second, 10*time.Millisecond, "Channel should be closed after context cancellation")
 }
 
-// TestIsRunning verifies that IsRunning returns the correct value based on the state
-func TestIsRunning(t *testing.T) {
+// TestIsReady verifies that IsReady returns the correct value based on the state
+func TestIsReady(t *testing.T) {
 	t.Parallel()
 
 	server, listenPort := createTestServer(t,
@@ -85,32 +85,32 @@ func TestIsRunning(t *testing.T) {
 	// Test when state is not running
 	err := server.fsm.SetState(finitestate.StatusNew)
 	require.NoError(t, err)
-	assert.False(t, server.IsRunning(), "Should return false when state is New")
+	assert.False(t, server.IsReady(), "Should return false when state is New")
 
 	// Test when state is Booting
 	err = server.fsm.SetState(finitestate.StatusBooting)
 	require.NoError(t, err)
-	assert.False(t, server.IsRunning(), "Should return false when state is Booting")
+	assert.False(t, server.IsReady(), "Should return false when state is Booting")
 
 	// Test when state is Running
 	err = server.fsm.SetState(finitestate.StatusRunning)
 	require.NoError(t, err)
-	assert.True(t, server.IsRunning(), "Should return true when state is Running")
+	assert.True(t, server.IsReady(), "Should return true when state is Running")
 
 	// Test when state is Stopping
 	err = server.fsm.SetState(finitestate.StatusStopping)
 	require.NoError(t, err)
-	assert.False(t, server.IsRunning(), "Should return false when state is Stopping")
+	assert.False(t, server.IsReady(), "Should return false when state is Stopping")
 
 	// Test when state is Stopped
 	err = server.fsm.SetState(finitestate.StatusStopped)
 	require.NoError(t, err)
-	assert.False(t, server.IsRunning(), "Should return false when state is Stopped")
+	assert.False(t, server.IsReady(), "Should return false when state is Stopped")
 
 	// Test when state is Error
 	err = server.fsm.SetState(finitestate.StatusError)
 	require.NoError(t, err)
-	assert.False(t, server.IsRunning(), "Should return false when state is Error")
+	assert.False(t, server.IsReady(), "Should return false when state is Error")
 }
 
 // TestSetStateError verifies the error state setting functionality

--- a/runnables/mocks/mocks.go
+++ b/runnables/mocks/mocks.go
@@ -93,9 +93,13 @@ func (m *MockRunnableWithStateable) GetStateChan(ctx context.Context) <-chan str
 	return args.Get(0).(chan string)
 }
 
-// IsRunning mocks the IsRunning method of the Stateable interface.
-// It returns true if the service is currently running, as configured in test expectations.
-func (m *MockRunnableWithStateable) IsRunning() bool {
+// IsReady mocks the IsReady method of the Readiness interface. It returns
+// true once the service has finished its startup phase, as configured in
+// test expectations. Stateable and Readiness are now orthogonal interfaces;
+// MockRunnableWithStateable implements both for backwards compatibility with
+// existing tests. Tests that want only Readiness (no Stateable) should use
+// MockRunnableWithReadiness instead.
+func (m *MockRunnableWithStateable) IsReady() bool {
 	args := m.Called()
 	return args.Bool(0)
 }
@@ -103,6 +107,27 @@ func (m *MockRunnableWithStateable) IsRunning() bool {
 // NewMockRunnableWithStateable creates a new MockRunnableWithStateable.
 func NewMockRunnableWithStateable() *MockRunnableWithStateable {
 	return &MockRunnableWithStateable{
+		Runnable: NewMockRunnable(),
+	}
+}
+
+// MockRunnableWithReadiness extends Runnable to implement only the Readiness
+// interface (without Stateable's GetState/GetStateChan). Use this for tests
+// that exercise the supervisor's startup gate without setting up state-channel
+// monitoring expectations.
+type MockRunnableWithReadiness struct {
+	*Runnable
+}
+
+// IsReady mocks the IsReady method of the Readiness interface.
+func (m *MockRunnableWithReadiness) IsReady() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
+// NewMockRunnableWithReadiness creates a new MockRunnableWithReadiness.
+func NewMockRunnableWithReadiness() *MockRunnableWithReadiness {
+	return &MockRunnableWithReadiness{
 		Runnable: NewMockRunnable(),
 	}
 }

--- a/runnables/mocks/mocks_test.go
+++ b/runnables/mocks/mocks_test.go
@@ -212,11 +212,11 @@ func TestMockRunnableWithStateable(t *testing.T) {
 		mockRunnable.AssertExpectations(t)
 	})
 
-	t.Run("IsRunning method", func(t *testing.T) {
+	t.Run("IsReady method", func(t *testing.T) {
 		// Create a mock
 		mockRunnable := mocks.NewMockRunnableWithStateable()
-		mockRunnable.On("IsRunning", mock.Anything).Return(true)
-		r := mockRunnable.IsRunning()
+		mockRunnable.On("IsReady", mock.Anything).Return(true)
+		r := mockRunnable.IsReady()
 		assert.True(t, r)
 		mockRunnable.AssertExpectations(t)
 	})

--- a/runnables/mocks/mocks_test.go
+++ b/runnables/mocks/mocks_test.go
@@ -114,6 +114,21 @@ func testHelperInheritedMethods(t *testing.T, mockRunnable any, displayName stri
 		assert.Equal(t, displayName, name)
 		mockObj.AssertExpectations(t)
 
+	case *mocks.MockRunnableWithReadiness:
+		mockObj.On("Run", mock.Anything).Return(nil)
+		mockObj.On("Stop").Return()
+		mockObj.On("Reload", mock.Anything).Return()
+		mockObj.On("String").Return(displayName)
+
+		// Call and verify methods
+		err := mockObj.Run(context.Background())
+		require.NoError(t, err)
+		mockObj.Stop()
+		mockObj.Reload(t.Context())
+		name := mockObj.String()
+		assert.Equal(t, displayName, name)
+		mockObj.AssertExpectations(t)
+
 	default:
 		t.Fatalf("Unsupported mock type: %T", mockRunnable)
 	}
@@ -215,7 +230,8 @@ func TestMockRunnableWithStateable(t *testing.T) {
 	t.Run("IsReady method", func(t *testing.T) {
 		// Create a mock
 		mockRunnable := mocks.NewMockRunnableWithStateable()
-		mockRunnable.On("IsReady", mock.Anything).Return(true)
+		// IsReady takes no arguments; the expectation must match accordingly.
+		mockRunnable.On("IsReady").Return(true)
 		r := mockRunnable.IsReady()
 		assert.True(t, r)
 		mockRunnable.AssertExpectations(t)
@@ -223,6 +239,19 @@ func TestMockRunnableWithStateable(t *testing.T) {
 
 	t.Run("inherits from base Runnable", func(t *testing.T) {
 		testHelperInheritedMethods(t, mocks.NewMockRunnableWithStateable(), "StatefulService")
+	})
+}
+
+func TestMockRunnableWithReadiness(t *testing.T) {
+	t.Run("IsReady method", func(t *testing.T) {
+		mockRunnable := mocks.NewMockRunnableWithReadiness()
+		mockRunnable.On("IsReady").Return(true).Once()
+		require.True(t, mockRunnable.IsReady())
+		mockRunnable.AssertExpectations(t)
+	})
+
+	t.Run("inherits from base Runnable", func(t *testing.T) {
+		testHelperInheritedMethods(t, mocks.NewMockRunnableWithReadiness(), "ReadinessService")
 	})
 }
 

--- a/supervisor/interfaces.go
+++ b/supervisor/interfaces.go
@@ -50,10 +50,13 @@ type Reloadable interface {
 	Reload(ctx context.Context)
 }
 
-// Stateable represents a service that can report its state.
+// Stateable represents a service that reports its current state. It is
+// orthogonal to Readiness: a service can be Stateable without being Readiness
+// (no startup gate participation), and a service can be Readiness without
+// being Stateable (transient readiness signal only). The supervisor uses
+// Stateable for continuous state observation (logging, GetStateChan
+// monitoring) and Readiness for the one-shot startup gate.
 type Stateable interface {
-	Readiness
-
 	// GetState returns the current state of the service.
 	GetState() string
 
@@ -61,10 +64,15 @@ type Stateable interface {
 	GetStateChan(context.Context) <-chan string
 }
 
-// Readiness provides a way to check if a Runnable is currently running,
-// used to determine if a Runnable is done with it's startup phase.
+// Readiness reports whether the service has finished its startup phase. The
+// supervisor's Run() polls IsReady on every Readiness runnable before
+// proceeding to spawn the next one, so a runnable only needs to implement
+// Readiness if it has a meaningful startup phase the supervisor should wait
+// on. Returning true means the service is initialized enough for downstream
+// runnables to start; it does not imply the service is in any particular
+// FSM state.
 type Readiness interface {
-	IsRunning() bool
+	IsReady() bool
 }
 
 // ReloadSender represents a service that can trigger reloads.

--- a/supervisor/interfaces_test.go
+++ b/supervisor/interfaces_test.go
@@ -1,0 +1,99 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// onlyStateable implements Stateable but NOT Readiness, demonstrating that
+// after the T3.2 decoupling the two interfaces are genuinely orthogonal.
+type onlyStateable struct{}
+
+func (onlyStateable) GetState() string                             { return "" }
+func (onlyStateable) GetStateChan(_ context.Context) <-chan string { return nil }
+
+// onlyReadiness implements Readiness but NOT Stateable, the symmetric case.
+type onlyReadiness struct{}
+
+func (onlyReadiness) IsReady() bool { return true }
+
+// stateAndReadiness implements both — most production runnables look like this.
+type stateAndReadiness struct{}
+
+func (stateAndReadiness) GetState() string                             { return "" }
+func (stateAndReadiness) GetStateChan(_ context.Context) <-chan string { return nil }
+func (stateAndReadiness) IsReady() bool                                { return true }
+
+// TestStateableReadinessDecoupled pins down the T3.2 contract: Stateable no
+// longer embeds Readiness, so a type satisfies one interface only if it has
+// the corresponding methods. Pre-T3.2 a Stateable was always a Readiness via
+// the embedding; this test prevents accidentally re-introducing the embed.
+func TestStateableReadinessDecoupled(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Stateable does not imply Readiness", func(t *testing.T) {
+		var v any = onlyStateable{}
+		_, isStateable := v.(Stateable)
+		_, isReadiness := v.(Readiness)
+		require.True(t, isStateable, "must satisfy Stateable")
+		require.False(t, isReadiness, "must NOT satisfy Readiness — embedding is gone")
+	})
+
+	t.Run("Readiness does not imply Stateable", func(t *testing.T) {
+		var v any = onlyReadiness{}
+		_, isStateable := v.(Stateable)
+		_, isReadiness := v.(Readiness)
+		require.False(t, isStateable, "must NOT satisfy Stateable")
+		require.True(t, isReadiness, "must satisfy Readiness")
+	})
+
+	t.Run("a type with both methods satisfies both", func(t *testing.T) {
+		var v any = stateAndReadiness{}
+		_, isStateable := v.(Stateable)
+		_, isReadiness := v.(Readiness)
+		require.True(t, isStateable)
+		require.True(t, isReadiness)
+	})
+}
+
+// TestBlockUntilRunnableReady_AcceptsReadinessOnly verifies that the
+// supervisor's startup gate asks for Readiness, not Stateable. Pre-T3.2 the
+// gate took a Stateable and exploited the Readiness embedding; T3.2 narrowed
+// it to Readiness, so a runnable can participate in the startup gate without
+// also implementing GetState/GetStateChan.
+func TestBlockUntilRunnableReady_AcceptsReadinessOnly(t *testing.T) {
+	t.Parallel()
+
+	r := mocks.NewMockRunnableWithReadiness()
+	r.On("IsReady").Return(true).Once()
+
+	pidZero, err := New(WithRunnables(r))
+	require.NoError(t, err)
+
+	require.NoError(t, pidZero.blockUntilRunnableReady(r),
+		"blockUntilRunnableReady must accept a Readiness-only runnable")
+	r.AssertExpectations(t)
+}
+
+// TestBlockUntilRunnableReady_DoesNotRequireStateable is a compile-time
+// assertion via type-assertion: the mock satisfies Readiness but not Stateable.
+// If a future refactor re-tightens the gate to Stateable this test will fail
+// to compile / panic at the cast.
+func TestBlockUntilRunnableReady_DoesNotRequireStateable(t *testing.T) {
+	t.Parallel()
+
+	var r any = mocks.NewMockRunnableWithReadiness()
+	_, isStateable := r.(Stateable)
+	require.False(t, isStateable,
+		"MockRunnableWithReadiness must NOT satisfy Stateable; the startup gate must work without it")
+	_, isReadiness := r.(Readiness)
+	require.True(t, isReadiness)
+
+	// Reference mock.Anything to keep the testify import in use across builds
+	// where the previous tests get optimised away.
+	_ = mock.Anything
+}

--- a/supervisor/state_monitoring_test.go
+++ b/supervisor/state_monitoring_test.go
@@ -27,7 +27,7 @@ func TestPIDZero_StartStateMonitor(t *testing.T) {
 	stateChan := make(chan string, 5)
 	mockStateable.On("GetStateChan", mock.Anything).Return(stateChan).Once()
 
-	mockStateable.On("IsRunning").Return(true).Once()
+	mockStateable.On("IsReady").Return(true).Once()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -243,9 +243,11 @@ func (p *PIDZero) Run() error {
 			}
 		})
 
-		// if this Runnable implements the Stateable block here until IsRunning()
-		if stateable, ok := r.(Stateable); ok {
-			err := p.blockUntilRunnableReady(stateable)
+		// If this Runnable implements Readiness, block here until IsReady()
+		// returns true (or startup deadline fires). The startup gate cares
+		// about readiness, not state-reporting — Stateable is unrelated.
+		if ready, ok := r.(Readiness); ok {
+			err := p.blockUntilRunnableReady(ready)
 			if err != nil {
 				// Ctx-cancellation is a clean shutdown trigger, not a
 				// runnable failure — match reap's nil return.
@@ -259,7 +261,7 @@ func (p *PIDZero) Run() error {
 				return err
 			}
 		} else {
-			p.logger.Debug("Runnable does not implement Stateable, continuing", "runnable", r)
+			p.logger.Debug("Runnable does not implement Readiness, continuing", "runnable", r)
 		}
 
 		// Honor cancellation between iterations so a mid-startup cancel
@@ -276,8 +278,10 @@ func (p *PIDZero) Run() error {
 	return p.reap()
 }
 
-// blockUntilRunnableReady blocks until the runnable is in a running state.
-func (p *PIDZero) blockUntilRunnableReady(r Stateable) error {
+// blockUntilRunnableReady polls the Readiness gate until the runnable
+// reports it has finished its startup phase, or the startup deadline
+// fires, or the supervisor's ctx is cancelled.
+func (p *PIDZero) blockUntilRunnableReady(r Readiness) error {
 	startupCtx, cancel := context.WithTimeout(p.ctx, p.startupTimeout)
 	defer cancel()
 
@@ -289,8 +293,8 @@ func (p *PIDZero) blockUntilRunnableReady(r Stateable) error {
 	time.Sleep(timeout) // Initial delay before checking the runnable state
 
 	for {
-		if r.IsRunning() {
-			logger.Debug("Runnable is running")
+		if r.IsReady() {
+			logger.Debug("Runnable is ready")
 			return nil
 		}
 
@@ -319,8 +323,8 @@ func (p *PIDZero) blockUntilRunnableReady(r Stateable) error {
 			return p.ctx.Err()
 		case <-ticker.C:
 			// continue waiting, adding an exponential backoff
-			if r.IsRunning() {
-				logger.Debug("Runnable is running")
+			if r.IsReady() {
+				logger.Debug("Runnable is ready")
 				return nil
 			}
 			timeout = timeout * 2

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -167,7 +167,7 @@ func TestBlockUntilRunnableReady(t *testing.T) {
 	t.Run("immediately ready", func(t *testing.T) {
 		mockRunnable := mocks.NewMockRunnableWithStateable()
 		mockRunnable.On("String").Return("ready-runnable").Maybe()
-		mockRunnable.On("IsRunning").Return(true).Once()
+		mockRunnable.On("IsReady").Return(true).Once()
 
 		sv, err := New(
 			WithRunnables(mockRunnable),
@@ -187,9 +187,9 @@ func TestBlockUntilRunnableReady(t *testing.T) {
 	t.Run("becomes ready after delay", func(t *testing.T) {
 		mockRunnable := mocks.NewMockRunnableWithStateable()
 		mockRunnable.On("String").Return("delayed-runnable").Maybe()
-		mockRunnable.On("IsRunning").Return(false).Once()
-		mockRunnable.On("IsRunning").Return(false).Once()
-		mockRunnable.On("IsRunning").Return(true).Once()
+		mockRunnable.On("IsReady").Return(false).Once()
+		mockRunnable.On("IsReady").Return(false).Once()
+		mockRunnable.On("IsReady").Return(true).Once()
 
 		sv, err := New(
 			WithRunnables(mockRunnable),
@@ -211,7 +211,7 @@ func TestBlockUntilRunnableReady(t *testing.T) {
 		// Setup mock that never reports as running
 		mockRunnable := mocks.NewMockRunnableWithStateable()
 		mockRunnable.On("String").Return("stuck-runnable").Maybe()
-		mockRunnable.On("IsRunning").Return(false).Maybe() // Always returns false
+		mockRunnable.On("IsReady").Return(false).Maybe() // Always returns false
 
 		// Create supervisor with a very short timeout
 		sv, err := New(
@@ -237,7 +237,7 @@ func TestBlockUntilRunnableReady(t *testing.T) {
 		// Setup mock that never reports as running
 		mockRunnable := mocks.NewMockRunnableWithStateable()
 		mockRunnable.On("String").Return("canceled-runnable").Maybe()
-		mockRunnable.On("IsRunning").Return(false).Maybe() // Always returns false
+		mockRunnable.On("IsReady").Return(false).Maybe() // Always returns false
 
 		// Create supervisor with a context
 		ctx, cancel := context.WithCancel(context.Background())
@@ -271,7 +271,7 @@ func TestBlockUntilRunnableReady(t *testing.T) {
 		for i := range iterations {
 			mockRunnable := mocks.NewMockRunnableWithStateable()
 			mockRunnable.On("String").Return("racy-runnable").Maybe()
-			mockRunnable.On("IsRunning").Return(false).Maybe()
+			mockRunnable.On("IsReady").Return(false).Maybe()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			sv, err := New(
@@ -295,7 +295,7 @@ func TestBlockUntilRunnableReady(t *testing.T) {
 		// Setup mock that never reports as running
 		mockRunnable := mocks.NewMockRunnableWithStateable()
 		mockRunnable.On("String").Return("error-runnable").Maybe()
-		mockRunnable.On("IsRunning").Return(false).Maybe() // Always returns false
+		mockRunnable.On("IsReady").Return(false).Maybe() // Always returns false
 
 		sv, err := New(
 			WithRunnables(mockRunnable),
@@ -345,8 +345,8 @@ func TestBlockUntilRunnableReady_TickerRetry(t *testing.T) {
 	mockRunnable.On("String").Return("delayed-ready-runnable").Maybe()
 
 	// First few calls return false, then true
-	mockRunnable.On("IsRunning").Return(false).Times(4) // Initial check + 3 ticker retries
-	mockRunnable.On("IsRunning").Return(true).Once()    // Finally becomes ready
+	mockRunnable.On("IsReady").Return(false).Times(4) // Initial check + 3 ticker retries
+	mockRunnable.On("IsReady").Return(true).Once()    // Finally becomes ready
 
 	sv, err := New(
 		WithRunnables(mockRunnable),
@@ -874,12 +874,12 @@ func TestPIDZero_CancelContextFromParent(t *testing.T) {
 //
 // Cannot use synctest: pidZero.Run() calls signal.Notify, which is incompatible
 // with synctest. Synchronization is via a sync.Once-guarded channel send from
-// A's IsRunning callback — deterministic without timing assumptions.
+// A's IsReady callback — deterministic without timing assumptions.
 func TestPIDZero_Run_StartupCancelStopsLoop(t *testing.T) {
 	t.Parallel()
 
-	// A: Stateable, IsRunning always returns false so blockUntilRunnableReady
-	// stays in its polling loop. The first IsRunning call signals reachedCh,
+	// A: Stateable, IsReady always returns false so blockUntilRunnableReady
+	// stays in its polling loop. The first IsReady call signals reachedCh,
 	// which the test uses to know Run has entered blockUntilRunnableReady.
 	reachedCh := make(chan struct{}, 1)
 	var signalOnce sync.Once
@@ -888,7 +888,7 @@ func TestPIDZero_Run_StartupCancelStopsLoop(t *testing.T) {
 	a.On("GetState").Return("not-running").Maybe()
 	aStateChan := make(chan string)
 	a.On("GetStateChan", mock.Anything).Return(aStateChan).Maybe()
-	a.On("IsRunning").Return(false).Run(func(args mock.Arguments) {
+	a.On("IsReady").Return(false).Run(func(args mock.Arguments) {
 		signalOnce.Do(func() { reachedCh <- struct{}{} })
 	})
 	a.On("Run", mock.Anything).Return(nil).Once().Run(func(args mock.Arguments) {
@@ -986,7 +986,7 @@ func TestPIDZero_Run_PreCancelledCtxStopsAtFirst(t *testing.T) {
 }
 
 // slowBootRunnable wraps MockRunnableWithStateable so the test can gate
-// IsRunning() on a channel rather than testify's count-based mock returns.
+// IsReady() on a channel rather than testify's count-based mock returns.
 // This holds the supervisor's startup loop in blockUntilRunnableReady until
 // the gate is closed, giving the test a deterministic window to inject a
 // signal mid-boot.
@@ -995,7 +995,7 @@ type slowBootRunnable struct {
 	ready chan struct{}
 }
 
-func (s *slowBootRunnable) IsRunning() bool {
+func (s *slowBootRunnable) IsReady() bool {
 	select {
 	case <-s.ready:
 		return true
@@ -1041,7 +1041,7 @@ func TestPIDZero_Run_SIGTERMDuringBoot(t *testing.T) {
 
 	// Inject SIGTERM while Run is still in its startup phase —
 	// blockUntilRunnableReady is either in its initial time.Sleep
-	// (p.startupInitial, default 50ms) or polling IsRunning() afterwards.
+	// (p.startupInitial, default 50ms) or polling IsReady() afterwards.
 	// Either way reap hasn't started, so the signal queues in p.signalChan
 	// and nothing drains it yet.
 	pidZero.SendSignal(syscall.SIGTERM)
@@ -1161,7 +1161,7 @@ func TestPIDZero_Run_RunnableStartupFailure(t *testing.T) {
 	// Create a failing stateable runnable
 	mockRunnable := mocks.NewMockRunnableWithStateable()
 	mockRunnable.On("String").Return("failing-runnable").Maybe()
-	mockRunnable.On("IsRunning").Return(false) // Never becomes ready, called multiple times during timeout
+	mockRunnable.On("IsReady").Return(false) // Never becomes ready, called multiple times during timeout
 	mockRunnable.On("Run", mock.Anything).Return(nil).Once()
 	mockRunnable.On("Stop").Once()
 
@@ -1201,7 +1201,7 @@ func TestPIDZero_Shutdown_NoTimeout(t *testing.T) {
 	mockRunnable.On("String").Return("noTimeoutRunnable").Maybe()
 	mockRunnable.On("Run", mock.Anything).Return(nil).Once()
 	mockRunnable.On("Stop").Once().After(50 * time.Millisecond) // Small delay to test wait
-	mockRunnable.On("IsRunning").Return(true)
+	mockRunnable.On("IsReady").Return(true)
 
 	// Setup for Stateable interface
 	stateChan := make(chan string)


### PR DESCRIPTION
## Summary

**Breaking changes**, bundled because both touch `interfaces.go` and the same ~60 test mock expectations.

**T3.2 — Decouple `Stateable` from `Readiness`.** The two interfaces become orthogonal: implement `Stateable` for state-channel observability, `Readiness` for the startup gate, or both. The supervisor's startup gate (`blockUntilRunnableReady`) now takes `Readiness`, not `Stateable` — the gate cares about readiness, not state-reporting.

**T3.3 — Rename `Readiness.IsRunning() bool` → `IsReady() bool`.** The old name conflicted with the FSM state name \`Running\`; \`Ready\` cleanly says "startup phase complete, doesn't imply any FSM state."

This is **PR-B of three** in the Tier 3 breaking-change series:
- PR-A — T3.4 — \`ReloadableWithConfig\` takes ctx (#104, already landed)
- **PR-B (this) — T3.2 + T3.3** — Readiness decouple + rename
- PR-C — T3.1 (narrowed) — \`Reload(ctx) error\` (Stop stays no-error)

**Changes:**
- \`supervisor/interfaces.go\` — rewrite \`Stateable\`/\`Readiness\` godoc to spell out the orthogonal concerns.
- \`supervisor/supervisor.go\` — \`blockUntilRunnableReady\` takes \`Readiness\`; the type-assertion at the spawn site is \`r.(Readiness)\`, not \`r.(Stateable)\`.
- \`runnables/{httpserver,httpcluster,composite}/state.go\` — rename method.
- \`runnables/httpcluster/interfaces.go\` — \`httpServerRunner\` lists \`Readiness\` explicitly; no longer via \`Stateable\` embedding.
- \`runnables/httpcluster/runner.go\` — \`waitForIsRunning\` → \`waitForReady\`.
- \`runnables/mocks/mocks.go\` — \`MockRunnableWithStateable.IsRunning\` → \`IsReady\`. New \`MockRunnableWithReadiness\` for tests that want only \`Readiness\` (no \`GetState\`/\`GetStateChan\` setup).
- \`README.md\` — interface snippet + Supervisor options updated.
- \`supervisor/interfaces_test.go\` (new) — pins down the decoupling via type-assertion tests + a test that \`blockUntilRunnableReady\` accepts a Readiness-only mock.
- ~17 test files — mass rename of \`On("IsRunning")\` → \`On("IsReady")\` and \`r.IsRunning()\` → \`r.IsReady()\`.

**Drive-by fix:** \`examples/composite/worker.go\` got an explicit \`if ctx.Err() != nil { return }\` pre-check before the queue-insert select. Without it, with a cancelled ctx and an empty queue, both select cases are ready and select picks pseudo-randomly — the queue could win. The \`TestWorker_ReloadWithConfig_RespectsCtx\` test added in PR-A was racy as a result; this fix makes it deterministic.

**Migration for external implementers:**
- Rename your \`IsRunning() bool\` method to \`IsReady() bool\`.
- If you implemented \`Stateable\` only to gain \`IsRunning()\` via the embedding, you now need to implement \`Readiness\` explicitly.
- If you implemented \`Stateable\` for actual state reporting AND need readiness, implement both interfaces.

## Test plan

- [x] \`go build ./...\` — clean.
- [x] \`go test -race ./...\` — all green.
- [x] 10× stress on \`TestWorker_ReloadWithConfig_RespectsCtx\` — green (was racy before drive-by fix).
- [x] \`make lint\` — 0 issues.
- [x] \`git grep IsRunning\` — 0 occurrences in non-comment code.