### PR TITLE
supervisor: bound state-monitor shutdown wait

### DIFF
--- a/supervisor/state.go
+++ b/supervisor/state.go
@@ -180,9 +180,6 @@ func (p *PIDZero) broadcastState() {
 // is a safety net that prevents a misbehaving Stateable from blocking supervisor
 // shutdown indefinitely. Hitting the bound logs a Warn and returns. A bound of 0
 // disables the deadline (waits indefinitely).
-// startStateMonitor initiates background goroutines to monitor state changes for each
-// Stateable runnable. It blocks until the context is done, coordinating state updates
-// from all state-emitting services.
 func (p *PIDZero) startStateMonitor() {
 	p.logger.Debug("Starting state monitor...")
 

--- a/supervisor/state.go
+++ b/supervisor/state.go
@@ -19,7 +19,17 @@ package supervisor
 import (
 	"context"
 	"sync"
+	"time"
 )
+
+// stateMonitorShutdownTimeout caps how long startStateMonitor waits for its
+// per-runnable monitoring goroutines to exit after the supervisor context
+// is canceled. Hitting this bound logs a Warn and returns; the leaked
+// goroutines are bounded by the broader Go runtime lifetime. 5s matches
+// internal/finitestate.Machine.GetStateChan's per-broadcast timeout for
+// symmetry. Declared as var (not const) so tests can substitute a smaller
+// value via t.Cleanup; production callers must not modify it.
+var stateMonitorShutdownTimeout = 5 * time.Second
 
 // StateMap is a map of runnable string representation to its current state
 type StateMap map[string]string
@@ -171,6 +181,12 @@ func (p *PIDZero) broadcastState() {
 // State deduplication works by comparing incoming states against the previously recorded state.
 // Only when a state differs from the previous one is it stored and broadcast, preventing
 // unnecessary broadcasts and reducing system load when runnables emit frequent duplicate states.
+//
+// Shutdown: when the supervisor context is canceled, startStateMonitor waits up to
+// stateMonitorShutdownTimeout (5s) for its per-runnable goroutines to exit. Healthy
+// goroutines exit promptly because their inner select listens on ctx.Done(); the bound
+// is a safety net that prevents a misbehaving Stateable from blocking supervisor
+// shutdown indefinitely. Hitting the bound logs a Warn and returns.
 // startStateMonitor initiates background goroutines to monitor state changes for each
 // Stateable runnable. It blocks until the context is done, coordinating state updates
 // from all state-emitting services.
@@ -247,9 +263,35 @@ func (p *PIDZero) startStateMonitor() {
 		}
 	}
 
-	// Block here until context is done, then wait for all monitoring goroutines to finish
+	// Block here until context is done, then bounded-wait for all monitoring
+	// goroutines to finish. The bound prevents a misbehaving Stateable from
+	// blocking supervisor shutdown indefinitely; see stateMonitorShutdownTimeout.
 	<-p.ctx.Done()
 	p.logger.Debug("State monitor received context done signal, waiting for monitors to exit...")
-	stateWg.Wait()
-	p.logger.Debug("State monitor complete.")
+	p.boundedWaitOnStateGoroutines(&stateWg)
+}
+
+// boundedWaitOnStateGoroutines waits up to stateMonitorShutdownTimeout for
+// wg to reach zero. Hitting the bound logs a Warn and returns; the leaked
+// goroutines remain bound by the broader Go runtime lifetime. Extracted
+// from startStateMonitor for direct testing of the timer.C branch under
+// testing/synctest.
+func (p *PIDZero) boundedWaitOnStateGoroutines(wg *sync.WaitGroup) {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	timer := time.NewTimer(stateMonitorShutdownTimeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+		p.logger.Debug("State monitor complete.")
+	case <-timer.C:
+		p.logger.Warn(
+			"State monitor shutdown deadline exceeded; leaking monitor goroutines",
+			"timeout", stateMonitorShutdownTimeout,
+		)
+	}
 }

--- a/supervisor/state.go
+++ b/supervisor/state.go
@@ -22,15 +22,6 @@ import (
 	"time"
 )
 
-// stateMonitorShutdownTimeout caps how long startStateMonitor waits for its
-// per-runnable monitoring goroutines to exit after the supervisor context
-// is canceled. Hitting this bound logs a Warn and returns; the leaked
-// goroutines are bounded by the broader Go runtime lifetime. 5s matches
-// internal/finitestate.Machine.GetStateChan's per-broadcast timeout for
-// symmetry. Declared as var (not const) so tests can substitute a smaller
-// value via t.Cleanup; production callers must not modify it.
-var stateMonitorShutdownTimeout = 5 * time.Second
-
 // StateMap is a map of runnable string representation to its current state
 type StateMap map[string]string
 
@@ -183,10 +174,12 @@ func (p *PIDZero) broadcastState() {
 // unnecessary broadcasts and reducing system load when runnables emit frequent duplicate states.
 //
 // Shutdown: when the supervisor context is canceled, startStateMonitor waits up to
-// stateMonitorShutdownTimeout (5s) for its per-runnable goroutines to exit. Healthy
+// p.stateMonitorShutdownTimeout (default 5s, configurable via
+// WithStateMonitorShutdownTimeout) for its per-runnable goroutines to exit. Healthy
 // goroutines exit promptly because their inner select listens on ctx.Done(); the bound
 // is a safety net that prevents a misbehaving Stateable from blocking supervisor
-// shutdown indefinitely. Hitting the bound logs a Warn and returns.
+// shutdown indefinitely. Hitting the bound logs a Warn and returns. A bound of 0
+// disables the deadline (waits indefinitely).
 // startStateMonitor initiates background goroutines to monitor state changes for each
 // Stateable runnable. It blocks until the context is done, coordinating state updates
 // from all state-emitting services.
@@ -271,19 +264,26 @@ func (p *PIDZero) startStateMonitor() {
 	p.boundedWaitOnStateGoroutines(&stateWg)
 }
 
-// boundedWaitOnStateGoroutines waits up to stateMonitorShutdownTimeout for
-// wg to reach zero. Hitting the bound logs a Warn and returns; the leaked
-// goroutines remain bound by the broader Go runtime lifetime. Extracted
-// from startStateMonitor for direct testing of the timer.C branch under
+// boundedWaitOnStateGoroutines waits up to p.stateMonitorShutdownTimeout
+// for wg to reach zero. Hitting the bound logs a Warn and returns; the
+// leaked goroutines remain bound by the broader Go runtime lifetime. A
+// timeout of 0 disables the deadline (waits indefinitely). Extracted from
+// startStateMonitor for direct testing of the timer.C branch under
 // testing/synctest.
 func (p *PIDZero) boundedWaitOnStateGoroutines(wg *sync.WaitGroup) {
+	if p.stateMonitorShutdownTimeout == 0 {
+		wg.Wait()
+		p.logger.Debug("State monitor complete.")
+		return
+	}
+
 	done := make(chan struct{})
 	go func() {
 		wg.Wait()
 		close(done)
 	}()
 
-	timer := time.NewTimer(stateMonitorShutdownTimeout)
+	timer := time.NewTimer(p.stateMonitorShutdownTimeout)
 	defer timer.Stop()
 	select {
 	case <-done:
@@ -291,7 +291,7 @@ func (p *PIDZero) boundedWaitOnStateGoroutines(wg *sync.WaitGroup) {
 	case <-timer.C:
 		p.logger.Warn(
 			"State monitor shutdown deadline exceeded; leaking monitor goroutines",
-			"timeout", stateMonitorShutdownTimeout,
+			"timeout", p.stateMonitorShutdownTimeout,
 		)
 	}
 }

--- a/supervisor/state.go
+++ b/supervisor/state.go
@@ -183,82 +183,103 @@ func (p *PIDZero) broadcastState() {
 func (p *PIDZero) startStateMonitor() {
 	p.logger.Debug("Starting state monitor...")
 
-	// Create a WaitGroup to track state monitoring goroutines
-	var stateWg sync.WaitGroup
-
-	// Start a goroutine for each Stateable runnable
+	var wg sync.WaitGroup
 	for _, run := range p.runnables {
 		if stateable, ok := run.(Stateable); ok {
-			stateWg.Add(1)
-			go func(r Runnable, s Stateable) {
-				defer stateWg.Done()
-				stateChan := s.GetStateChan(p.ctx)
-
-				// Read the first state and discard it - it's the initial state
-				// that we've already captured and stored manually in startRunnable
-				select {
-				case <-p.ctx.Done():
-					return
-				case state, ok := <-stateChan:
-					if !ok {
-						return
-					}
-					// First state discarded to avoid duplicate broadcast
-					p.logger.Debug("Discarded initial state", "runnable", r, "state", state)
-				}
-
-				// Keep track of the last state to avoid duplicate broadcasts
-				var lastState string
-				if currentState, ok := p.stateMap.Load(r); ok {
-					lastState = currentState.(string)
-				}
-
-				// Process state changes until context is done
-				for {
-					select {
-					case <-p.ctx.Done():
-						return
-					case state, ok := <-stateChan:
-						if !ok {
-							return
-						}
-
-						if state == lastState {
-							p.logger.Debug(
-								"Received duplicate state (ignoring)",
-								"runnable", r,
-								"state", state)
-							continue
-						}
-
-						prev, loaded := p.stateMap.Swap(r, state)
-						if !loaded {
-							// The state map entry for this runnable was expected to be created in startRunnable
-							p.logger.Warn(
-								"Unexpected State map entry created",
-								"runnable", r,
-								"state", state)
-						} else {
-							p.logger.Debug(
-								"State map entry updated",
-								"runnable", r,
-								"oldState", prev,
-								"state", state)
-						}
-						lastState = state  // enable local state deduplication
-						p.broadcastState() // Broadcast state change to all subscribers
-					}
-				}
-			}(run, stateable)
+			wg.Add(1)
+			go p.monitorStateable(run, stateable, &wg)
 		}
 	}
 
-	// Block here until context is done, then bounded-wait for all monitoring
-	// goroutines to finish. The bound prevents a misbehaving Stateable from
-	// blocking supervisor shutdown indefinitely; see stateMonitorShutdownTimeout.
 	<-p.ctx.Done()
 	p.logger.Debug("State monitor received context done signal, waiting for monitors to exit...")
-	p.boundedWaitOnStateGoroutines(&stateWg)
+	p.boundedWaitOnStateGoroutines(&wg)
+}
+
+// monitorStateable consumes state updates from a single Stateable runnable
+// and forwards changes to stateMap and subscribers. Identical consecutive
+// states are deduplicated. Exits when the supervisor context is canceled
+// or the state channel closes.
+func (p *PIDZero) monitorStateable(r Runnable, s Stateable, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	stateChan := s.GetStateChan(p.ctx)
+	if !p.discardInitialState(r, stateChan) {
+		return
+	}
+
+	lastState := p.loadCachedState(r)
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case state, ok := <-stateChan:
+			if !ok {
+				return
+			}
+			if state == lastState {
+				p.logger.Debug(
+					"Received duplicate state (ignoring)",
+					"runnable", r,
+					"state", state)
+				continue
+			}
+			p.recordStateChange(r, state)
+			lastState = state
+			p.broadcastState()
+		}
+	}
+}
+
+// discardInitialState reads and drops the first value from stateChan. The
+// initial state is already seeded in stateMap by startRunnable, so re-broadcasting
+// it would produce a duplicate. Returns false if the supervisor context was
+// canceled or the channel closed before the first state arrived.
+func (p *PIDZero) discardInitialState(r Runnable, stateChan <-chan string) bool {
+	select {
+	case <-p.ctx.Done():
+		return false
+	case state, ok := <-stateChan:
+		if !ok {
+			return false
+		}
+		p.logger.Debug("Discarded initial state", "runnable", r, "state", state)
+		return true
+	}
+}
+
+// loadCachedState returns the cached state for r from stateMap. Returns ""
+// if no entry exists or the stored value is the wrong type. The entry is
+// expected to have been seeded by startRunnable.
+func (p *PIDZero) loadCachedState(r Runnable) string {
+	cur, ok := p.stateMap.Load(r)
+	if !ok {
+		return ""
+	}
+	s, ok := cur.(string)
+	if !ok {
+		return ""
+	}
+	return s
+}
+
+// recordStateChange swaps the runnable's state into stateMap and logs the
+// transition. Logs Warn if no prior entry existed (startRunnable should
+// always have seeded one).
+func (p *PIDZero) recordStateChange(r Runnable, state string) {
+	prev, loaded := p.stateMap.Swap(r, state)
+	if !loaded {
+		p.logger.Warn(
+			"Unexpected State map entry created",
+			"runnable", r,
+			"state", state)
+		return
+	}
+	p.logger.Debug(
+		"State map entry updated",
+		"runnable", r,
+		"oldState", prev,
+		"state", state)
 }
 
 // boundedWaitOnStateGoroutines waits up to p.stateMonitorShutdownTimeout

--- a/supervisor/state_monitoring_test.go
+++ b/supervisor/state_monitoring_test.go
@@ -206,3 +206,104 @@ func TestBoundedWaitOnStateGoroutines(t *testing.T) {
 		})
 	})
 }
