### PR TITLE
examples/http: use random port in TestRunServer

### DIFF
--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -91,11 +91,12 @@ func buildRoutes(logHandler slog.Handler) ([]httpserver.Route, error) {
 func RunServer(
 	ctx context.Context,
 	logHandler slog.Handler,
+	addr string,
 	routes []httpserver.Route,
 ) (*supervisor.PIDZero, error) {
 	// Create a config callback function that will be used by the runner
 	configCallback := func() (*httpserver.Config, error) {
-		return httpserver.NewConfig(ListenOn, routes, httpserver.WithDrainTimeout(DrainTimeout))
+		return httpserver.NewConfig(addr, routes, httpserver.WithDrainTimeout(DrainTimeout))
 	}
 
 	// Create the HTTP server runner
@@ -136,7 +137,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	sv, err := RunServer(ctx, handler, routes)
+	sv, err := RunServer(ctx, handler, ListenOn, routes)
 	if err != nil {
 		slog.Error("Failed to setup server", "error", err)
 		os.Exit(1)

--- a/examples/http/main_test.go
+++ b/examples/http/main_test.go
@@ -45,10 +45,11 @@ func TestRunServer(t *testing.T) {
 	}()
 
 	statusURL := "http://localhost" + addr + "/status"
+	client := &http.Client{Timeout: time.Second}
 
 	// Wait for the server to be ready by checking if it responds to requests
 	assert.Eventually(t, func() bool {
-		resp, err := http.Get(statusURL)
+		resp, err := client.Get(statusURL)
 		if err != nil {
 			return false
 		}
@@ -57,7 +58,7 @@ func TestRunServer(t *testing.T) {
 	}, 2*time.Second, 50*time.Millisecond, "Server should become ready")
 
 	// Make a request to the server
-	resp, err := http.Get(statusURL)
+	resp, err := client.Get(statusURL)
 	require.NoError(t, err, "Failed to make GET request")
 
 	body, err := io.ReadAll(resp.Body)

--- a/examples/http/main_test.go
+++ b/examples/http/main_test.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/robbyt/go-supervisor/internal/networking"
 	"github.com/robbyt/go-supervisor/runnables/httpserver"
 	"github.com/robbyt/go-supervisor/supervisor"
 	"github.com/stretchr/testify/assert"
@@ -31,7 +33,8 @@ func TestRunServer(t *testing.T) {
 	require.NoError(t, err, "Failed to build routes")
 	require.NotEmpty(t, routes, "Routes should not be empty")
 
-	sv, err := RunServer(ctx, logHandler, routes)
+	addr := fmt.Sprintf(":%d", networking.GetRandomPort(t))
+	sv, err := RunServer(ctx, logHandler, addr, routes)
 	require.NoError(t, err, "RunServer should not return an error")
 	require.NotNil(t, sv, "Supervisor should not be nil")
 
@@ -41,9 +44,11 @@ func TestRunServer(t *testing.T) {
 		errCh <- sv.Run()
 	}()
 
+	statusURL := "http://localhost" + addr + "/status"
+
 	// Wait for the server to be ready by checking if it responds to requests
 	assert.Eventually(t, func() bool {
-		resp, err := http.Get("http://localhost:8080/status")
+		resp, err := http.Get(statusURL)
 		if err != nil {
 			return false
 		}
@@ -52,7 +57,7 @@ func TestRunServer(t *testing.T) {
 	}, 2*time.Second, 50*time.Millisecond, "Server should become ready")
 
 	// Make a request to the server
-	resp, err := http.Get("http://localhost:8080/status")
+	resp, err := http.Get(statusURL)
 	require.NoError(t, err, "Failed to make GET request")
 
 	body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
## Summary

`TestRunServer` hit `http://localhost:8080/status` twice via the hardcoded `ListenOn = ":8080"` constant. If anything else bound 8080 during CI (another test process, dev daemon, leftover container), the test flaked or hung the whole run.

- Parameterize `RunServer` with an `addr string`. `main()` keeps passing `ListenOn` so runtime behavior of the example is unchanged.
- Test computes `addr := fmt.Sprintf(":%d", networking.GetRandomPort(t))` using the existing `internal/networking` helper (bounded retry, fatal on exhaustion since #107) and constructs its probe URL from that addr.
- `TestRunServerInvalidPort` is unaffected — still uses `:-1` directly.

## Test plan

- [x] `go vet ./examples/http/...`
- [x] `go build ./examples/http/...`
- [x] `go test -race ./examples/http/... -count=5 -timeout 90s` (5x to flush the eventually-poll path)
- [x] CI: build + dependency-review + SonarCloud quality gate

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_