### PR TITLE
httpserver/config: validate addr, duplicate paths, timeouts

### DIFF
--- a/runnables/httpserver/config.go
+++ b/runnables/httpserver/config.go
@@ -126,23 +126,33 @@ func WithConfigCopy(src *Config) ConfigOption {
 	}
 }
 
-// NewConfig creates a new Config with the address and routes
-// plus any optional configuration via functional options
-func NewConfig(addr string, routes Routes, opts ...ConfigOption) (*Config, error) {
-	if len(routes) == 0 {
-		return nil, errors.New("routes cannot be empty")
-	}
-	if addr == "" {
-		return nil, errors.New("addr cannot be empty")
-	}
-	seen := make(map[string]struct{}, len(routes))
-	for _, r := range routes {
-		if _, dup := seen[r.Path]; dup {
-			return nil, fmt.Errorf("duplicate route path: %q", r.Path)
+// validateRoutePatterns surfaces http.ServeMux pattern conflicts at
+// construction time by pre-registering each route against a throwaway mux.
+// ServeMux.Handle panics on identical patterns and (Go 1.22+) on conflicting
+// patterns where neither is more specific (e.g. "/a/{x}/b" vs "/a/y/{z}");
+// running the same registration here lets us recover that panic and return
+// it as a normal error instead of letting the server crash at start.
+func validateRoutePatterns(routes Routes) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("invalid or conflicting route patterns: %v", r)
 		}
-		seen[r.Path] = struct{}{}
+	}()
+	mux := http.NewServeMux()
+	noopHandler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+	for _, route := range routes {
+		mux.Handle(route.Path, noopHandler)
 	}
+	return nil
+}
 
