### PR TITLE
httpserver/recovery: handle panic after headers written

### DIFF
--- a/runnables/httpserver/middleware/recovery/recovery.go
+++ b/runnables/httpserver/middleware/recovery/recovery.go
@@ -38,7 +38,9 @@ func New(handler slog.Handler) httpserver.HandlerFunc {
 
 				if headersWritten {
 					// Status is committed; preserve the partial response and
-					// flush any buffered body so the client doesn't hang.
+					// best-effort flush any buffered body so the client doesn't
+					// hang. The wrapper's Flush is a no-op when the underlying
+					// writer doesn't implement http.Flusher.
 					if f, ok := writer.(http.Flusher); ok {
 						f.Flush()
 					}

--- a/runnables/httpserver/middleware/recovery/recovery.go
+++ b/runnables/httpserver/middleware/recovery/recovery.go
@@ -7,32 +7,44 @@ import (
 	"github.com/robbyt/go-supervisor/runnables/httpserver"
 )
 
-// New creates a middleware that recovers from panics in HTTP handlers.
-// It returns a 500 Internal Server Error response when panics occur.
-// If handler is provided, panics are logged. If handler is nil, recovery is silent.
+// New creates a middleware that recovers from panics in HTTP handlers,
+// writes a 500 Internal Server Error response, and aborts the chain.
+// When handler is non-nil, the recovered panic is logged at Error level.
+//
+// Note: if the handler panics AFTER it has already called WriteHeader or
+// Write, the response status is already committed and cannot be replaced
+// with 500. In that case the middleware preserves the partial response
+// and flushes any pending data so the client is not left waiting; the
+// panic still appears in the log with headers_written=true so operators
+// can identify the request.
+//
+// If handler is nil, recovery is silent.
 func New(handler slog.Handler) httpserver.HandlerFunc {
-	// Default logger that does nothing if no handler is provided
-	// This allows the middleware to be used without logging if passed a nil handler.
-	logger := func(err any, path string, method string) {}
-
-	if handler != nil {
-		logger = func(err any, path string, method string) {
-			slogger := slog.New(handler)
-			slogger.Error("HTTP handler panic recovered",
-				"error", err,
-				"path", path,
-				"method", method,
-			)
-		}
-	}
-
 	return func(rp *httpserver.RequestProcessor) {
 		defer func() {
 			if err := recover(); err != nil {
 				req := rp.Request()
 				writer := rp.Writer()
-				logger(err, req.URL.Path, req.Method)
-				http.Error(writer, "Internal Server Error", http.StatusInternalServerError)
+				headersWritten := writer.Written()
+
+				if handler != nil {
+					slog.New(handler).Error("HTTP handler panic recovered",
+						"error", err,
+						"path", req.URL.Path,
+						"method", req.Method,
+						"headers_written", headersWritten,
+					)
+				}
+
+				if headersWritten {
+					// Status is committed; preserve the partial response and
+					// flush any buffered body so the client doesn't hang.
+					if f, ok := writer.(http.Flusher); ok {
+						f.Flush()
+					}
+				} else {
+					http.Error(writer, "Internal Server Error", http.StatusInternalServerError)
+				}
 				rp.Abort()
 			}
 		}()

--- a/runnables/httpserver/middleware/recovery/recovery_test.go
+++ b/runnables/httpserver/middleware/recovery/recovery_test.go
@@ -91,7 +91,7 @@ func TestRecoveryMiddleware(t *testing.T) {
 
 	t.Run("preserves partial response when panic happens after WriteHeader", func(t *testing.T) {
 		logBuffer, logHandler := setupLogBuffer(t, slog.LevelError)
-		rec, req := setupRequest(t, "GET", "/partial")
+		rec, req := setupRequest(t, "GET", "/test")
 		handler := func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte("partial body"))

--- a/runnables/httpserver/middleware/recovery/recovery_test.go
+++ b/runnables/httpserver/middleware/recovery/recovery_test.go
@@ -86,6 +86,35 @@ func TestRecoveryMiddleware(t *testing.T) {
 		assert.Contains(t, logOutput, "error=\"test panic\"")
 		assert.Contains(t, logOutput, "path=/test")
 		assert.Contains(t, logOutput, "method=GET")
+		assert.Contains(t, logOutput, "headers_written=false")
+	})
+
+	t.Run("preserves partial response when panic happens after WriteHeader", func(t *testing.T) {
+		logBuffer, logHandler := setupLogBuffer(t, slog.LevelError)
+		rec, req := setupRequest(t, "GET", "/partial")
+		handler := func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("partial body"))
+			require.NoError(t, err)
+			panic("panic after writing")
+		}
+
+		executeHandlerWithRecovery(t, handler, logHandler, rec, req)
+
+		// Status and body must NOT be overwritten by Internal Server Error;
+		// http.Error would silently fail to set the status (already committed)
+		// and would append "Internal Server Error\n" to the partial body.
+		assert.Equal(t, http.StatusOK, rec.Code,
+			"committed status must be preserved")
+		assert.Equal(t, "partial body", rec.Body.String(),
+			"partial body must not be appended with Internal Server Error")
+		assert.True(t, rec.Flushed,
+			"recovery should Flush() so the client doesn't hang")
+
+		logOutput := logBuffer.String()
+		assert.Contains(t, logOutput, "HTTP handler panic recovered")
+		assert.Contains(t, logOutput, "error=\"panic after writing\"")
+		assert.Contains(t, logOutput, "headers_written=true")
 	})
 
 	t.Run("recovers from panic silently with nil handler", func(t *testing.T) {

--- a/runnables/httpserver/middleware/recovery/recovery_test.go
+++ b/runnables/httpserver/middleware/recovery/recovery_test.go
@@ -95,7 +95,7 @@ func TestRecoveryMiddleware(t *testing.T) {
 		handler := func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte("partial body"))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			panic("panic after writing")
 		}
 

--- a/runnables/httpserver/response_writer.go
+++ b/runnables/httpserver/response_writer.go
@@ -93,3 +93,11 @@ func (rw *responseWriter) Written() bool {
 func (rw *responseWriter) Size() int {
 	return rw.size
 }
+
+// Flush implements http.Flusher when the underlying writer supports it,
+// pushing any pending response data to the client. No-op otherwise.
+func (rw *responseWriter) Flush() {
+	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/runnables/httpserver/response_writer_test.go
+++ b/runnables/httpserver/response_writer_test.go
@@ -311,6 +311,28 @@ func TestResponseWriter_PartialWrite(t *testing.T) {
 	assert.Equal(t, 5, rw.Size(), "size should match actual bytes written, not requested")
 }
 
+func TestResponseWriter_Flush(t *testing.T) {
+	t.Run("delegates to wrapped Flusher", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		rw := newResponseWriter(recorder)
+
+		require.Implements(t, (*http.Flusher)(nil), rw,
+			"wrapper should satisfy http.Flusher")
+		rw.(http.Flusher).Flush()
+		assert.True(t, recorder.Flushed,
+			"underlying recorder should observe Flush call")
+	})
+
+	t.Run("no-op when wrapped writer is not a Flusher", func(t *testing.T) {
+		rw := newResponseWriter(&failingResponseWriter{})
+
+		require.Implements(t, (*http.Flusher)(nil), rw)
+		assert.NotPanics(t, func() {
+			rw.(http.Flusher).Flush()
+		}, "Flush should be a safe no-op when wrapped writer lacks Flush")
+	})
+}
+
 // Helper types for testing error conditions
 
 type failingResponseWriter struct {


### PR DESCRIPTION
## Summary

- Recovery middleware now detects when the handler has already called `WriteHeader`/`Write` before panicking and preserves the partial response instead of corrupting it. Previously, `http.Error` silently failed to overwrite the committed status while still appending `"Internal Server Error\n"` to the partial body.
- The recovered panic is logged with a new `headers_written` field so operators can identify requests where the response is partial.
- `responseWriter` gains a `Flush()` method that delegates to the wrapped `http.Flusher` when available (no-op otherwise) — required so the type assertion in recovery succeeds across the interface-embedded wrapper.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -race ./runnables/httpserver/middleware/recovery/... -count=1 -timeout 60s` green; new test `preserves partial response when panic happens after WriteHeader` passes
- [x] `go test -race ./runnables/httpserver/... -count=1 -timeout 90s` green; new `TestResponseWriter_Flush` covers both delegated and no-op cases
- [x] `go test -race ./... -count=1 -timeout 300s` full repo green

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_