### PR TITLE
Drop dead nil-check in broadcastState

### DIFF
--- a/supervisor/state.go
+++ b/supervisor/state.go
@@ -123,7 +123,7 @@ func (p *PIDZero) broadcastState() {
 	defer p.subscriberMutex.Unlock()
 
 	stateMap := p.GetStateMap()
-	if len(stateMap) == 0 || stateMap == nil {
+	if len(stateMap) == 0 {
 		p.logger.Debug("No state to broadcast; stateMap is empty")
 		return
 	}


### PR DESCRIPTION
## Summary

- `broadcastState` in `supervisor/state.go:126` had `if len(stateMap) == 0 || stateMap == nil { ... }`. `stateMap` is built locally by `GetStateMap()` via `make(StateMap)`, so it is never nil — the second clause is unreachable.
- Drops the dead clause; behavior is unchanged.

## Test plan

- [x] `go test -timeout 3m -race ./supervisor/...` passes locally
- [x] `go vet ./...` clean

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9