### PR TITLE
httpcluster: drop unused serverEntry.ctx field

### DIFF
--- a/runnables/httpcluster/entries.go
+++ b/runnables/httpcluster/entries.go
@@ -24,7 +24,11 @@ type serverEntry struct {
 
 	// Runtime state - nil if server is not running
 	runner httpServerRunner
-	ctx    context.Context
+	// cancel terminates the per-server goroutine. It's set when the server
+	// starts and called from the cluster's stop path to remove this server
+	// without disturbing siblings. The per-server ctx itself is owned by the
+	// goroutine closure (see createAndStartServer); this struct holds only
+	// the cancel handle.
 	cancel context.CancelFunc
 
 	// Pending action for the commit phase
@@ -128,7 +132,6 @@ func (e *entries) commit() entriesManager {
 			id:     entry.id,
 			config: entry.config,
 			runner: entry.runner,
-			ctx:    entry.ctx,
 			cancel: entry.cancel,
 			action: actionNone,
 		}
@@ -143,7 +146,6 @@ func (e *entries) commit() entriesManager {
 func (e *entries) setRuntime(
 	id string,
 	runner httpServerRunner,
-	ctx context.Context,
 	cancel context.CancelFunc,
 ) entriesManager {
 	_, exists := e.servers[id]
@@ -160,7 +162,6 @@ func (e *entries) setRuntime(
 				id:     v.id,
 				config: v.config,
 				runner: runner,
-				ctx:    ctx,
 				cancel: cancel,
 				action: v.action, // Preserve action
 			}

--- a/runnables/httpcluster/entries_test.go
+++ b/runnables/httpcluster/entries_test.go
@@ -46,7 +46,7 @@ func createTestServerEntry(
 	}
 
 	if withRuntime {
-		_, cancel := context.WithCancel(context.Background())
+		_, cancel := context.WithCancel(t.Context())
 		// Set minimal runtime state for testing
 		entry.cancel = cancel
 		// Set a non-nil runner to indicate the server is running
@@ -384,7 +384,7 @@ func TestEntriesSetRuntime(t *testing.T) {
 			},
 		}
 
-		_, cancel := context.WithCancel(context.Background())
+		_, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		updated := entries.setRuntime("server1", nil, cancel)
@@ -406,7 +406,7 @@ func TestEntriesSetRuntime(t *testing.T) {
 			servers: map[string]*serverEntry{},
 		}
 
-		_, cancel := context.WithCancel(context.Background())
+		_, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		updated := entries.setRuntime("nonexistent", nil, cancel)
@@ -417,7 +417,7 @@ func TestEntriesSetRuntime(t *testing.T) {
 
 func TestEntriesClearRuntime(t *testing.T) {
 	t.Run("clear runtime for existing entry", func(t *testing.T) {
-		_, cancel := context.WithCancel(context.Background())
+		_, cancel := context.WithCancel(t.Context())
 		entries := &entries{
 			servers: map[string]*serverEntry{
 				"server1": {
@@ -537,7 +537,7 @@ func TestEntriesImmutability(t *testing.T) {
 			},
 		}
 
-		_, cancel := context.WithCancel(context.Background())
+		_, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		updated := original.setRuntime("server1", nil, cancel)

--- a/runnables/httpcluster/entries_test.go
+++ b/runnables/httpcluster/entries_test.go
@@ -46,9 +46,8 @@ func createTestServerEntry(
 	}
 
 	if withRuntime {
-		ctx, cancel := context.WithCancel(context.Background())
+		_, cancel := context.WithCancel(context.Background())
 		// Set minimal runtime state for testing
-		entry.ctx = ctx
 		entry.cancel = cancel
 		// Set a non-nil runner to indicate the server is running
 		entry.runner = &httpserver.Runner{}
@@ -385,21 +384,21 @@ func TestEntriesSetRuntime(t *testing.T) {
 			},
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		_, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		updated := entries.setRuntime("server1", nil, ctx, cancel)
+		updated := entries.setRuntime("server1", nil, cancel)
 
 		require.NotNil(t, updated)
 		assert.Equal(t, 1, updated.count())
 
 		entry := updated.get("server1")
 		require.NotNil(t, entry)
-		assert.Equal(t, ctx, entry.ctx)
+		assert.NotNil(t, entry.cancel, "cancel should be set")
 		assert.Equal(t, actionStart, entry.action, "Action should be preserved")
 
 		originalEntry := entries.get("server1")
-		assert.Nil(t, originalEntry.ctx, "Original entries should be unchanged")
+		assert.Nil(t, originalEntry.cancel, "Original entries should be unchanged")
 	})
 
 	t.Run("set runtime for non-existing entry", func(t *testing.T) {
@@ -407,10 +406,10 @@ func TestEntriesSetRuntime(t *testing.T) {
 			servers: map[string]*serverEntry{},
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		_, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		updated := entries.setRuntime("nonexistent", nil, ctx, cancel)
+		updated := entries.setRuntime("nonexistent", nil, cancel)
 
 		assert.Nil(t, updated)
 	})
@@ -418,13 +417,12 @@ func TestEntriesSetRuntime(t *testing.T) {
 
 func TestEntriesClearRuntime(t *testing.T) {
 	t.Run("clear runtime for existing entry", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
+		_, cancel := context.WithCancel(context.Background())
 		entries := &entries{
 			servers: map[string]*serverEntry{
 				"server1": {
 					id:     "server1",
 					config: createTestHTTPConfig(t, ":8001"),
-					ctx:    ctx,
 					cancel: cancel,
 					action: actionStop,
 				},
@@ -438,12 +436,11 @@ func TestEntriesClearRuntime(t *testing.T) {
 
 		entry := updated.get("server1")
 		require.NotNil(t, entry)
-		assert.Nil(t, entry.ctx)
 		assert.Nil(t, entry.cancel)
 		assert.Equal(t, actionStop, entry.action, "Action should be preserved")
 
 		originalEntry := entries.get("server1")
-		assert.NotNil(t, originalEntry.ctx, "Original entries should be unchanged")
+		assert.NotNil(t, originalEntry.cancel, "Original entries should be unchanged")
 	})
 
 	t.Run("clear runtime for non-existing entry", func(t *testing.T) {
@@ -540,18 +537,18 @@ func TestEntriesImmutability(t *testing.T) {
 			},
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		_, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		updated := original.setRuntime("server1", nil, ctx, cancel)
+		updated := original.setRuntime("server1", nil, cancel)
 
 		// Original unchanged
 		originalEntry := original.get("server1")
-		assert.Nil(t, originalEntry.ctx)
+		assert.Nil(t, originalEntry.cancel)
 
 		// Updated has runtime
 		updatedEntry := updated.get("server1")
-		assert.NotNil(t, updatedEntry.ctx)
+		assert.NotNil(t, updatedEntry.cancel)
 	})
 }
 

--- a/runnables/httpcluster/interfaces.go
+++ b/runnables/httpcluster/interfaces.go
@@ -31,7 +31,6 @@ type entriesManager interface {
 	setRuntime(
 		id string,
 		runner httpServerRunner,
-		ctx context.Context,
 		cancel context.CancelFunc,
 	) entriesManager
 

--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -414,7 +414,7 @@ func (r *Runner) startServers(
 		logger.Debug("Starting server")
 
 		// Create and start the server
-		runner, serverCtx, serverCancel, err := r.createAndStartServer(ctx, entry)
+		runner, serverCancel, err := r.createAndStartServer(ctx, entry)
 		if err != nil {
 			logger.Error("Failed to create server", "error", err)
 			hadFailure = true
@@ -424,7 +424,7 @@ func (r *Runner) startServers(
 		}
 
 		// Update entries with runtime info
-		if updated := current.setRuntime(id, runner, serverCtx, serverCancel); updated != nil {
+		if updated := current.setRuntime(id, runner, serverCancel); updated != nil {
 			current = updated
 		}
 
@@ -463,7 +463,7 @@ func (r *Runner) startServers(
 func (r *Runner) createAndStartServer(
 	ctx context.Context,
 	entry *serverEntry,
-) (httpServerRunner, context.Context, context.CancelFunc, error) {
+) (httpServerRunner, context.CancelFunc, error) {
 	// Create server context
 	serverCtx, serverCancel := context.WithCancel(ctx)
 
@@ -471,7 +471,7 @@ func (r *Runner) createAndStartServer(
 	runner, err := r.runnerFactory(serverCtx, entry.id, entry.config, r.logger.Handler())
 	if err != nil {
 		serverCancel()
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	// Start that Runnable implementation in a goroutine
@@ -496,7 +496,7 @@ func (r *Runner) createAndStartServer(
 		logger.Debug("Instance stopped")
 	}(entry.id, runner, serverCtx, serverCancel)
 
-	return runner, serverCtx, serverCancel, nil
+	return runner, serverCancel, nil
 }
 
 // removeEntryIfMatches drops the entry stored under id only if it still points

--- a/runnables/httpcluster/runner_test.go
+++ b/runnables/httpcluster/runner_test.go
@@ -673,7 +673,7 @@ func TestRunnerExecuteActions(t *testing.T) {
 		mockEntries.On("get", "start1").Return(testEntry)
 
 		// Mock setRuntime to return the same mock (simulating immutable update)
-		mockEntries.On("setRuntime", "start1", mock.Anything, mock.Anything, mock.Anything).
+		mockEntries.On("setRuntime", "start1", mock.Anything, mock.Anything).
 			Return(mockEntries).Maybe()
 
 		// Mock clearRuntime in case the server fails to become ready (can happen in slow environments)

--- a/runnables/httpcluster/runner_test.go
+++ b/runnables/httpcluster/runner_test.go
@@ -54,10 +54,9 @@ func (m *MockEntriesManager) commit() entriesManager {
 func (m *MockEntriesManager) setRuntime(
 	id string,
 	runner httpServerRunner,
-	ctx context.Context,
 	cancel context.CancelFunc,
 ) entriesManager {
-	args := m.Called(id, runner, ctx, cancel)
+	args := m.Called(id, runner, cancel)
 	if args.Get(0) == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary

The Context Lifecycle Redesign (PRs #89/#90/#92/#94) banned storing `context.Context` in struct fields. `httpcluster`'s `serverEntry` carved out an exception for per-server cancellation, holding both `ctx` and `cancel`. T3.5 of the master defects+ergonomics plan was to revisit that carve-out.

A spike confirmed the `ctx` field was never actually read in production — only assigned in `setRuntime` and copied in `commit`. The per-server goroutine captures `serverCtx` via closure (in `createAndStartServer`), so the struct field was pure dead weight.

This PR drops the field and trims the related signatures. The surviving `cancel context.CancelFunc` is just a function value — it doesn't trigger the no-ctx-in-struct rule, and storing a cancel func in a registry is the standard Go pattern for cross-goroutine cancellation.

## Changes

- `serverEntry`: drop `ctx context.Context` field; add a doc comment on the surviving `cancel` describing what it terminates.
- `entriesManager.setRuntime` / `entries.setRuntime`: drop the `ctx context.Context` parameter.
- `entries.commit()`: drop the `ctx: entry.ctx` field copy.
- `Runner.createAndStartServer`: return signature `(httpServerRunner, context.Context, context.CancelFunc, error)` → `(httpServerRunner, context.CancelFunc, error)`. The goroutine's `serverCtx` is still captured via closure as before.
- `Runner.startServers`: caller updated to drop the now-unreturned `serverCtx`.
- `MockEntriesManager.setRuntime` and tests in `entries_test.go`: drop ctx references; assertions retargeted to `entry.cancel` where they were checking the runtime fields' presence/absence.

## Test plan

- [x] `go test -race ./runnables/httpcluster/...` — green
- [x] `go test -race ./...` — green across the repo
- [x] `make lint` — 0 issues
- [x] `git grep -nE 'serverEntry.*ctx|entry\.ctx' runnables/httpcluster/` — zero hits

No new tests required. The existing per-server lifecycle tests (hot-add, hot-remove, crash mid-run, cluster shutdown, port-binding race, concurrent add/remove) cover the cancel-funcs paths; removing dead state introduces no new behavior to test.