### PR TITLE
mocks: move runnables/mocks to internal/mocks

### DIFF
--- a/internal/mocks/mocks.go
+++ b/internal/mocks/mocks.go
@@ -12,7 +12,7 @@
 //
 //		"github.com/stretchr/testify/mock"
 //
-//		"github.com/robbyt/go-supervisor/runnables/mocks"
+//		"github.com/robbyt/go-supervisor/internal/mocks"
 //		"github.com/robbyt/go-supervisor/supervisor"
 //	)
 //

--- a/internal/mocks/mocks_test.go
+++ b/internal/mocks/mocks_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/robbyt/go-supervisor/supervisor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/runnables/composite/config_test.go
+++ b/runnables/composite/config_test.go
@@ -3,7 +3,7 @@ package composite
 import (
 	"testing"
 
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/runnables/composite/integration_race_test.go
+++ b/runnables/composite/integration_race_test.go
@@ -7,7 +7,7 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/runnables/composite/reload_test.go
+++ b/runnables/composite/reload_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/runnables/composite/runner_run_test.go
+++ b/runnables/composite/runner_run_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/runnables/composite/runner_test.go
+++ b/runnables/composite/runner_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/robbyt/go-supervisor/supervisor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/runnables/composite/state_test.go
+++ b/runnables/composite/state_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/robbyt/go-supervisor/supervisor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/runnables/httpcluster/integration_test.go
+++ b/runnables/httpcluster/integration_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/robbyt/go-supervisor/internal/networking"
 	"github.com/robbyt/go-supervisor/runnables/httpserver"
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/runnables/httpcluster/integration_test.go
+++ b/runnables/httpcluster/integration_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/robbyt/go-supervisor/internal/networking"
 	"github.com/robbyt/go-supervisor/runnables/httpserver"
-	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/runnables/httpcluster/runner_context_test.go
+++ b/runnables/httpcluster/runner_context_test.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
-	"github.com/robbyt/go-supervisor/runnables/httpserver"
 	"github.com/robbyt/go-supervisor/internal/mocks"
+	"github.com/robbyt/go-supervisor/runnables/httpserver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/runnables/httpcluster/runner_context_test.go
+++ b/runnables/httpcluster/runner_context_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
 	"github.com/robbyt/go-supervisor/runnables/httpserver"
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/runnables/httpcluster/runner_failure_test.go
+++ b/runnables/httpcluster/runner_failure_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
-	"github.com/robbyt/go-supervisor/runnables/httpserver"
 	"github.com/robbyt/go-supervisor/internal/mocks"
+	"github.com/robbyt/go-supervisor/runnables/httpserver"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )

--- a/runnables/httpcluster/runner_failure_test.go
+++ b/runnables/httpcluster/runner_failure_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
 	"github.com/robbyt/go-supervisor/runnables/httpserver"
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )

--- a/runnables/httpcluster/runner_test.go
+++ b/runnables/httpcluster/runner_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/robbyt/go-supervisor/internal/finitestate"
 	"github.com/robbyt/go-supervisor/internal/networking"
 	"github.com/robbyt/go-supervisor/runnables/httpserver"
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/runnables/httpcluster/runner_test.go
+++ b/runnables/httpcluster/runner_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/robbyt/go-supervisor/internal/networking"
 	"github.com/robbyt/go-supervisor/runnables/httpserver"
-	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/supervisor/interfaces_test.go
+++ b/supervisor/interfaces_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )

--- a/supervisor/reload_test.go
+++ b/supervisor/reload_test.go
@@ -14,7 +14,7 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/supervisor/shutdown_test.go
+++ b/supervisor/shutdown_test.go
@@ -6,7 +6,7 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/supervisor/state_deduplication_test.go
+++ b/supervisor/state_deduplication_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"testing/synctest"
 
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/supervisor/state_monitoring_test.go
+++ b/supervisor/state_monitoring_test.go
@@ -6,7 +6,7 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/supervisor/state_test.go
+++ b/supervisor/state_test.go
@@ -3,7 +3,7 @@ package supervisor
 import (
 	"testing"
 
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
## Summary

The mocks package sat at `runnables/mocks/`, a non-`internal/` path. Even though it has never been advertised in README/CHANGELOG/examples and only in-repo test code imports it, the path made it de-facto public surface — an external consumer could import it and lock the API.

Move the package under `internal/` so the path itself signals "not public" and Go tooling blocks out-of-module importers.

Mechanical change:
- `git mv runnables/mocks/{mocks,mocks_test}.go internal/mocks/` (rename detection preserves history)
- update the docstring example inside `mocks.go` and the import inside `mocks_test.go`
- update import paths in 17 in-repo test files across `supervisor/`, `runnables/composite/`, `runnables/httpcluster/`

Package name stays `mocks`, so every existing call site (`mocks.NewMockRunnable(...)` etc.) keeps compiling unchanged.

⚠️ **Breaking change for any external consumer importing `github.com/robbyt/go-supervisor/runnables/mocks`.** None known. Justified by pre-1.0 SemVer (latest tag `v0.0.21`).

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test -race ./... -count=1 -timeout 120s` (every package green, including `internal/mocks` at the new path)
- [x] `grep -rn 'runnables/mocks' . --include='*.go'` returns zero matches
- [x] CI: build + dependency-review + SonarCloud quality gate

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_