### PR TITLE
Bound portfinder retries instead of recursing without a limit

### DIFF
--- a/internal/networking/portfinder.go
+++ b/internal/networking/portfinder.go
@@ -7,52 +7,66 @@ import (
 	"testing"
 )
 
+// maxPortAttempts bounds the retry loop in GetRandomPort and
+// GetRandomListeningPort so a pathological run cannot grow the stack
+// (previously via unbounded recursion) or hang the test.
+const maxPortAttempts = 100
+
 // reduce the chance of port conflicts
 var (
 	portMutex = &sync.Mutex{}
 	usedPorts = make(map[int]struct{})
 )
 
-// GetRandomPort finds an available port for a test by binding to port 0
+// GetRandomPort finds an available port for a test by binding to port 0.
+// It retries up to maxPortAttempts times if the kernel hands back a port
+// already taken from this process; on exhaustion it calls tb.Fatalf.
 func GetRandomPort(tb testing.TB) int {
 	tb.Helper()
-	portMutex.Lock()
-	listener, err := net.Listen("tcp", ":0")
-	if err != nil {
-		portMutex.Unlock()
-		tb.Fatalf("Failed to get random port: %v", err)
-	}
+	for attempt := 0; attempt < maxPortAttempts; attempt++ {
+		portMutex.Lock()
+		listener, err := net.Listen("tcp", ":0")
+		if err != nil {
+			portMutex.Unlock()
+			tb.Fatalf("Failed to get random port: %v", err)
+			return 0
+		}
 
-	err = listener.Close()
-	if err != nil {
-		portMutex.Unlock()
-		tb.Fatalf("Failed to close listener: %v", err)
-	}
+		if err := listener.Close(); err != nil {
+			portMutex.Unlock()
+			tb.Fatalf("Failed to close listener: %v", err)
+			return 0
+		}
 
-	addr := listener.Addr().(*net.TCPAddr)
-	p := addr.Port
-	// Check if the port is already used
-	if _, ok := usedPorts[p]; ok {
+		p := listener.Addr().(*net.TCPAddr).Port
+		if _, taken := usedPorts[p]; !taken {
+			usedPorts[p] = struct{}{}
+			portMutex.Unlock()
+			return p
+		}
 		portMutex.Unlock()
-		return GetRandomPort(tb)
 	}
-	usedPorts[p] = struct{}{}
-	portMutex.Unlock()
-	return p
+	tb.Fatalf("Failed to find unused random port after %d attempts", maxPortAttempts)
+	return 0
 }
 
-// GetRandomListeningPort finds an available port for a test by binding to port 0, and returns a string like localhost:PORT
+// GetRandomListeningPort finds an available port for a test by binding to port 0,
+// and returns a string like localhost:PORT. It retries up to maxPortAttempts times
+// if the chosen port can't be re-bound; on exhaustion it calls tb.Fatalf.
 func GetRandomListeningPort(tb testing.TB) string {
 	tb.Helper()
-	p := GetRandomPort(tb)
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", p))
-	if err != nil {
-		return GetRandomListeningPort(tb)
+	for attempt := 0; attempt < maxPortAttempts; attempt++ {
+		p := GetRandomPort(tb)
+		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", p))
+		if err != nil {
+			continue
+		}
+		if err := listener.Close(); err != nil {
+			tb.Fatalf("Failed to close listener: %v", err)
+			return ""
+		}
+		return fmt.Sprintf("localhost:%d", p)
 	}
-	err = listener.Close()
-	if err != nil {
-		tb.Fatalf("Failed to close listener: %v", err)
-	}
-
-	return fmt.Sprintf("localhost:%d", p)
+	tb.Fatalf("Failed to find listening port after %d attempts", maxPortAttempts)
+	return ""
 }

--- a/internal/networking/portfinder.go
+++ b/internal/networking/portfinder.go
@@ -12,6 +12,9 @@ import (
 // (previously via unbounded recursion) or hang the test.
 const maxPortAttempts = 100
 
+// listenTCP wraps net.Listen so tests can inject bind failures.
+var listenTCP = net.Listen
+
 // reduce the chance of port conflicts
 var (
 	portMutex = &sync.Mutex{}
@@ -25,7 +28,7 @@ func GetRandomPort(tb testing.TB) int {
 	tb.Helper()
 	for attempt := 0; attempt < maxPortAttempts; attempt++ {
 		portMutex.Lock()
-		listener, err := net.Listen("tcp", ":0")
+		listener, err := listenTCP("tcp", ":0")
 		if err != nil {
 			portMutex.Unlock()
 			tb.Fatalf("Failed to get random port: %v", err)
@@ -52,13 +55,21 @@ func GetRandomPort(tb testing.TB) int {
 
 // GetRandomListeningPort finds an available port for a test by binding to port 0,
 // and returns a string like localhost:PORT. It retries up to maxPortAttempts times
-// if the chosen port can't be re-bound; on exhaustion it calls tb.Fatalf.
+// if the chosen port can't be re-bound; on exhaustion it calls tb.Fatalf with the
+// last underlying bind error so failures are diagnosable.
 func GetRandomListeningPort(tb testing.TB) string {
 	tb.Helper()
+	var lastErr error
 	for attempt := 0; attempt < maxPortAttempts; attempt++ {
 		p := GetRandomPort(tb)
-		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", p))
+		listener, err := listenTCP("tcp", fmt.Sprintf(":%d", p))
 		if err != nil {
+			lastErr = err
+			// Don't burn this port in usedPorts since we never actually bound it;
+			// otherwise repeated failures could permanently exhaust the pool.
+			portMutex.Lock()
+			delete(usedPorts, p)
+			portMutex.Unlock()
 			continue
 		}
 		if err := listener.Close(); err != nil {
@@ -67,6 +78,10 @@ func GetRandomListeningPort(tb testing.TB) string {
 		}
 		return fmt.Sprintf("localhost:%d", p)
 	}
-	tb.Fatalf("Failed to find listening port after %d attempts", maxPortAttempts)
+	tb.Fatalf(
+		"Failed to find listening port after %d attempts: last error: %v",
+		maxPortAttempts,
+		lastErr,
+	)
 	return ""
 }

--- a/internal/networking/portfinder_test.go
+++ b/internal/networking/portfinder_test.go
@@ -15,7 +15,7 @@ func TestGetRandomPort(t *testing.T) {
 	t.Parallel()
 
 	p := GetRandomPort(t)
-	assert.Greater(t, p, 0)
+	assert.Positive(t, p)
 	assert.LessOrEqual(t, p, 65535)
 }
 

--- a/internal/networking/portfinder_test.go
+++ b/internal/networking/portfinder_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -112,16 +113,16 @@ func TestGetRandomPortFailsOnListenError(t *testing.T) {
 }
 
 func TestGetRandomListeningPortRetriesOnRebindFailure(t *testing.T) {
-	calls := 0
 	var failedPort int
 
 	withListenTCP(t, func(network, address string) (net.Listener, error) {
-		calls++
 		// Calls alternate: GetRandomPort (":0") then re-bind on port (":N").
 		// Fail the first re-bind, succeed afterwards.
 		if address != ":0" && failedPort == 0 {
 			// Capture the port so we can check it gets released, then fail.
-			fmt.Sscanf(address, ":%d", &failedPort)
+			p, err := strconv.Atoi(strings.TrimPrefix(address, ":"))
+			require.NoError(t, err)
+			failedPort = p
 			return nil, errors.New("simulated rebind failure")
 		}
 		return net.Listen(network, address)
@@ -151,7 +152,7 @@ func TestGetRandomListeningPortFailsAfterLimit(t *testing.T) {
 
 	tb := &fakeTB{}
 	got := GetRandomListeningPort(tb)
-	assert.Equal(t, "", got)
+	assert.Empty(t, got)
 	msg := tb.message()
 	assert.Contains(t, msg, fmt.Sprintf("%d attempts", maxPortAttempts))
 	assert.Contains(t, msg, "simulated rebind failure")

--- a/internal/networking/portfinder_test.go
+++ b/internal/networking/portfinder_test.go
@@ -1,6 +1,7 @@
 package networking
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -87,4 +88,71 @@ func TestGetRandomPortFailsAfterLimit(t *testing.T) {
 	got := GetRandomPort(tb)
 	assert.Equal(t, 0, got)
 	assert.Contains(t, tb.message(), fmt.Sprintf("%d attempts", maxPortAttempts))
+}
+
+// withListenTCP swaps the package-level listenTCP for the duration of a test.
+// Not safe for parallel tests in this package.
+func withListenTCP(t *testing.T, fn func(network, address string) (net.Listener, error)) {
+	t.Helper()
+	original := listenTCP
+	listenTCP = fn
+	t.Cleanup(func() { listenTCP = original })
+}
+
+func TestGetRandomPortFailsOnListenError(t *testing.T) {
+	withListenTCP(t, func(network, address string) (net.Listener, error) {
+		return nil, errors.New("simulated listen failure")
+	})
+
+	tb := &fakeTB{}
+	got := GetRandomPort(tb)
+	assert.Equal(t, 0, got)
+	assert.Contains(t, tb.message(), "Failed to get random port")
+	assert.Contains(t, tb.message(), "simulated listen failure")
+}
+
+func TestGetRandomListeningPortRetriesOnRebindFailure(t *testing.T) {
+	calls := 0
+	var failedPort int
+
+	withListenTCP(t, func(network, address string) (net.Listener, error) {
+		calls++
+		// Calls alternate: GetRandomPort (":0") then re-bind on port (":N").
+		// Fail the first re-bind, succeed afterwards.
+		if address != ":0" && failedPort == 0 {
+			// Capture the port so we can check it gets released, then fail.
+			fmt.Sscanf(address, ":%d", &failedPort)
+			return nil, errors.New("simulated rebind failure")
+		}
+		return net.Listen(network, address)
+	})
+
+	addr := GetRandomListeningPort(t)
+	require.True(t, strings.HasPrefix(addr, "localhost:"))
+
+	// failedPort must NOT remain marked as used after a failed rebind, otherwise
+	// repeated failures would exhaust the pool.
+	require.NotZero(t, failedPort)
+	portMutex.Lock()
+	_, stillUsed := usedPorts[failedPort]
+	portMutex.Unlock()
+	assert.False(t, stillUsed, "port %d was burned in usedPorts after rebind failure", failedPort)
+}
+
+func TestGetRandomListeningPortFailsAfterLimit(t *testing.T) {
+	withListenTCP(t, func(network, address string) (net.Listener, error) {
+		// GetRandomPort uses ":0"; let it succeed so we exercise the
+		// re-bind branch and the lastErr propagation.
+		if address == ":0" {
+			return net.Listen(network, address)
+		}
+		return nil, errors.New("simulated rebind failure")
+	})
+
+	tb := &fakeTB{}
+	got := GetRandomListeningPort(tb)
+	assert.Equal(t, "", got)
+	msg := tb.message()
+	assert.Contains(t, msg, fmt.Sprintf("%d attempts", maxPortAttempts))
+	assert.Contains(t, msg, "simulated rebind failure")
 }

--- a/internal/networking/portfinder_test.go
+++ b/internal/networking/portfinder_test.go
@@ -1,0 +1,90 @@
+package networking
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetRandomPort(t *testing.T) {
+	t.Parallel()
+
+	p := GetRandomPort(t)
+	assert.Greater(t, p, 0)
+	assert.LessOrEqual(t, p, 65535)
+}
+
+func TestGetRandomPortReturnsUnique(t *testing.T) {
+	t.Parallel()
+
+	const n = 20
+	seen := make(map[int]struct{}, n)
+	for i := 0; i < n; i++ {
+		p := GetRandomPort(t)
+		_, dup := seen[p]
+		assert.False(t, dup, "GetRandomPort returned duplicate port %d", p)
+		seen[p] = struct{}{}
+	}
+}
+
+func TestGetRandomListeningPort(t *testing.T) {
+	t.Parallel()
+
+	addr := GetRandomListeningPort(t)
+	require.True(t, strings.HasPrefix(addr, "localhost:"))
+
+	// The returned address must actually be bindable.
+	l, err := net.Listen("tcp", addr)
+	require.NoError(t, err)
+	require.NoError(t, l.Close())
+}
+
+// fakeTB captures Fatalf without aborting the surrounding test.
+type fakeTB struct {
+	testing.TB
+	mu       sync.Mutex
+	fatalMsg string
+}
+
+func (f *fakeTB) Helper() {}
+
+func (f *fakeTB) Fatalf(format string, args ...any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.fatalMsg == "" {
+		f.fatalMsg = fmt.Sprintf(format, args...)
+	}
+}
+
+func (f *fakeTB) message() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.fatalMsg
+}
+
+func TestGetRandomPortFailsAfterLimit(t *testing.T) {
+	// Not parallel: this test mutates the package-level usedPorts map.
+	portMutex.Lock()
+	originalUsed := usedPorts
+	usedPorts = make(map[int]struct{})
+	for p := 1; p <= 65535; p++ {
+		usedPorts[p] = struct{}{}
+	}
+	portMutex.Unlock()
+
+	t.Cleanup(func() {
+		portMutex.Lock()
+		usedPorts = originalUsed
+		portMutex.Unlock()
+	})
+
+	tb := &fakeTB{}
+	got := GetRandomPort(tb)
+	assert.Equal(t, 0, got)
+	assert.Contains(t, tb.message(), fmt.Sprintf("%d attempts", maxPortAttempts))
+}


### PR DESCRIPTION
## Summary

- `GetRandomPort` and `GetRandomListeningPort` in `internal/networking/portfinder.go` previously recursed without a limit. A sufficiently full `usedPorts` map, or repeated re-bind failures on the chosen port, could grow the goroutine stack indefinitely or mask the underlying failure.
- Convert both functions to a bounded loop (`maxPortAttempts = 100`) and call `tb.Fatalf` when the limit is reached, surfacing the failure clearly to the test runner.
- Adds `internal/networking/portfinder_test.go` covering the happy path, uniqueness across calls, and the exhaustion path via a stub `testing.TB`.

This is item #2 from the project audit (`/root/.claude/plans/perform-a-full-project-curious-koala.md`). The broader concern (the `usedPorts` map providing only weak guarantees because the OS reassigns released ports anyway) is intentionally **out of scope** for this PR — only the recursion bound was requested.

## Test plan

- [x] `go test -timeout 3m -race ./...` passes locally on Go 1.26.0
- [x] New tests exercise both happy path and the bounded-failure path
- [ ] CI build/lint pass on this PR

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_