### PR TITLE
Drop misleading "Public fields" label in RequestProcessor

### DIFF
--- a/runnables/httpserver/request_processor.go
+++ b/runnables/httpserver/request_processor.go
@@ -19,13 +19,12 @@ import (
 // HandlerFunc is the middleware/handler signature
 type HandlerFunc func(*RequestProcessor)
 
-// RequestProcessor carries the request/response and middleware chain
+// RequestProcessor carries the request/response and middleware chain.
+// All fields are unexported; access them via the Writer/Request methods
+// and mutate via SetWriter.
 type RequestProcessor struct {
-	// Public fields for direct access
-	writer  ResponseWriter
-	request *http.Request
-
-	// Private fields
+	writer   ResponseWriter
+	request  *http.Request
 	handlers []HandlerFunc
 	index    int
 }


### PR DESCRIPTION
## Summary

- The `RequestProcessor` struct comment partitioned its fields as "Public fields for direct access" vs. "Private fields", but **all four fields are unexported** (`writer`, `request`, `handlers`, `index`).
- The first group is reached via `Writer()` / `Request()` getters (and `SetWriter()`); the second is internal middleware-chain control state. The labels were misleading.
- Drops the section labels and rewrites the type godoc to describe how callers actually interact with the struct.
- No behavior change.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -timeout 3m -race ./runnables/httpserver/...` passes locally

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_