### PR TITLE
httpserver/wildcard: clone request before stripping prefix

### DIFF
--- a/runnables/httpserver/middleware/wildcard/wildcard.go
+++ b/runnables/httpserver/middleware/wildcard/wildcard.go
@@ -79,7 +79,9 @@ func New(prefix string) httpserver.HandlerFunc {
 			rp.Abort()
 			return
 		}
-		req.URL.Path = strings.TrimPrefix(req.URL.Path, prefix)
+		cloned := req.Clone(req.Context())
+		cloned.URL.Path = strings.TrimPrefix(req.URL.Path, prefix)
+		rp.SetRequest(cloned)
 		rp.Next()
 	}
 }

--- a/runnables/httpserver/middleware/wildcard/wildcard.go
+++ b/runnables/httpserver/middleware/wildcard/wildcard.go
@@ -80,7 +80,7 @@ func New(prefix string) httpserver.HandlerFunc {
 			return
 		}
 		cloned := req.Clone(req.Context())
-		cloned.URL.Path = strings.TrimPrefix(req.URL.Path, prefix)
+		cloned.URL.Path = strings.TrimPrefix(cloned.URL.Path, prefix)
 		rp.SetRequest(cloned)
 		rp.Next()
 	}

--- a/runnables/httpserver/middleware/wildcard/wildcard_test.go
+++ b/runnables/httpserver/middleware/wildcard/wildcard_test.go
@@ -129,6 +129,26 @@ func TestWildcard_PrefixWithoutTrailingSlash(t *testing.T) {
 	assert.Equal(t, "users", rec.Body.String())
 }
 
+func TestWildcard_DoesNotMutateOriginalRequest(t *testing.T) {
+	t.Parallel()
+	handler := createPathEchoHandler(t)
+	rec, req := setupRequest(t, "GET", "/api/users/123")
+	originalPath := req.URL.Path
+	originalURL := req.URL
+
+	executeHandlerWithWildcard(t, handler, "/api/", rec, req)
+
+	// Handler observed the stripped path (existing contract).
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "users/123", rec.Body.String())
+	// Caller's request pointer is unchanged: neither URL.Path nor the URL
+	// pointer itself was rewritten on the request the caller passed in.
+	assert.Equal(t, originalPath, req.URL.Path,
+		"wildcard must not mutate the caller's request URL.Path")
+	assert.Same(t, originalURL, req.URL,
+		"wildcard must not swap the caller's URL pointer")
+}
+
 func TestWildcard_RequestProcessorAbort(t *testing.T) {
 	t.Parallel()
 	var nextCalled bool

--- a/runnables/httpserver/request_processor.go
+++ b/runnables/httpserver/request_processor.go
@@ -63,3 +63,11 @@ func (rp *RequestProcessor) Request() *http.Request {
 func (rp *RequestProcessor) SetWriter(w ResponseWriter) {
 	rp.writer = w
 }
+
+// SetRequest replaces the *http.Request for the chain.
+// Middleware that needs to transform the request (e.g., strip a path prefix)
+// should clone the original via r.Clone(ctx), mutate the clone, and call
+// SetRequest with it — leaving the caller's request pointer untouched.
+func (rp *RequestProcessor) SetRequest(r *http.Request) {
+	rp.request = r
+}

--- a/runnables/httpserver/request_processor_test.go
+++ b/runnables/httpserver/request_processor_test.go
@@ -315,3 +315,27 @@ func TestRequestProcessor_SetWriter(t *testing.T) {
 	// Verify new writer is set
 	assert.Same(t, newRW, rp.Writer(), "should have new writer after SetWriter")
 }
+
+func TestRequestProcessor_SetRequest(t *testing.T) {
+	originalReq := httptest.NewRequest("GET", "/api/users/123", nil)
+	rw := newResponseWriter(httptest.NewRecorder())
+
+	rp := &RequestProcessor{
+		writer:  rw,
+		request: originalReq,
+	}
+
+	// Verify original request
+	assert.Same(t, originalReq, rp.Request(), "should initially have original request")
+
+	// Swap in a clone with a transformed path, leaving the caller's pointer untouched
+	cloned := originalReq.Clone(originalReq.Context())
+	cloned.URL.Path = "/users/123"
+	rp.SetRequest(cloned)
+
+	// Verify the new request is held and is a different pointer than the original
+	assert.Same(t, cloned, rp.Request(), "should have new request after SetRequest")
+	assert.NotSame(t, originalReq, rp.Request(), "SetRequest should not retain original pointer")
+	assert.Equal(t, "/api/users/123", originalReq.URL.Path,
+		"original request must remain unchanged")
+}


### PR DESCRIPTION
## Summary

Wildcard middleware mutated `req.URL.Path` on the shared `*http.Request` held by the `RequestProcessor`. Because all middleware in the chain see the same pointer, any code that captured `rp.Request()` before wildcard ran (deferred recovery closure, audit logger applied after wildcard, external holder of the request pointer) would later observe the stripped path.

- Added `RequestProcessor.SetRequest`, symmetric with the existing `SetWriter`, so middleware can swap in a transformed request rather than mutate the shared one.
- Updated wildcard middleware to `req.Clone(req.Context())` the request, strip the prefix on the clone, and `SetRequest` the clone before `Next`. Downstream handlers still see the stripped path; the caller's pointer is untouched.
- Added `TestWildcard_DoesNotMutateOriginalRequest` that captures both `URL.Path` and the `*url.URL` pointer before invoking the chain and asserts neither was rewritten on the caller's request after `ServeHTTP` returned.

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./runnables/httpserver/middleware/wildcard/... -count=1 -v` (new + all existing tests pass)
- [x] `go test -race ./runnables/httpserver/... -count=1 -timeout 90s` (no regressions in broader package)
- [x] `go test -race ./examples/http/... -count=5` (example app's wildcard route still works end-to-end)
- [x] CI: build + dependency-review + SonarCloud quality gate

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_