+// NewConfig creates a new Config with the address and routes
+// plus any optional configuration via functional options.
+//
+// All validation runs after the supplied ConfigOptions have been applied,
+// so options that mutate Routes/ListenAddr/timeouts are still bound by the
+// same checks as the caller's positional arguments.
+func NewConfig(addr string, routes Routes, opts ...ConfigOption) (*Config, error) {
 	// Use constants for default values
 	c := &Config{
 		ListenAddr:    addr,
@@ -160,6 +170,31 @@ func NewConfig(addr string, routes Routes, opts ...ConfigOption) (*Config, error
 		opt(c)
 	}
 
+	if len(c.Routes) == 0 {
+		return nil, errors.New("routes cannot be empty")
+	}
+	if c.ListenAddr == "" {
+		return nil, errors.New("addr cannot be empty")
+	}
+	// Byte-for-byte duplicates: report every duplicated path, not just the first,
+	// so a config with several typos surfaces them all at once. Each duplicated
+	// path is reported once regardless of how many copies appear.
+	seen := make(map[string]int, len(c.Routes))
+	var dupErrs []error
+	for _, r := range c.Routes {
+		seen[r.Path]++
+		if seen[r.Path] == 2 {
+			dupErrs = append(dupErrs, fmt.Errorf("duplicate route path: %q", r.Path))
+		}
+	}
+	if len(dupErrs) > 0 {
+		return nil, errors.Join(dupErrs...)
+	}
+	// Go 1.22+ http.ServeMux also panics on overlapping non-identical patterns
+	// (e.g. "/a/{x}/b" vs "/a/y/{z}"); validateRoutePatterns catches that class.
+	if err := validateRoutePatterns(c.Routes); err != nil {
+		return nil, err
+	}
 	if c.DrainTimeout < 0 {
 		return nil, fmt.Errorf("DrainTimeout must be >= 0, got %s", c.DrainTimeout)
 	}

--- a/runnables/httpserver/config.go
+++ b/runnables/httpserver/config.go
@@ -132,6 +132,16 @@ func NewConfig(addr string, routes Routes, opts ...ConfigOption) (*Config, error
 	if len(routes) == 0 {
 		return nil, errors.New("routes cannot be empty")
 	}
+	if addr == "" {
+		return nil, errors.New("addr cannot be empty")
+	}
+	seen := make(map[string]struct{}, len(routes))
+	for _, r := range routes {
+		if _, dup := seen[r.Path]; dup {
+			return nil, fmt.Errorf("duplicate route path: %q", r.Path)
+		}
+		seen[r.Path] = struct{}{}
+	}
 
 	// Use constants for default values
 	c := &Config{
@@ -148,6 +158,19 @@ func NewConfig(addr string, routes Routes, opts ...ConfigOption) (*Config, error
 	// Apply overrides from the functional options
 	for _, opt := range opts {
 		opt(c)
+	}
+
+	if c.DrainTimeout < 0 {
+		return nil, fmt.Errorf("DrainTimeout must be >= 0, got %s", c.DrainTimeout)
+	}
+	if c.ReadTimeout < 0 {
+		return nil, fmt.Errorf("ReadTimeout must be >= 0, got %s", c.ReadTimeout)
+	}
+	if c.WriteTimeout < 0 {
+		return nil, fmt.Errorf("WriteTimeout must be >= 0, got %s", c.WriteTimeout)
+	}
+	if c.IdleTimeout < 0 {
+		return nil, fmt.Errorf("IdleTimeout must be >= 0, got %s", c.IdleTimeout)
 	}
 
 	return c, nil

--- a/runnables/httpserver/config_test.go
+++ b/runnables/httpserver/config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -705,6 +706,57 @@ func TestNewConfig(t *testing.T) {
 			expectedStr: "",
 		},
 		{
+			name: "MultipleDuplicates",
+			// Three duplicated paths in one slice; errors.Join should report
+			// each once (not "first dup, then return"). /unique appears once
+			// and must NOT be reported.
+			addr: ":8080",
+			routes: func() Routes {
+				h := func(w http.ResponseWriter, r *http.Request) {}
+				mk := func(name, path string) Route {
+					r, err := NewRouteFromHandlerFunc(name, path, h)
+					if err != nil {
+						panic(err)
+					}
+					return *r
+				}
+				return Routes{
+					mk("v1", "/a"),
+					mk("v2", "/a"),
+					mk("v3", "/a"),
+					mk("v4", "/b"),
+					mk("v5", "/b"),
+					mk("v6", "/unique"),
+				}
+			}(),
+			opts:        nil,
+			expectError: true,
+			expectedStr: "",
+		},
+		{
+			name: "ConflictingPatterns",
+			// Go 1.22+ http.ServeMux: "/a/{x}/b" and "/a/y/{z}" both match
+			// "/a/y/b" with neither more specific. ServeMux panics on the
+			// second registration; validateRoutePatterns turns that into an
+			// error here.
+			addr: ":8080",
+			routes: func() Routes {
+				h := func(w http.ResponseWriter, r *http.Request) {}
+				r1, err := NewRouteFromHandlerFunc("v1", "/a/{x}/b", h)
+				if err != nil {
+					panic(err)
+				}
+				r2, err := NewRouteFromHandlerFunc("v2", "/a/y/{z}", h)
+				if err != nil {
+					panic(err)
+				}
+				return Routes{*r1, *r2}
+			}(),
+			opts:        nil,
+			expectError: true,
+			expectedStr: "",
+		},
+		{
 			name: "NegativeReadTimeout",
 			addr: ":8080",
 			routes: func() Routes {
@@ -898,4 +950,40 @@ func TestWithConfigCopy(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNewConfig_MultipleDuplicatesAccumulate verifies that NewConfig surfaces
+// every duplicated route path via errors.Join, not just the first one. This
+// gives users a complete picture in a single failed-config message instead of
+// forcing them to fix one typo, retry, fix the next, retry, etc.
+func TestNewConfig_MultipleDuplicatesAccumulate(t *testing.T) {
+	t.Parallel()
+	h := func(w http.ResponseWriter, r *http.Request) {}
+	mk := func(name, path string) Route {
+		r, err := NewRouteFromHandlerFunc(name, path, h)
+		require.NoError(t, err)
+		return *r
+	}
+	routes := Routes{
+		mk("v1", "/a"),
+		mk("v2", "/a"),
+		mk("v3", "/a"),
+		mk("v4", "/b"),
+		mk("v5", "/b"),
+		mk("v6", "/unique"),
+	}
+
+	config, err := NewConfig(":8080", routes)
+	require.Error(t, err)
+	assert.Nil(t, config)
+
+	msg := err.Error()
+	assert.Contains(t, msg, `"/a"`, "joined error should mention /a")
+	assert.Contains(t, msg, `"/b"`, "joined error should mention /b")
+	assert.NotContains(t, msg, `"/unique"`, "non-duplicated path must not be reported")
+	// Each duplicated path appears exactly once regardless of copy count.
+	assert.Equal(t, 1, strings.Count(msg, `"/a"`),
+		"duplicated path /a should be reported once even with 3 copies")
+	assert.Equal(t, 1, strings.Count(msg, `"/b"`),
+		"duplicated path /b should be reported once even with 2 copies")
 }

--- a/runnables/httpserver/config_test.go
+++ b/runnables/httpserver/config_test.go
@@ -594,243 +594,116 @@ func TestFunctionalOptions(t *testing.T) {
 	}
 }
 
-// TestNewConfig tests that the NewConfig function creates a Config with the expected values
+// TestNewConfig tests that the NewConfig function creates a Config with the
+// expected values, and rejects every documented invalid input. Each case is
+// its own sub-test so the failure mode of one does not obscure the others.
 func TestNewConfig(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name        string
-		addr        string
-		routes      Routes
-		opts        []ConfigOption
-		expectError bool
-		expectedStr string
-	}{
-		{
-			name: "ValidConfig",
-			addr: ":8080",
-			routes: func() Routes {
-				route, err := NewRouteFromHandlerFunc(
-					"v1",
-					"/test",
-					func(w http.ResponseWriter, r *http.Request) {},
-				)
-				if err != nil {
-					panic(err)
-				}
-				return Routes{*route}
-			}(),
-			opts:        []ConfigOption{WithDrainTimeout(30 * time.Second)},
-			expectError: false,
-			expectedStr: "Config<addr=:8080, drainTimeout=30s, routes=Routes<Name: v1, Path: /test>, timeouts=[read=15s,write=15s,idle=1m0s]>",
-		},
-		{
-			name:        "EmptyRoutes",
-			addr:        ":8080",
-			routes:      Routes{},
-			opts:        nil,
-			expectError: true,
-			expectedStr: "",
-		},
-		{
-			name: "ZeroDrainTimeout",
-			addr: ":8080",
-			routes: func() Routes {
-				route, err := NewRouteFromHandlerFunc(
-					"v1",
-					"/test",
-					func(w http.ResponseWriter, r *http.Request) {},
-				)
-				if err != nil {
-					panic(err)
-				}
-				return Routes{*route}
-			}(),
-			opts:        []ConfigOption{WithDrainTimeout(0)},
-			expectError: false,
-			expectedStr: "Config<addr=:8080, drainTimeout=0s, routes=Routes<Name: v1, Path: /test>, timeouts=[read=15s,write=15s,idle=1m0s]>",
-		},
-		{
-			name: "NegativeDrainTimeout",
-			addr: ":8080",
-			routes: func() Routes {
-				route, err := NewRouteFromHandlerFunc(
-					"v1",
-					"/test",
-					func(w http.ResponseWriter, r *http.Request) {},
-				)
-				if err != nil {
-					panic(err)
-				}
-				return Routes{*route}
-			}(),
-			opts:        []ConfigOption{WithDrainTimeout(-10 * time.Second)},
-			expectError: true,
-			expectedStr: "",
-		},
-		{
-			name: "EmptyAddr",
-			addr: "",
-			routes: func() Routes {
-				route, err := NewRouteFromHandlerFunc(
-					"v1",
-					"/test",
-					func(w http.ResponseWriter, r *http.Request) {},
-				)
-				if err != nil {
-					panic(err)
-				}
-				return Routes{*route}
-			}(),
-			opts:        nil,
-			expectError: true,
-			expectedStr: "",
-		},
-		{
-			name: "DuplicatePaths",
-			addr: ":8080",
-			routes: func() Routes {
-				h := func(w http.ResponseWriter, r *http.Request) {}
-				r1, err := NewRouteFromHandlerFunc("v1", "/test", h)
-				if err != nil {
-					panic(err)
-				}
-				r2, err := NewRouteFromHandlerFunc("v2", "/test", h)
-				if err != nil {
-					panic(err)
-				}
-				return Routes{*r1, *r2}
-			}(),
-			opts:        nil,
-			expectError: true,
-			expectedStr: "",
-		},
-		{
-			name: "MultipleDuplicates",
-			// Three duplicated paths in one slice; errors.Join should report
-			// each once (not "first dup, then return"). /unique appears once
-			// and must NOT be reported.
-			addr: ":8080",
-			routes: func() Routes {
-				h := func(w http.ResponseWriter, r *http.Request) {}
-				mk := func(name, path string) Route {
-					r, err := NewRouteFromHandlerFunc(name, path, h)
-					if err != nil {
-						panic(err)
-					}
-					return *r
-				}
-				return Routes{
-					mk("v1", "/a"),
-					mk("v2", "/a"),
-					mk("v3", "/a"),
-					mk("v4", "/b"),
-					mk("v5", "/b"),
-					mk("v6", "/unique"),
-				}
-			}(),
-			opts:        nil,
-			expectError: true,
-			expectedStr: "",
-		},
-		{
-			name: "ConflictingPatterns",
-			// Go 1.22+ http.ServeMux: "/a/{x}/b" and "/a/y/{z}" both match
-			// "/a/y/b" with neither more specific. ServeMux panics on the
-			// second registration; validateRoutePatterns turns that into an
-			// error here.
-			addr: ":8080",
-			routes: func() Routes {
-				h := func(w http.ResponseWriter, r *http.Request) {}
-				r1, err := NewRouteFromHandlerFunc("v1", "/a/{x}/b", h)
-				if err != nil {
-					panic(err)
-				}
-				r2, err := NewRouteFromHandlerFunc("v2", "/a/y/{z}", h)
-				if err != nil {
-					panic(err)
-				}
-				return Routes{*r1, *r2}
-			}(),
-			opts:        nil,
-			expectError: true,
-			expectedStr: "",
-		},
-		{
-			name: "NegativeReadTimeout",
-			addr: ":8080",
-			routes: func() Routes {
-				route, err := NewRouteFromHandlerFunc(
-					"v1",
-					"/test",
-					func(w http.ResponseWriter, r *http.Request) {},
-				)
-				if err != nil {
-					panic(err)
-				}
-				return Routes{*route}
-			}(),
-			opts:        []ConfigOption{WithReadTimeout(-1 * time.Second)},
-			expectError: true,
-			expectedStr: "",
-		},
-		{
-			name: "NegativeWriteTimeout",
-			addr: ":8080",
-			routes: func() Routes {
-				route, err := NewRouteFromHandlerFunc(
-					"v1",
-					"/test",
-					func(w http.ResponseWriter, r *http.Request) {},
-				)
-				if err != nil {
-					panic(err)
-				}
-				return Routes{*route}
-			}(),
-			opts:        []ConfigOption{WithWriteTimeout(-1 * time.Second)},
-			expectError: true,
-			expectedStr: "",
-		},
-		{
-			name: "NegativeIdleTimeout",
-			addr: ":8080",
-			routes: func() Routes {
-				route, err := NewRouteFromHandlerFunc(
-					"v1",
-					"/test",
-					func(w http.ResponseWriter, r *http.Request) {},
-				)
-				if err != nil {
-					panic(err)
-				}
-				return Routes{*route}
-			}(),
-			opts:        []ConfigOption{WithIdleTimeout(-1 * time.Second)},
-			expectError: true,
-			expectedStr: "",
-		},
+	noopHandler := func(w http.ResponseWriter, r *http.Request) {}
+	mkRoute := func(t *testing.T, name, path string) Route {
+		t.Helper()
+		r, err := NewRouteFromHandlerFunc(name, path, noopHandler)
+		require.NoError(t, err)
+		return *r
+	}
+	singleRoute := func(t *testing.T) Routes {
+		t.Helper()
+		return Routes{mkRoute(t, "v1", "/test")}
 	}
 
-	for _, tt := range tests {
-		tt := tt // capture range variable
-		t.Run(tt.name, func(t *testing.T) {
-			config, err := NewConfig(tt.addr, tt.routes, tt.opts...)
-			if tt.expectError {
-				require.Error(t, err)
-				assert.Nil(t, config)
-			} else {
-				require.NoError(t, err)
-				assert.NotNil(t, config)
-				assert.Equal(t, tt.addr, config.ListenAddr)
-				// DrainTimeout is now set via options
-				assert.Equal(t, tt.routes, config.Routes)
-				// Test Config.String()
-				assert.Equal(t, tt.expectedStr, config.String())
-			}
+	t.Run("ValidConfig", func(t *testing.T) {
+		t.Parallel()
+		routes := singleRoute(t)
+		cfg, err := NewConfig(":8080", routes, WithDrainTimeout(30*time.Second))
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t, ":8080", cfg.ListenAddr)
+		assert.Equal(t, routes, cfg.Routes)
+		assert.Equal(t,
+			"Config<addr=:8080, drainTimeout=30s, routes=Routes<Name: v1, Path: /test>, timeouts=[read=15s,write=15s,idle=1m0s]>",
+			cfg.String(),
+		)
+	})
+
+	t.Run("ZeroDrainTimeout", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewConfig(":8080", singleRoute(t), WithDrainTimeout(0))
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+		assert.Equal(t,
+			"Config<addr=:8080, drainTimeout=0s, routes=Routes<Name: v1, Path: /test>, timeouts=[read=15s,write=15s,idle=1m0s]>",
+			cfg.String(),
+		)
+	})
+
+	t.Run("EmptyRoutes", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewConfig(":8080", Routes{})
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("EmptyAddr", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewConfig("", singleRoute(t))
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("NegativeDrainTimeout", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewConfig(":8080", singleRoute(t), WithDrainTimeout(-10*time.Second))
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("NegativeReadTimeout", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewConfig(":8080", singleRoute(t), WithReadTimeout(-1*time.Second))
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("NegativeWriteTimeout", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewConfig(":8080", singleRoute(t), WithWriteTimeout(-1*time.Second))
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("NegativeIdleTimeout", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewConfig(":8080", singleRoute(t), WithIdleTimeout(-1*time.Second))
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("DuplicatePaths", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := NewConfig(":8080", Routes{
+			mkRoute(t, "v1", "/test"),
+			mkRoute(t, "v2", "/test"),
 		})
-	}
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("ConflictingPatterns", func(t *testing.T) {
+		t.Parallel()
+		// Go 1.22+ http.ServeMux: "/a/{x}/b" and "/a/y/{z}" both match
+		// "/a/y/b" with neither more specific. ServeMux panics on the
+		// second registration; validateRoutePatterns surfaces it as an
+		// error here.
+		cfg, err := NewConfig(":8080", Routes{
+			mkRoute(t, "v1", "/a/{x}/b"),
+			mkRoute(t, "v2", "/a/y/{z}"),
+		})
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+	})
 }
+
 
 // TestWithConfigCopy tests that the WithConfigCopy option correctly copies settings
 func TestWithConfigCopy(t *testing.T) {

--- a/runnables/httpserver/config_test.go
+++ b/runnables/httpserver/config_test.go
@@ -664,8 +664,99 @@ func TestNewConfig(t *testing.T) {
 				return Routes{*route}
 			}(),
 			opts:        []ConfigOption{WithDrainTimeout(-10 * time.Second)},
-			expectError: false,
-			expectedStr: "Config<addr=:8080, drainTimeout=-10s, routes=Routes<Name: v1, Path: /test>, timeouts=[read=15s,write=15s,idle=1m0s]>",
+			expectError: true,
+			expectedStr: "",
+		},
+		{
+			name: "EmptyAddr",
+			addr: "",
+			routes: func() Routes {
+				route, err := NewRouteFromHandlerFunc(
+					"v1",
+					"/test",
+					func(w http.ResponseWriter, r *http.Request) {},
+				)
+				if err != nil {
+					panic(err)
+				}
+				return Routes{*route}
+			}(),
+			opts:        nil,
+			expectError: true,
+			expectedStr: "",
+		},
+		{
+			name: "DuplicatePaths",
+			addr: ":8080",
+			routes: func() Routes {
+				h := func(w http.ResponseWriter, r *http.Request) {}
+				r1, err := NewRouteFromHandlerFunc("v1", "/test", h)
+				if err != nil {
+					panic(err)
+				}
+				r2, err := NewRouteFromHandlerFunc("v2", "/test", h)
+				if err != nil {
+					panic(err)
+				}
+				return Routes{*r1, *r2}
+			}(),
+			opts:        nil,
+			expectError: true,
+			expectedStr: "",
+		},
+		{
+			name: "NegativeReadTimeout",
+			addr: ":8080",
+			routes: func() Routes {
+				route, err := NewRouteFromHandlerFunc(
+					"v1",
+					"/test",
+					func(w http.ResponseWriter, r *http.Request) {},
+				)
+				if err != nil {
+					panic(err)
+				}
+				return Routes{*route}
+			}(),
+			opts:        []ConfigOption{WithReadTimeout(-1 * time.Second)},
+			expectError: true,
+			expectedStr: "",
+		},
+		{
+			name: "NegativeWriteTimeout",
+			addr: ":8080",
+			routes: func() Routes {
+				route, err := NewRouteFromHandlerFunc(
+					"v1",
+					"/test",
+					func(w http.ResponseWriter, r *http.Request) {},
+				)
+				if err != nil {
+					panic(err)
+				}
+				return Routes{*route}
+			}(),
+			opts:        []ConfigOption{WithWriteTimeout(-1 * time.Second)},
+			expectError: true,
+			expectedStr: "",
+		},
+		{
+			name: "NegativeIdleTimeout",
+			addr: ":8080",
+			routes: func() Routes {
+				route, err := NewRouteFromHandlerFunc(
+					"v1",
+					"/test",
+					func(w http.ResponseWriter, r *http.Request) {},
+				)
+				if err != nil {
+					panic(err)
+				}
+				return Routes{*route}
+			}(),
+			opts:        []ConfigOption{WithIdleTimeout(-1 * time.Second)},
+			expectError: true,
+			expectedStr: "",
 		},
 	}
 

--- a/runnables/httpserver/config_test.go
+++ b/runnables/httpserver/config_test.go
@@ -704,7 +704,6 @@ func TestNewConfig(t *testing.T) {
 	})
 }
 
-
 // TestWithConfigCopy tests that the WithConfigCopy option correctly copies settings
 func TestWithConfigCopy(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

`NewConfig` only checked that routes was non-empty. Three real invariants slipped through and surfaced later as panics or generic errors:

- **Empty `addr`** → generic `net.Listen` error at server start.
- **Duplicate route paths** → `http.ServeMux.Handle` panics on duplicate pattern registration when `getMux` runs at server start.
- **Negative timeouts** (DrainTimeout / ReadTimeout / WriteTimeout / IdleTimeout) → previously accepted, then misbehave inside stdlib `http`.

Added validation in `NewConfig`: addr non-empty, no duplicate `Route.Path`, and all four timeouts `>= 0`. Zero remains valid: `DrainTimeout=0` means "no drain wait"; `Read/Write/IdleTimeout=0` means "no timeout" per stdlib.

⚠️ **Behavior change**: `NewConfig` now rejects negative `DrainTimeout`. The existing `NegativeDrainTimeout` test contract (which asserted `-10s` returned no error) is intentionally flipped from `expectError:false` to `true`. Five new test cases cover the new error branches.

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./runnables/httpserver/... -count=1 -timeout 90s`
- [x] `go test -race ./examples/http/... -count=5`
- [x] `go tool cover -func` confirms `NewConfig` at 100% in package
- [x] CI: build + dependency-review + SonarCloud quality gate

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_