### PR TITLE
httpserver: document Stop drain semantics and stopServer ctx rationale

### DIFF
--- a/runnables/httpserver/runner.go
+++ b/runnables/httpserver/runner.go
@@ -261,7 +261,13 @@ func (r *Runner) drainReloadCh() {
 	}
 }
 
-// Stop signals the HTTP server to shut down and blocks until Run() completes.
+// Stop signals the HTTP server to begin graceful shutdown and blocks until
+// Run() completes. In-flight HTTP requests are given up to the configured
+// Config.DrainTimeout to finish before remaining connections are forcibly
+// closed. Cancelling the context passed to Run() does NOT accelerate this
+// drain — the drain timeout is honored regardless, so active requests are
+// never truncated mid-flight by supervisor cancellation. See stopServer for
+// the rationale.
 func (r *Runner) Stop() {
 	r.logger.Debug("Stopping HTTP server")
 	r.lc.Stop()
@@ -408,11 +414,21 @@ func (r *Runner) getConfig() *Config {
 	return newConfig
 }
 
-// stopServer performs graceful HTTP server shutdown with timeout handling.
-// It uses sync.Once to ensure shutdown occurs only once per server instance.
+// stopServer performs graceful HTTP server shutdown bounded by
+// Config.DrainTimeout. The shutdown context is intentionally derived from
+// context.Background() rather than the parent ctx: the drain window exists
+// to let in-flight HTTP requests complete cleanly, and a cancelled parent
+// ctx would defeat that purpose by truncating active requests. DrainTimeout
+// is the sole upper bound on how long Shutdown waits for connections to drain.
+//
+// Run() calls runCancel() before invoking shutdown(), so on the normal
+// shutdown path ctx is already cancelled here — another reason this function
+// must not derive its timeout from it.
+//
+// sync.Once ensures shutdown runs at most once per server instance.
 func (r *Runner) stopServer(ctx context.Context) error {
 	var shutdownErr error
-	//nolint:contextcheck // We intentionally use context.Background() for shutdown timeout
+	//nolint:contextcheck // intentional: drain must outlive parent ctx so in-flight requests finish; see godoc
 	r.serverCloseOnce.Do(func() {
 		r.serverMutex.RLock()
 		defer r.serverMutex.RUnlock()

--- a/runnables/httpserver/runner.go
+++ b/runnables/httpserver/runner.go
@@ -262,12 +262,14 @@ func (r *Runner) drainReloadCh() {
 }
 
 // Stop signals the HTTP server to begin graceful shutdown and blocks until
-// Run() completes. In-flight HTTP requests are given up to the configured
-// Config.DrainTimeout to finish before remaining connections are forcibly
-// closed. Cancelling the context passed to Run() does NOT accelerate this
-// drain — the drain timeout is honored regardless, so active requests are
-// never truncated mid-flight by supervisor cancellation. See stopServer for
-// the rationale.
+// Run() completes. http.Server.Shutdown is invoked with a timeout of
+// Config.DrainTimeout, giving in-flight HTTP requests up to that long to
+// complete before Shutdown returns. This drain window is decoupled from
+// the context passed to Run() — cancelling that context does not shorten
+// the wait. Note that the server's BaseContext is derived from Run's ctx,
+// so request handlers that honor r.Context() will still observe
+// cancellation independently of the drain timeout. See stopServer for the
+// rationale.
 func (r *Runner) Stop() {
 	r.logger.Debug("Stopping HTTP server")
 	r.lc.Stop()
@@ -414,21 +416,22 @@ func (r *Runner) getConfig() *Config {
 	return newConfig
 }
 
-// stopServer performs graceful HTTP server shutdown bounded by
-// Config.DrainTimeout. The shutdown context is intentionally derived from
-// context.Background() rather than the parent ctx: the drain window exists
-// to let in-flight HTTP requests complete cleanly, and a cancelled parent
-// ctx would defeat that purpose by truncating active requests. DrainTimeout
-// is the sole upper bound on how long Shutdown waits for connections to drain.
+// stopServer invokes http.Server.Shutdown with a timeout of
+// Config.DrainTimeout, giving in-flight requests a bounded window to
+// complete before Shutdown returns. The shutdown context is derived from
+// context.Background() rather than the parent ctx because Run() calls
+// runCancel() before invoking shutdown(), so on the normal shutdown path
+// the parent ctx is already done here — a ctx-derived timeout would fire
+// immediately and Shutdown would return without waiting for the drain.
 //
-// Run() calls runCancel() before invoking shutdown(), so on the normal
-// shutdown path ctx is already cancelled here — another reason this function
-// must not derive its timeout from it.
+// http.Server.Shutdown does not itself terminate in-flight handlers when
+// its ctx fires; it just stops waiting and returns. Active requests
+// continue running on connections that outlive Shutdown.
 //
 // sync.Once ensures shutdown runs at most once per server instance.
 func (r *Runner) stopServer(ctx context.Context) error {
 	var shutdownErr error
-	//nolint:contextcheck // intentional: drain must outlive parent ctx so in-flight requests finish; see godoc
+	//nolint:contextcheck // intentional: Run cancels runCtx before shutdown(); a ctx-derived timeout would fire immediately and skip the drain
 	r.serverCloseOnce.Do(func() {
 		r.serverMutex.RLock()
 		defer r.serverMutex.RUnlock()


### PR DESCRIPTION
## Summary

- `Stop()`'s godoc didn't communicate the drain contract — callers had to read `stopServer` to learn that `DrainTimeout` bounds the wait and that cancelling Run's ctx will not accelerate it.
- The `contextcheck` nolint on `stopServer` was equally terse, leaving the intent ("drain must outlive ctx so in-flight requests can finish") implicit.
- Expanded both godocs to spell out the rationale: the drain window exists to let active HTTP requests complete cleanly; a cancelled parent ctx would truncate them. Also notes that `Run()` calls `runCancel()` before `shutdown()`, so swapping to a ctx-derived timeout would always fire immediately and skip the drain entirely.

No behavior change. Doc-only.

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./runnables/httpserver/... -count=1`
- [x] CI: build + dependency-review + SonarCloud

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_