### PR TITLE
supervisor: guard sync.Map Range type assertions

### DIFF
--- a/supervisor/state.go
+++ b/supervisor/state.go
@@ -51,8 +51,16 @@ func (p *PIDZero) GetStateMap() StateMap {
 
 	// Use the stateMap as the source of truth for consistent state reporting
 	p.stateMap.Range(func(key, value any) bool {
-		r := key.(Runnable)
-		state := value.(string)
+		r, ok := key.(Runnable)
+		if !ok {
+			p.logger.Warn("stateMap key is not a Runnable; skipping", "key", key)
+			return true
+		}
+		state, ok := value.(string)
+		if !ok {
+			p.logger.Warn("stateMap value is not a string; skipping", "runnable", r, "value", value)
+			return true
+		}
 		stateMap[r.String()] = state
 		return true
 	})
@@ -129,7 +137,11 @@ func (p *PIDZero) broadcastState() {
 	}
 
 	p.stateSubscribers.Range(func(key, value any) bool {
-		ch := key.(chan StateMap)
+		ch, ok := key.(chan StateMap)
+		if !ok {
+			p.logger.Warn("stateSubscribers key is not a chan StateMap; skipping", "key", key)
+			return true
+		}
 		select {
 		case ch <- stateMap:
 			p.logger.Debug("Sent state update to subscriber")


### PR DESCRIPTION
## Summary

- Three unguarded type assertions inside `sync.Map.Range` closures in `supervisor/state.go` (two in `GetStateMap`, one in `broadcastState`) would panic if the maps ever held an unexpected type.
- The maps are populated only by internal callers today, so the panic is unreachable, but a future refactor could trip them.
- Rewrote each as `comma-ok` with a `Warn` log on the false branch and `return true` so a single bad entry can never abort a state broadcast or query.

No public API change; no behavior change in the happy path.

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./supervisor/... -count=1`
- [x] CI: build + dependency-review + SonarCloud

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_