+
+// TestMonitorStateable_CtxCancelExits verifies that a per-runnable monitor
+// goroutine, parked inside the inner select waiting for the next state,
+// exits cleanly when the supervisor context is canceled. synctest.Wait
+// confirms the goroutine is durably blocked in the select before cancel
+// fires, so the test exercises the ctx.Done branch deterministically.
+func TestMonitorStateable_CtxCancelExits(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+
+		s := mocks.NewMockRunnableWithStateable()
+		s.On("String").Return("svc").Maybe()
+		stateChan := make(chan string, 5)
+		s.On("GetStateChan", mock.Anything).Return(stateChan).Once()
+
+		pid0, err := New(WithContext(ctx), WithRunnables(s))
+		require.NoError(t, err)
+
+		// First state is consumed and discarded by discardInitialState.
+		stateChan <- "initial"
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go pid0.monitorStateable(s, s, &wg)
+
+		// Wait until the monitor has consumed "initial" and is parked in
+		// the inner select. With synctest this is durably blocked.
+		synctest.Wait()
+
+		cancel()
+		wg.Wait() // unblocks when monitorStateable returns and runs its defer
+
+		s.AssertExpectations(t)
+	})
+}
+
+// TestMonitorStateable_ChannelCloseExits verifies that the monitor goroutine
+// exits cleanly when its state channel is closed (the case where a Stateable
+// shuts itself down without going through supervisor ctx cancellation).
+func TestMonitorStateable_ChannelCloseExits(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		s := mocks.NewMockRunnableWithStateable()
+		s.On("String").Return("svc").Maybe()
+		stateChan := make(chan string, 5)
+		s.On("GetStateChan", mock.Anything).Return(stateChan).Once()
+
+		pid0, err := New(WithContext(ctx), WithRunnables(s))
+		require.NoError(t, err)
+
+		stateChan <- "initial"
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go pid0.monitorStateable(s, s, &wg)
+		synctest.Wait()
+
+		close(stateChan)
+		wg.Wait()
+
+		s.AssertExpectations(t)
+	})
+}
+
+// TestDiscardInitialState_CtxCancelsDuringWait verifies the helper returns
+// false when the supervisor context cancels while it's parked waiting for
+// the first state. synctest pins the helper inside the select, then the
+// outer goroutine cancels ctx and observes a deterministic return.
+func TestDiscardInitialState_CtxCancelsDuringWait(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+
+		stub := mocks.NewMockRunnable()
+		stub.On("String").Return("stub").Maybe()
+		pid0, err := New(WithContext(ctx), WithRunnables(stub))
+		require.NoError(t, err)
+
+		stateChan := make(chan string) // never sends
+		r := mocks.NewMockRunnableWithStateable()
+		r.On("String").Return("r").Maybe()
+
+		var consumed bool
+		done := make(chan struct{})
+		go func() {
+			consumed = pid0.discardInitialState(r, stateChan)
+			close(done)
+		}()
+
+		synctest.Wait() // helper goroutine durably blocked in select
+
+		cancel()
+		<-done
+
+		assert.False(t, consumed, "should return false when ctx cancels before first state")
+	})
+}

