### PR TITLE
httpserver: use slices.Equal in Routes.Equal name comparison

### DIFF
--- a/runnables/httpserver/routes.go
+++ b/runnables/httpserver/routes.go
@@ -101,7 +101,7 @@ func (r Routes) Equal(other Routes) bool {
 	}
 	slices.Sort(newNames)
 
-	if fmt.Sprintf("%v", oldNames) != fmt.Sprintf("%v", newNames) {
+	if !slices.Equal(oldNames, newNames) {
 		return false
 	}
 


### PR DESCRIPTION
## Summary

`Routes.Equal` compared two sorted `[]string` of route names via `fmt.Sprintf("%v", oldNames) != fmt.Sprintf("%v", newNames)`. Replace with `slices.Equal(oldNames, newNames)` — the `slices` package is already imported (used by `slices.Sort` immediately above).

No semantic change. `Routes.Equal` remains intentionally handler-blind: `Route.name` is the equality key (documented at `routes.go:13` and contract-tested at `routes_test.go:245-256`), so callers signal a real reload by bumping the name.

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./runnables/httpserver/ -count=1` (full package, including `TestRoutesEqual*` and `TestConfigEqual*`)
- [ ] CI: build + dependency-review + SonarCloud quality gate

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_