--- a/supervisor/state_monitoring_test.go
+++ b/supervisor/state_monitoring_test.go
@@ -127,18 +127,21 @@ func TestPIDZero_SubscribeStateChanges(t *testing.T) {
 func TestBoundedWaitOnStateGoroutines(t *testing.T) {
 	t.Parallel()
 
+	const testTimeout = 50 * time.Millisecond
+
 	t.Run("returns within bound when wg drains in time", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			original := stateMonitorShutdownTimeout
-			stateMonitorShutdownTimeout = 50 * time.Millisecond
-			t.Cleanup(func() { stateMonitorShutdownTimeout = original })
-
 			logBuffer := &bytes.Buffer{}
 			logHandler := slog.NewTextHandler(logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug})
 
 			stub := mocks.NewMockRunnable()
 			stub.On("String").Return("stub").Maybe()
-			pid0, err := New(WithContext(t.Context()), WithRunnables(stub), WithLogHandler(logHandler))
+			pid0, err := New(
+				WithContext(t.Context()),
+				WithRunnables(stub),
+				WithLogHandler(logHandler),
+				WithStateMonitorShutdownTimeout(testTimeout),
+			)
 			require.NoError(t, err)
 
 			var wg sync.WaitGroup
@@ -152,7 +155,7 @@ func TestBoundedWaitOnStateGoroutines(t *testing.T) {
 			pid0.boundedWaitOnStateGoroutines(&wg)
 			elapsed := time.Since(start)
 
-			assert.Less(t, elapsed, stateMonitorShutdownTimeout,
+			assert.Less(t, elapsed, testTimeout,
 				"should exit on done branch, not timer")
 			assert.Contains(t, logBuffer.String(), "State monitor complete.")
 			assert.NotContains(t, logBuffer.String(), "deadline exceeded")
@@ -161,16 +164,17 @@ func TestBoundedWaitOnStateGoroutines(t *testing.T) {
 
 	t.Run("times out and warns when wg blocks past bound", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
-			original := stateMonitorShutdownTimeout
-			stateMonitorShutdownTimeout = 50 * time.Millisecond
-			t.Cleanup(func() { stateMonitorShutdownTimeout = original })
-
 			logBuffer := &bytes.Buffer{}
 			logHandler := slog.NewTextHandler(logBuffer, &slog.HandlerOptions{Level: slog.LevelWarn})
 
 			stub := mocks.NewMockRunnable()
 			stub.On("String").Return("stub").Maybe()
-			pid0, err := New(WithContext(t.Context()), WithRunnables(stub), WithLogHandler(logHandler))
+			pid0, err := New(
+				WithContext(t.Context()),
+				WithRunnables(stub),
+				WithLogHandler(logHandler),
+				WithStateMonitorShutdownTimeout(testTimeout),
+			)
 			require.NoError(t, err)
 
 			var wg sync.WaitGroup
@@ -190,7 +194,7 @@ func TestBoundedWaitOnStateGoroutines(t *testing.T) {
 			pid0.boundedWaitOnStateGoroutines(&wg)
 			elapsed := time.Since(start)
 
-			assert.Equal(t, stateMonitorShutdownTimeout, elapsed,
+			assert.Equal(t, testTimeout, elapsed,
 				"should exit exactly when the timer fires")
 			assert.Contains(t, logBuffer.String(),
 				"State monitor shutdown deadline exceeded")

--- a/supervisor/state_monitoring_test.go
+++ b/supervisor/state_monitoring_test.go
@@ -1,7 +1,10 @@
 package supervisor
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -12,65 +15,61 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPIDZero_StartStateMonitor tests that the state monitor is started for stateable runnables.
-// This test calls pid0.Run() which uses signal.Notify, so it cannot use synctest.
+// TestPIDZero_StartStateMonitor tests that the state monitor is started for
+// stateable runnables and forwards state changes to subscribers. Uses
+// testing/synctest by driving startStateMonitor directly (skipping the
+// pid0.Run() signal-handling path) so timing is deterministic.
 func TestPIDZero_StartStateMonitor(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
 
-	mockStateable := mocks.NewMockRunnableWithStateable()
-	mockStateable.On("String").Return("stateable-runnable")
-	mockStateable.On("Run", mock.Anything).Return(nil)
-	mockStateable.On("Stop").Once()
-	mockStateable.On("GetState").Return("initial").Once()
-	mockStateable.On("GetState").Return("running")
+		mockStateable := mocks.NewMockRunnableWithStateable()
+		mockStateable.On("String").Return("stateable-runnable")
+		stateChan := make(chan string, 5)
+		mockStateable.On("GetStateChan", mock.Anything).Return(stateChan).Once()
 
-	stateChan := make(chan string, 5)
-	mockStateable.On("GetStateChan", mock.Anything).Return(stateChan).Once()
-
-	mockStateable.On("IsReady").Return(true).Once()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	pid0, err := New(
-		WithContext(ctx),
-		WithRunnables(mockStateable),
-		WithStartupTimeout(100*time.Millisecond),
-	)
-	require.NoError(t, err)
-
-	stateUpdates := make(chan StateMap, 5)
-	unsubscribe := pid0.AddStateSubscriber(stateUpdates)
-	defer unsubscribe()
-
-	execDone := make(chan error, 1)
-	go func() {
-		execDone <- pid0.Run()
-	}()
-
-	stateChan <- "initial"
-	stateChan <- "running"
-	stateChan <- "stopping"
-
-	require.Eventually(t, func() bool {
-		select {
-		case stateMap := <-stateUpdates:
-			return stateMap["stateable-runnable"] != ""
-		default:
-			return false
-		}
-	}, 500*time.Millisecond, 50*time.Millisecond, "No state updates received")
-
-	cancel()
-
-	select {
-	case err := <-execDone:
+		pid0, err := New(WithContext(ctx), WithRunnables(mockStateable))
 		require.NoError(t, err)
-	case <-time.After(1 * time.Second):
-		t.Fatal("Supervisor did not shut down in time")
-	}
 
-	mockStateable.AssertExpectations(t)
+		// startRunnable seeds the initial state during a real Run(); seed
+		// it here directly since we're driving startStateMonitor in isolation.
+		pid0.stateMap.Store(mockStateable, "initial")
+
+		stateUpdates := make(chan StateMap, 5)
+		unsubscribe := pid0.AddStateSubscriber(stateUpdates)
+		defer unsubscribe()
+
+		pid0.wg.Go(pid0.startStateMonitor)
+		synctest.Wait()
+
+		// The first state on the channel is discarded by the monitor (it's
+		// already captured in stateMap by startRunnable in production).
+		stateChan <- "initial"
+		stateChan <- "running"
+		stateChan <- "stopping"
+		synctest.Wait()
+
+		// Drain stateUpdates and confirm the running and stopping states landed.
+		var sawRunning, sawStopping bool
+		for range len(stateUpdates) {
+			stateMap := <-stateUpdates
+			switch stateMap["stateable-runnable"] {
+			case "running":
+				sawRunning = true
+			case "stopping":
+				sawStopping = true
+			}
+		}
+		assert.True(t, sawRunning, "subscriber should observe 'running' state")
+		assert.True(t, sawStopping, "subscriber should observe 'stopping' state")
+
+		cancel()
+		synctest.Wait()
+
+		mockStateable.AssertExpectations(t)
+	})
 }
 
 // TestPIDZero_SubscribeStateChanges tests the SubscribeStateChanges functionality.
@@ -118,5 +117,88 @@ func TestPIDZero_SubscribeStateChanges(t *testing.T) {
 		cancel()
 
 		mockService.AssertExpectations(t)
+	})
+}
+
+// TestBoundedWaitOnStateGoroutines verifies that the bounded-wait helper
+// returns and logs a Warn when the WaitGroup doesn't drain inside
+// stateMonitorShutdownTimeout. This exercises the timer.C branch directly
+// without depending on a real per-runnable wedge.
+func TestBoundedWaitOnStateGoroutines(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns within bound when wg drains in time", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			original := stateMonitorShutdownTimeout
+			stateMonitorShutdownTimeout = 50 * time.Millisecond
+			t.Cleanup(func() { stateMonitorShutdownTimeout = original })
+
+			logBuffer := &bytes.Buffer{}
+			logHandler := slog.NewTextHandler(logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+			stub := mocks.NewMockRunnable()
+			stub.On("String").Return("stub").Maybe()
+			pid0, err := New(WithContext(t.Context()), WithRunnables(stub), WithLogHandler(logHandler))
+			require.NoError(t, err)
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				wg.Done()
+			}()
+
+			start := time.Now()
+			pid0.boundedWaitOnStateGoroutines(&wg)
+			elapsed := time.Since(start)
+
+			assert.Less(t, elapsed, stateMonitorShutdownTimeout,
+				"should exit on done branch, not timer")
+			assert.Contains(t, logBuffer.String(), "State monitor complete.")
+			assert.NotContains(t, logBuffer.String(), "deadline exceeded")
+		})
+	})
+
+	t.Run("times out and warns when wg blocks past bound", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			original := stateMonitorShutdownTimeout
+			stateMonitorShutdownTimeout = 50 * time.Millisecond
+			t.Cleanup(func() { stateMonitorShutdownTimeout = original })
+
+			logBuffer := &bytes.Buffer{}
+			logHandler := slog.NewTextHandler(logBuffer, &slog.HandlerOptions{Level: slog.LevelWarn})
+
+			stub := mocks.NewMockRunnable()
+			stub.On("String").Return("stub").Maybe()
+			pid0, err := New(WithContext(t.Context()), WithRunnables(stub), WithLogHandler(logHandler))
+			require.NoError(t, err)
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			// Helper goroutine parks on `release` until the test signals
+			// it; the bound must fire before that signal arrives. Using a
+			// channel (not time.Sleep) keeps the helper durably blocked
+			// without burning virtual time, and lets the test deterministically
+			// drain the bubble at the end.
+			release := make(chan struct{})
+			go func() {
+				<-release
+				wg.Done()
+			}()
+
+			start := time.Now()
+			pid0.boundedWaitOnStateGoroutines(&wg)
+			elapsed := time.Since(start)
+
+			assert.Equal(t, stateMonitorShutdownTimeout, elapsed,
+				"should exit exactly when the timer fires")
+			assert.Contains(t, logBuffer.String(),
+				"State monitor shutdown deadline exceeded")
+
+			// Drain the bubble: release the helper so wg.Done() runs,
+			// the inner wg.Wait goroutine closes done, and all spawned
+			// goroutines exit before the synctest function returns.
+			close(release)
+		})
 	})
 }

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -38,6 +38,13 @@ const (
 	// remaining budget, its goroutine is abandoned (logged) and shutdown
 	// continues. A timeout of 0 disables the deadline.
 	DefaultShutdownTimeout = 2 * time.Minute
+
+	// DefaultStateMonitorShutdownTimeout caps how long startStateMonitor waits
+	// for its per-runnable monitoring goroutines to exit after the supervisor
+	// context is canceled. Hitting this bound logs a Warn and returns; the
+	// leaked goroutines remain bounded by the broader Go runtime lifetime.
+	// The default matches go-fsm's per-broadcast timeout for symmetry.
+	DefaultStateMonitorShutdownTimeout = 5 * time.Second
 )
 
 // PIDZero manages multiple "runnables" and handles OS signals for HUP or graceful shutdown.
@@ -56,9 +63,10 @@ type PIDZero struct {
 	stateSubscribers   sync.Map
 	subscriberMutex    sync.Mutex
 
-	startupTimeout  time.Duration
-	startupInitial  time.Duration
-	shutdownTimeout time.Duration
+	startupTimeout              time.Duration
+	startupInitial              time.Duration
+	shutdownTimeout             time.Duration
+	stateMonitorShutdownTimeout time.Duration
 
 	logger *slog.Logger
 }
@@ -143,6 +151,23 @@ func WithShutdownTimeout(timeout time.Duration) Option {
 	}
 }
 
+// WithStateMonitorShutdownTimeout caps how long startStateMonitor waits
+// for its per-runnable monitoring goroutines to exit after the supervisor
+// context is canceled. If a Stateable runnable's monitoring goroutine
+// fails to exit promptly (for example because it is wedged inside
+// broadcastState or has a misbehaving GetStateChan implementation), the
+// state monitor abandons it and logs a Warn so supervisor shutdown is
+// not blocked indefinitely. A timeout of 0 disables the deadline (waits
+// indefinitely); negative values are ignored and leave the current
+// setting in place.
+func WithStateMonitorShutdownTimeout(timeout time.Duration) Option {
+	return func(p *PIDZero) {
+		if timeout >= 0 {
+			p.stateMonitorShutdownTimeout = timeout
+		}
+	}
+}
+
 // New creates a new PIDZero instance with the provided options.
 func New(opts ...Option) (*PIDZero, error) {
 	// Load the default logger and append the Supervisor group
@@ -165,10 +190,11 @@ func New(opts ...Option) (*PIDZero, error) {
 		cancel:           cancel,
 		subscribeSignals: defaultSignals,
 		reloadListener:   make(chan struct{}),
-		startupTimeout:   DefaultStartupTimeout,
-		startupInitial:   DefaultStartupInitial,
-		shutdownTimeout:  DefaultShutdownTimeout,
-		logger:           logger,
+		startupTimeout:              DefaultStartupTimeout,
+		startupInitial:              DefaultStartupInitial,
+		shutdownTimeout:             DefaultShutdownTimeout,
+		stateMonitorShutdownTimeout: DefaultStateMonitorShutdownTimeout,
+		logger:                      logger,
 	}
 
 	// Apply options

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -183,13 +183,13 @@ func New(opts ...Option) (*PIDZero, error) {
 	}
 
 	p := &PIDZero{
-		runnables:        []Runnable{},
-		signalChan:       make(chan os.Signal, 1), // OS signals must be buffered
-		errorChan:        make(chan error, 1),     // will be adjusted later
-		ctx:              ctx,
-		cancel:           cancel,
-		subscribeSignals: defaultSignals,
-		reloadListener:   make(chan struct{}),
+		runnables:                   []Runnable{},
+		signalChan:                  make(chan os.Signal, 1), // OS signals must be buffered
+		errorChan:                   make(chan error, 1),     // will be adjusted later
+		ctx:                         ctx,
+		cancel:                      cancel,
+		subscribeSignals:            defaultSignals,
+		reloadListener:              make(chan struct{}),
 		startupTimeout:              DefaultStartupTimeout,
 		startupInitial:              DefaultStartupInitial,
 		shutdownTimeout:             DefaultShutdownTimeout,


### PR DESCRIPTION
## Summary

- `startStateMonitor`'s post-cancellation `stateWg.Wait()` was unbounded; a Stateable runnable whose state processing got wedged (e.g., contending on `subscriberMutex` from inside `broadcastState`) could block supervisor shutdown indefinitely. The wait is now capped at `stateMonitorShutdownTimeout` (5s, matching go-fsm's per-broadcast timeout). Hitting the bound logs a Warn and returns; healthy goroutines still exit promptly via the existing ctx.Done() path so behavior is unchanged for well-behaved runnables.
- Extracted the bounded wait into `boundedWaitOnStateGoroutines` so the timer.C branch is testable directly under `testing/synctest`.
- Converted the existing `TestPIDZero_StartStateMonitor` to `testing/synctest` by driving `startStateMonitor` directly (skipping the `pid0.Run()` path that requires `signal.Notify`), so the file's timing is deterministic.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -race ./supervisor/... -count=1 -timeout 60s` green; new `TestBoundedWaitOnStateGoroutines` covers both done and timer.C branches under synctest
- [x] `go test -race ./... -count=1 -timeout 300s` full repo green

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_