### PR TITLE
supervisor: drop stateMap; derive GetStateMap from live GetState reads

### DIFF
--- a/supervisor/reload.go
+++ b/supervisor/reload.go
@@ -121,4 +121,3 @@ func (p *PIDZero) logStateIfStateable(r Runnable, msg string) {
 		p.logger.Debug(msg, "runnable", r, "state", stateable.GetState())
 	}
 }
-

--- a/supervisor/reload.go
+++ b/supervisor/reload.go
@@ -102,7 +102,7 @@ func (p *PIDZero) reloadAllRunnables() int {
 // its own FSM to Error so state-channel observers see the failure too.
 func (p *PIDZero) reloadOne(r Runnable, reloader Reloadable) bool {
 	p.logStateIfStateable(r, "Pre-reload state")
-	defer p.recordPostReloadState(r)
+	defer p.logStateIfStateable(r, "Post-reload state")
 
 	p.logger.Debug("Reloading", "runnable", r)
 	if err := reloader.Reload(p.ctx); err != nil {
@@ -122,15 +122,3 @@ func (p *PIDZero) logStateIfStateable(r Runnable, msg string) {
 	}
 }
 
-// recordPostReloadState caches the post-reload state in stateMap and logs it.
-// Combined into one helper so the reload-one path doesn't need to type-assert
-// Stateable twice.
-func (p *PIDZero) recordPostReloadState(r Runnable) {
-	stateable, ok := r.(Stateable)
-	if !ok {
-		return
-	}
-	postState := stateable.GetState()
-	p.stateMap.Store(r, postState)
-	p.logger.Debug("Post-reload state", "runnable", r, "state", postState)
-}

--- a/supervisor/shutdown_test.go
+++ b/supervisor/shutdown_test.go
@@ -299,60 +299,6 @@ func TestPIDZero_Shutdown(t *testing.T) {
 		runnable.AssertExpectations(t)
 	})
 
-	t.Run("abandoned stop does not cache post state", func(t *testing.T) {
-		releaseStop := make(chan struct{})
-		t.Cleanup(func() {
-			close(releaseStop)
-		})
-
-		runnable := mocks.NewMockRunnableWithStateable()
-		runnable.On("String").Return("stateable-runnable").Maybe()
-		runnable.On("GetState").Return("running").Once()
-		runnable.On("Stop").Run(func(args mock.Arguments) {
-			<-releaseStop
-		})
-
-		pidZero := newTestPIDZero(t,
-			WithRunnables(runnable),
-			WithShutdownTimeout(50*time.Millisecond),
-		)
-		pidZero.stateMap.Store(runnable, "cached-running")
-
-		shutdownDone := make(chan struct{})
-		go func() {
-			pidZero.Shutdown()
-			close(shutdownDone)
-		}()
-
-		eventuallyClosed(t, shutdownDone, "Shutdown did not complete after abandoning Stop()")
-
-		cachedState, ok := pidZero.stateMap.Load(runnable)
-		require.True(t, ok)
-		assert.Equal(t, "cached-running", cachedState)
-		runnable.AssertExpectations(t)
-	})
-
-	t.Run("completed stop caches post state", func(t *testing.T) {
-		runnable := mocks.NewMockRunnableWithStateable()
-		runnable.On("String").Return("stateable-runnable").Maybe()
-		runnable.On("GetState").Return("running").Once()
-		runnable.On("GetState").Return("stopped").Once()
-		runnable.On("Stop").Once()
-
-		pidZero := newTestPIDZero(t,
-			WithRunnables(runnable),
-			WithShutdownTimeout(time.Second),
-		)
-		pidZero.stateMap.Store(runnable, "cached-running")
-
-		pidZero.Shutdown()
-
-		cachedState, ok := pidZero.stateMap.Load(runnable)
-		require.True(t, ok)
-		assert.Equal(t, "stopped", cachedState)
-		runnable.AssertExpectations(t)
-	})
-
 	t.Run("stop runnable bounded completes before deadline", func(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			runnable := mocks.NewMockRunnable()

--- a/supervisor/state.go
+++ b/supervisor/state.go
@@ -87,9 +87,12 @@ func (p *PIDZero) AddStateSubscriber(ch chan StateMap) func() {
 
 	p.stateSubscribers.Store(ch, struct{}{})
 
-	// Try to send initial state
+	// Build the snapshot before the select. Per Go spec, expressions in
+	// select case clauses are evaluated on entering the select regardless
+	// of which branch fires; extracting the call makes that explicit.
+	initial := p.GetStateMap()
 	select {
-	case ch <- p.GetStateMap():
+	case ch <- initial:
 		p.logger.Debug("Sent initial state to subscriber")
 	default:
 		p.logger.Warn(
@@ -137,7 +140,21 @@ func (p *PIDZero) unsubscribeState(ch chan StateMap) {
 // is built before acquiring subscriberMutex so a slow GetState() implementation
 // in one runnable doesn't stall subscribe/unsubscribe operations on other
 // goroutines; the mutex is held only for the iteration over subscribers.
+//
+// Fast-path: if there are no subscribers, return without computing the
+// snapshot. broadcastState is called on every Stateable transition; skipping
+// the GetState() pass when nobody is listening avoids wasted work in the
+// common case where state monitoring is enabled but nothing has subscribed.
 func (p *PIDZero) broadcastState() {
+	var hasSubscriber bool
+	p.stateSubscribers.Range(func(_, _ any) bool {
+		hasSubscriber = true
+		return false // stop on first
+	})
+	if !hasSubscriber {
+		return
+	}
+
 	stateMap := p.GetStateMap()
 	if len(stateMap) == 0 {
 		p.logger.Debug("No state to broadcast; no Stateable runnables")

--- a/supervisor/state.go
+++ b/supervisor/state.go
@@ -48,8 +48,16 @@ func (p *PIDZero) GetCurrentStates() map[Runnable]string {
 // GetStateMap returns each Stateable runnable's current state, keyed by the
 // runnable's String() representation. The result is a best-effort, per-runnable
 // live read: runnables are iterated sequentially and GetState() is called on
-// each, so entries may reflect slightly different moments in time. There is
-// no cached layer; each call queries the runnables directly.
+// each, so entries may reflect slightly different moments in time.
+//
+// Atomicity contract: each individual entry is atomic (a single GetState() call),
+// but cross-runnable coherence is NOT guaranteed. If two runnables transition
+// concurrently, callers may observe the new value of one and the old value of
+// the other. Callers needing a coherent multi-runnable view should call
+// GetStateMap once and treat the result as approximate; calling it twice and
+// diffing the results is unreliable.
+//
+// There is no cached layer; each call queries the runnables directly.
 func (p *PIDZero) GetStateMap() StateMap {
 	out := make(StateMap)
 	for _, r := range p.runnables {
@@ -64,6 +72,15 @@ func (p *PIDZero) GetStateMap() StateMap {
 // the current state immediately (if possible), and will also receive future state changes
 // when any runnable's state is updated. A callback function is returned that should be called
 // to remove the channel from the list of subscribers when it is no longer needed.
+//
+// GetStateMap is called inside subscriberMutex on purpose, asymmetric with
+// broadcastState's split. The mutex serializes registration with broadcasts
+// so a new subscriber cannot miss the first transition that fires between
+// "snapshot computed" and "channel registered" — they either get the
+// pre-broadcast snapshot AND every subsequent broadcast, or they wait for the
+// in-flight broadcast to complete and then receive a fresh snapshot. A slow
+// GetState() implementation will stall this method; runnables should keep
+// GetState() fast and non-blocking.
 func (p *PIDZero) AddStateSubscriber(ch chan StateMap) func() {
 	p.subscriberMutex.Lock()
 	defer p.subscriberMutex.Unlock()

--- a/supervisor/state.go
+++ b/supervisor/state.go
@@ -45,28 +45,18 @@ func (p *PIDZero) GetCurrentStates() map[Runnable]string {
 	return states
 }
 
-// GetStateMap returns a map of runnable string representation to its current state.
-// It uses cached state values from stateMap for consistency with the state monitoring system.
+// GetStateMap returns a snapshot of each Stateable runnable's current state,
+// keyed by the runnable's String() representation. Each call performs a live
+// GetState() read per runnable; there is no cached layer, so the returned
+// values reflect each runnable's state at the moment of the call.
 func (p *PIDZero) GetStateMap() StateMap {
-	stateMap := make(StateMap)
-
-	// Use the stateMap as the source of truth for consistent state reporting
-	p.stateMap.Range(func(key, value any) bool {
-		r, ok := key.(Runnable)
-		if !ok {
-			p.logger.Warn("stateMap key is not a Runnable; skipping", "key", key)
-			return true
+	out := make(StateMap)
+	for _, r := range p.runnables {
+		if s, ok := r.(Stateable); ok {
+			out[r.String()] = s.GetState()
 		}
-		state, ok := value.(string)
-		if !ok {
-			p.logger.Warn("stateMap value is not a string; skipping", "runnable", r, "value", value)
-			return true
-		}
-		stateMap[r.String()] = state
-		return true
-	})
-
-	return stateMap
+	}
+	return out
 }
 
 // AddStateSubscriber adds a channel to the internal list of broadcast targets. It will receive
@@ -125,15 +115,14 @@ func (p *PIDZero) unsubscribeState(ch chan StateMap) {
 	p.stateSubscribers.Delete(ch)
 }
 
-// broadcastState sends the current state map to all subscribers.
+// broadcastState sends a fresh state snapshot to all subscribers.
 func (p *PIDZero) broadcastState() {
-	// Lock the entire broadcast to prevent race conditions
 	p.subscriberMutex.Lock()
 	defer p.subscriberMutex.Unlock()
 
 	stateMap := p.GetStateMap()
 	if len(stateMap) == 0 {
-		p.logger.Debug("No state to broadcast; stateMap is empty")
+		p.logger.Debug("No state to broadcast; no Stateable runnables")
 		return
 	}
 
@@ -153,25 +142,17 @@ func (p *PIDZero) broadcastState() {
 	})
 }
 
-// startStateMonitor initiates background goroutines to monitor state changes for each
-// Stateable runnable. Each runnable that implements the Stateable interface will
-// spawn a goroutine that will:
+// startStateMonitor spawns one goroutine per Stateable runnable to forward
+// state transitions to subscribers. Each goroutine subscribes to the runnable's
+// state channel via GetStateChan, captures the initial state pushed on
+// subscription as the dedup baseline (without broadcasting it — subscribers
+// already receive the initial snapshot from AddStateSubscriber), and then
+// broadcasts each subsequent transition that differs from the previous one.
 //
-// 1. Obtains a state channel from the runnable via the GetStateChan() method
-// 2. Discards the current/initial state from the channel (as it's already captured in startRunnable)
-// 3. Begins monitoring for new states, deduplicating identical consecutive states
-// 4. Updates the internal stateMap when states change
-// 5. Broadcasts state changes to all subscribers
-//
-// The many purposes of the stateMap:
-//   - Provides a thread-safe cache of the latest state for each runnable
-//   - Enables state change deduplication (avoiding duplicate broadcasts of identical states)
-//   - Represents the supervisor's "truth" for the state of current runnables
-//   - Allows state querying without directly accessing runnables (e.g. for APIs or UIs)
-//
-// State deduplication works by comparing incoming states against the previously recorded state.
-// Only when a state differs from the previous one is it stored and broadcast, preventing
-// unnecessary broadcasts and reducing system load when runnables emit frequent duplicate states.
+// State queries (GetStateMap, GetCurrentState, GetCurrentStates) read live
+// from each runnable's GetState(); the supervisor does not cache state. The
+// monitor exists solely to push transitions to subscribers, not to maintain
+// a state cache.
 //
 // Shutdown: when the supervisor context is canceled, startStateMonitor waits up to
 // p.stateMonitorShutdownTimeout (default 5s, configurable via
@@ -197,18 +178,18 @@ func (p *PIDZero) startStateMonitor() {
 }
 
 // monitorStateable consumes state updates from a single Stateable runnable
-// and forwards changes to stateMap and subscribers. Identical consecutive
-// states are deduplicated. Exits when the supervisor context is canceled
-// or the state channel closes.
+// and forwards transitions to subscribers. Identical consecutive states are
+// deduplicated. Exits when the supervisor context is canceled or the state
+// channel closes.
 func (p *PIDZero) monitorStateable(r Runnable, s Stateable, wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	stateChan := s.GetStateChan(p.ctx)
-	if !p.discardInitialState(r, stateChan) {
+	lastState, ok := p.consumeInitialState(r, stateChan)
+	if !ok {
 		return
 	}
 
-	lastState := p.loadCachedState(r)
 	for {
 		select {
 		case <-p.ctx.Done():
@@ -224,62 +205,33 @@ func (p *PIDZero) monitorStateable(r Runnable, s Stateable, wg *sync.WaitGroup) 
 					"state", state)
 				continue
 			}
-			p.recordStateChange(r, state)
+			p.logger.Debug("State changed",
+				"runnable", r,
+				"oldState", lastState,
+				"state", state)
 			lastState = state
 			p.broadcastState()
 		}
 	}
 }
 
-// discardInitialState reads and drops the first value from stateChan. The
-// initial state is already seeded in stateMap by startRunnable, so re-broadcasting
-// it would produce a duplicate. Returns false if the supervisor context was
-// canceled or the channel closed before the first state arrived.
-func (p *PIDZero) discardInitialState(r Runnable, stateChan <-chan string) bool {
+// consumeInitialState reads the first value pushed on stateChan after subscription.
+// Stateable FSMs emit their current state on subscribe, so this captures the
+// runnable's starting state to use as the dedup baseline. The value is NOT
+// broadcast — subscribers receive the initial state via AddStateSubscriber's own
+// snapshot send. Returns ("", false) if the supervisor context cancels or the
+// channel closes before the first state arrives.
+func (p *PIDZero) consumeInitialState(r Runnable, stateChan <-chan string) (string, bool) {
 	select {
 	case <-p.ctx.Done():
-		return false
+		return "", false
 	case state, ok := <-stateChan:
 		if !ok {
-			return false
+			return "", false
 		}
-		p.logger.Debug("Discarded initial state", "runnable", r, "state", state)
-		return true
+		p.logger.Debug("Captured initial state", "runnable", r, "state", state)
+		return state, true
 	}
-}
-
-// loadCachedState returns the cached state for r from stateMap. Returns ""
-// if no entry exists or the stored value is the wrong type. The entry is
-// expected to have been seeded by startRunnable.
-func (p *PIDZero) loadCachedState(r Runnable) string {
-	cur, ok := p.stateMap.Load(r)
-	if !ok {
-		return ""
-	}
-	s, ok := cur.(string)
-	if !ok {
-		return ""
-	}
-	return s
-}
-
-// recordStateChange swaps the runnable's state into stateMap and logs the
-// transition. Logs Warn if no prior entry existed (startRunnable should
-// always have seeded one).
-func (p *PIDZero) recordStateChange(r Runnable, state string) {
-	prev, loaded := p.stateMap.Swap(r, state)
-	if !loaded {
-		p.logger.Warn(
-			"Unexpected State map entry created",
-			"runnable", r,
-			"state", state)
-		return
-	}
-	p.logger.Debug(
-		"State map entry updated",
-		"runnable", r,
-		"oldState", prev,
-		"state", state)
 }
 
 // boundedWaitOnStateGoroutines waits up to p.stateMonitorShutdownTimeout

--- a/supervisor/state.go
+++ b/supervisor/state.go
@@ -45,10 +45,11 @@ func (p *PIDZero) GetCurrentStates() map[Runnable]string {
 	return states
 }
 
-// GetStateMap returns a snapshot of each Stateable runnable's current state,
-// keyed by the runnable's String() representation. Each call performs a live
-// GetState() read per runnable; there is no cached layer, so the returned
-// values reflect each runnable's state at the moment of the call.
+// GetStateMap returns each Stateable runnable's current state, keyed by the
+// runnable's String() representation. The result is a best-effort, per-runnable
+// live read: runnables are iterated sequentially and GetState() is called on
+// each, so entries may reflect slightly different moments in time. There is
+// no cached layer; each call queries the runnables directly.
 func (p *PIDZero) GetStateMap() StateMap {
 	out := make(StateMap)
 	for _, r := range p.runnables {
@@ -115,16 +116,19 @@ func (p *PIDZero) unsubscribeState(ch chan StateMap) {
 	p.stateSubscribers.Delete(ch)
 }
 
-// broadcastState sends a fresh state snapshot to all subscribers.
+// broadcastState sends a fresh state snapshot to all subscribers. The snapshot
+// is built before acquiring subscriberMutex so a slow GetState() implementation
+// in one runnable doesn't stall subscribe/unsubscribe operations on other
+// goroutines; the mutex is held only for the iteration over subscribers.
 func (p *PIDZero) broadcastState() {
-	p.subscriberMutex.Lock()
-	defer p.subscriberMutex.Unlock()
-
 	stateMap := p.GetStateMap()
 	if len(stateMap) == 0 {
 		p.logger.Debug("No state to broadcast; no Stateable runnables")
 		return
 	}
+
+	p.subscriberMutex.Lock()
+	defer p.subscriberMutex.Unlock()
 
 	p.stateSubscribers.Range(func(key, value any) bool {
 		ch, ok := key.(chan StateMap)

--- a/supervisor/state_concurrency_test.go
+++ b/supervisor/state_concurrency_test.go
@@ -184,3 +184,28 @@ func TestGetStateMap_ReflectsLiveGetStateValues(t *testing.T) {
 
 	s.AssertExpectations(t)
 }
+
+// TestBroadcastState_NoSubscribersFastPath verifies the perf optimization
+// that broadcastState skips the GetStateMap snapshot when no subscribers
+// are registered. The mock's GetState expectation has zero matching calls,
+// so any invocation would fail AssertExpectations.
+func TestBroadcastState_NoSubscribersFastPath(t *testing.T) {
+	t.Parallel()
+
+	s := mocks.NewMockRunnableWithStateable()
+	s.On("String").Return("svc").Maybe()
+	s.On("GetStateChan", mock.Anything).Return(make(chan string, 1)).Maybe()
+	// GetState intentionally NOT expected — broadcastState must short-circuit
+	// before computing the snapshot when the subscriber list is empty.
+
+	pid0, err := New(WithRunnables(s))
+	require.NoError(t, err)
+
+	// No AddStateSubscriber calls. broadcastState should return immediately.
+	pid0.broadcastState()
+	pid0.broadcastState()
+	pid0.broadcastState()
+
+	s.AssertExpectations(t)
+	s.AssertNotCalled(t, "GetState")
+}

--- a/supervisor/state_concurrency_test.go
+++ b/supervisor/state_concurrency_test.go
@@ -1,0 +1,186 @@
+package supervisor
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	"github.com/robbyt/go-supervisor/internal/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBroadcastState_SlowGetStateDoesNotBlockUnsubscribe verifies the
+// architectural fix that broadcastState computes its state snapshot OUTSIDE
+// subscriberMutex. With the snapshot inside the mutex, a slow GetState()
+// implementation would stall every subscribe/unsubscribe operation; with the
+// fix, unsubscribe proceeds while the broadcaster is parked in GetState.
+//
+// The test pins a broadcastState goroutine inside its GetStateMap call (via
+// a Stateable whose GetState blocks until release), then calls the
+// unsubscribe callback and asserts it returns before release fires. synctest
+// makes the timing deterministic.
+func TestBroadcastState_SlowGetStateDoesNotBlockUnsubscribe(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		// blockNow gates the slow path on GetState. AddStateSubscriber's
+		// own GetStateMap call must NOT block, so we flip the gate after
+		// the subscriber registers.
+		var blockNow atomic.Bool
+		release := make(chan struct{})
+
+		s := mocks.NewMockRunnableWithStateable()
+		s.On("String").Return("svc").Maybe()
+		s.On("GetStateChan", mock.Anything).Return(make(chan string, 1)).Maybe()
+		s.On("GetState").Return("running").Run(func(args mock.Arguments) {
+			if blockNow.Load() {
+				<-release
+			}
+		}).Maybe()
+
+		pid0, err := New(WithContext(t.Context()), WithRunnables(s))
+		require.NoError(t, err)
+
+		// Register the subscriber while GetState is fast.
+		ch := make(chan StateMap, 5)
+		unsubscribe := pid0.AddStateSubscriber(ch)
+
+		// Make subsequent GetState calls block.
+		blockNow.Store(true)
+
+		// Spawn a broadcaster — it will compute the snapshot via
+		// GetStateMap, which calls GetState, which blocks on release.
+		broadcasterDone := make(chan struct{})
+		go func() {
+			pid0.broadcastState()
+			close(broadcasterDone)
+		}()
+
+		// Wait until the broadcaster is durably parked in GetState.
+		synctest.Wait()
+
+		// Sanity check: broadcaster has NOT completed.
+		select {
+		case <-broadcasterDone:
+			t.Fatal("broadcaster completed before release; slow GetState did not block")
+		default:
+		}
+
+		// Now call unsubscribe. With the fix, broadcastState does not hold
+		// subscriberMutex during GetStateMap, so this should return without
+		// waiting for the broadcaster. Run it in a goroutine so synctest
+		// can observe whether it durably blocks.
+		unsubscribeDone := make(chan struct{})
+		go func() {
+			unsubscribe()
+			close(unsubscribeDone)
+		}()
+		synctest.Wait()
+
+		select {
+		case <-unsubscribeDone:
+			// Pass — unsubscribe completed despite the broadcaster being
+			// blocked in its (mutex-free) snapshot computation.
+		default:
+			t.Fatal("unsubscribe blocked while broadcaster was in GetStateMap; " +
+				"snapshot must be computed outside subscriberMutex")
+		}
+
+		// Drain the bubble: release the slow GetState so the broadcaster
+		// can finish before the synctest function returns.
+		close(release)
+		<-broadcasterDone
+	})
+}
+
+// TestStateConcurrency_StressBroadcastsSubscribesGetStateMap exercises
+// concurrent broadcastState, AddStateSubscriber/unsubscribe, and GetStateMap
+// callers against a single PIDZero. There are no correctness assertions
+// beyond completion — the test exists to surface any data races caught by
+// `go test -race` across the new mutex split in broadcastState and the
+// shared p.stateSubscribers map.
+func TestStateConcurrency_StressBroadcastsSubscribesGetStateMap(t *testing.T) {
+	t.Parallel()
+
+	const (
+		goroutinesPerKind = 8
+		iterations        = 200
+	)
+
+	a := mocks.NewMockRunnableWithStateable()
+	a.On("String").Return("a").Maybe()
+	a.On("GetStateChan", mock.Anything).Return(make(chan string, 1)).Maybe()
+	a.On("GetState").Return("running").Maybe()
+
+	b := mocks.NewMockRunnableWithStateable()
+	b.On("String").Return("b").Maybe()
+	b.On("GetStateChan", mock.Anything).Return(make(chan string, 1)).Maybe()
+	b.On("GetState").Return("stopped").Maybe()
+
+	pid0, err := New(WithRunnables(a, b))
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	// Broadcasters: hammer broadcastState.
+	for range goroutinesPerKind {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				pid0.broadcastState()
+			}
+		}()
+	}
+
+	// Subscriber churn: AddStateSubscriber + unsubscribe.
+	for range goroutinesPerKind {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				ch := make(chan StateMap, 4)
+				unsub := pid0.AddStateSubscriber(ch)
+				unsub()
+			}
+		}()
+	}
+
+	// GetStateMap pollers.
+	for range goroutinesPerKind {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				_ = pid0.GetStateMap()
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestGetStateMap_ReflectsLiveGetStateValues asserts the live-read contract:
+// each GetStateMap call queries the runnables fresh, so subsequent calls
+// reflect updated state without any caching layer between them.
+func TestGetStateMap_ReflectsLiveGetStateValues(t *testing.T) {
+	t.Parallel()
+
+	s := mocks.NewMockRunnableWithStateable()
+	s.On("String").Return("svc").Maybe()
+	s.On("GetStateChan", mock.Anything).Return(make(chan string, 1)).Maybe()
+	s.On("GetState").Return("starting").Once()
+	s.On("GetState").Return("running").Once()
+	s.On("GetState").Return("stopped").Once()
+
+	pid0, err := New(WithRunnables(s))
+	require.NoError(t, err)
+
+	assert.Equal(t, StateMap{"svc": "starting"}, pid0.GetStateMap())
+	assert.Equal(t, StateMap{"svc": "running"}, pid0.GetStateMap())
+	assert.Equal(t, StateMap{"svc": "stopped"}, pid0.GetStateMap())
+
+	s.AssertExpectations(t)
+}

--- a/supervisor/state_deduplication_test.go
+++ b/supervisor/state_deduplication_test.go
@@ -24,6 +24,13 @@ func TestStateDeduplication(t *testing.T) {
 		runnable := mocks.NewMockRunnableWithStateable()
 		runnable.On("String").Return("test-runnable")
 		runnable.On("GetStateChan", mock.Anything).Return(stateChan)
+		// One GetState per snapshot: AddStateSubscriber + one per transition
+		// broadcast (running, stopped, error). Duplicates are deduplicated
+		// upstream and never reach broadcastState.
+		runnable.On("GetState").Return("initial").Once()
+		runnable.On("GetState").Return("running").Once()
+		runnable.On("GetState").Return("stopped").Once()
+		runnable.On("GetState").Return("error").Once()
 
 		pidZero, err := New(WithContext(ctx), WithRunnables(runnable))
 		require.NoError(t, err)
@@ -52,18 +59,17 @@ func TestStateDeduplication(t *testing.T) {
 			}
 		}()
 
-		pidZero.stateMap.Store(runnable, "initial")
 		pidZero.wg.Go(pidZero.startStateMonitor)
 
 		// Test sequence:
-		// 1. Send "initial" - should be discarded (already captured in startRunnable)
+		// 1. Send "initial" - consumed by consumeInitialState as dedup baseline
 		// 2. Send "running" once - should trigger broadcast
 		// 3. Send "running" twice more - should be ignored as duplicates
 		// 4. Send "stopped" - should trigger broadcast
 		// 5. Send "stopped" again - should be ignored as duplicate
 		// 6. Send "error" - should trigger broadcast
 
-		t.Log("Sending 'initial' to be discarded")
+		t.Log("Sending 'initial' as dedup baseline")
 		stateChan <- "initial"
 
 		t.Log("Sending 'running' state")

--- a/supervisor/state_monitoring_test.go
+++ b/supervisor/state_monitoring_test.go
@@ -29,13 +29,15 @@ func TestPIDZero_StartStateMonitor(t *testing.T) {
 		mockStateable.On("String").Return("stateable-runnable")
 		stateChan := make(chan string, 5)
 		mockStateable.On("GetStateChan", mock.Anything).Return(stateChan).Once()
+		// GetState is called once per snapshot: AddStateSubscriber initial
+		// send, then once per broadcast. Sequenced to mirror the values
+		// pushed on stateChan.
+		mockStateable.On("GetState").Return("initial").Once()
+		mockStateable.On("GetState").Return("running").Once()
+		mockStateable.On("GetState").Return("stopping")
 
 		pid0, err := New(WithContext(ctx), WithRunnables(mockStateable))
 		require.NoError(t, err)
-
-		// startRunnable seeds the initial state during a real Run(); seed
-		// it here directly since we're driving startStateMonitor in isolation.
-		pid0.stateMap.Store(mockStateable, "initial")
 
 		stateUpdates := make(chan StateMap, 5)
 		unsubscribe := pid0.AddStateSubscriber(stateUpdates)
@@ -44,8 +46,10 @@ func TestPIDZero_StartStateMonitor(t *testing.T) {
 		pid0.wg.Go(pid0.startStateMonitor)
 		synctest.Wait()
 
-		// The first state on the channel is discarded by the monitor (it's
-		// already captured in stateMap by startRunnable in production).
+		// The first value is consumed by consumeInitialState as the dedup
+		// baseline (not broadcast — subscribers already received an initial
+		// snapshot via AddStateSubscriber). Subsequent values are real
+		// transitions and trigger broadcasts.
 		stateChan <- "initial"
 		stateChan <- "running"
 		stateChan <- "stopping"
@@ -83,11 +87,11 @@ func TestPIDZero_SubscribeStateChanges(t *testing.T) {
 		stateChan := make(chan string, 2)
 		mockService.On("GetStateChan", mock.Anything).Return(stateChan).Once()
 		mockService.On("String").Return("mock-service")
+		mockService.On("GetState").Return("initial").Once()
+		mockService.On("GetState").Return("running")
 
 		pid0, err := New(WithContext(ctx), WithRunnables(mockService))
 		require.NoError(t, err)
-
-		pid0.stateMap.Store(mockService, "initial")
 
 		subCtx, subCancel := context.WithCancel(t.Context())
 		defer subCancel()
@@ -96,12 +100,8 @@ func TestPIDZero_SubscribeStateChanges(t *testing.T) {
 		pid0.wg.Go(pid0.startStateMonitor)
 		synctest.Wait()
 
-		stateChan <- "initial"
-		stateChan <- "running"
-
-		pid0.stateMap.Store(mockService, "running")
-		pid0.broadcastState()
-
+		stateChan <- "initial" // consumed by consumeInitialState
+		stateChan <- "running" // monitor broadcasts via GetStateMap → GetState
 		synctest.Wait()
 
 		var foundRunning bool
@@ -225,7 +225,7 @@ func TestMonitorStateable_CtxCancelExits(t *testing.T) {
 		pid0, err := New(WithContext(ctx), WithRunnables(s))
 		require.NoError(t, err)
 
-		// First state is consumed and discarded by discardInitialState.
+		// First state is read by consumeInitialState as the dedup baseline.
 		stateChan <- "initial"
 
 		var wg sync.WaitGroup
@@ -274,11 +274,11 @@ func TestMonitorStateable_ChannelCloseExits(t *testing.T) {
 	})
 }
 
-// TestDiscardInitialState_CtxCancelsDuringWait verifies the helper returns
-// false when the supervisor context cancels while it's parked waiting for
+// TestConsumeInitialState_CtxCancelsDuringWait verifies the helper returns
+// ok=false when the supervisor context cancels while it's parked waiting for
 // the first state. synctest pins the helper inside the select, then the
 // outer goroutine cancels ctx and observes a deterministic return.
-func TestDiscardInitialState_CtxCancelsDuringWait(t *testing.T) {
+func TestConsumeInitialState_CtxCancelsDuringWait(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
@@ -292,10 +292,13 @@ func TestDiscardInitialState_CtxCancelsDuringWait(t *testing.T) {
 		r := mocks.NewMockRunnableWithStateable()
 		r.On("String").Return("r").Maybe()
 
-		var consumed bool
+		var (
+			state string
+			ok    bool
+		)
 		done := make(chan struct{})
 		go func() {
-			consumed = pid0.discardInitialState(r, stateChan)
+			state, ok = pid0.consumeInitialState(r, stateChan)
 			close(done)
 		}()
 
@@ -304,6 +307,7 @@ func TestDiscardInitialState_CtxCancelsDuringWait(t *testing.T) {
 		cancel()
 		<-done
 
-		assert.False(t, consumed, "should return false when ctx cancels before first state")
+		assert.False(t, ok, "should return ok=false when ctx cancels before first state")
+		assert.Empty(t, state, "should return empty state when ctx cancels before first state")
 	})
 }

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -59,7 +59,6 @@ type PIDZero struct {
 	shutdownOnce       sync.Once
 	subscribeSignals   []os.Signal
 	reloadListener     chan struct{}
-	stateMap           sync.Map
 	stateSubscribers   sync.Map
 	subscriberMutex    sync.Mutex
 
@@ -404,10 +403,8 @@ func (p *PIDZero) Shutdown() {
 
 			if stopped {
 				if stateable, ok := r.(Stateable); ok {
-					finalState := stateable.GetState()
-					p.stateMap.Store(r, finalState)
 					p.logger.Debug("Post-shutdown state",
-						"runnable", r, "state", finalState)
+						"runnable", r, "state", stateable.GetState())
 				}
 				p.logger.Debug("Runnable stopped",
 					"runnable", r, "duration", time.Since(runnableStart))
@@ -513,11 +510,8 @@ func (p *PIDZero) listenForSignals() {
 
 // startRunnable starts a service and sends any errors to the error channel
 func (p *PIDZero) startRunnable(r Runnable) error {
-	// Log the initial state if available
 	if stateable, ok := r.(Stateable); ok {
-		initialState := stateable.GetState()
-		p.stateMap.Store(r, initialState)
-		p.logger.Debug("Initial state", "runnable", r, "state", initialState)
+		p.logger.Debug("Initial state", "runnable", r, "state", stateable.GetState())
 	}
 
 	// Create a child context for this runnable to prevent cross-cancellation issues


### PR DESCRIPTION
The supervisor maintained stateMap (a sync.Map keyed by Runnable holding the
last-known state) alongside per-runnable FSMs that already track state. Two
sources of truth — GetCurrentState/GetCurrentStates always read live, while
GetStateMap read the cache — could disagree, and the cache had to be written
from four sites (startRunnable, shutdown, reload, monitor) just to keep them
roughly in sync.

Drop the cache. GetStateMap now iterates p.runnables and calls GetState() on
each Stateable, matching GetCurrentStates. The monitor goroutine still
broadcasts transitions to subscribers, but no longer maintains the cache —
the dedup baseline now comes from the FSM's own initial-subscribe push,
captured by consumeInitialState (renamed from discardInitialState because
the value is now the dedup baseline rather than discarded).

Removed:
- PIDZero.stateMap field and its 4 write sites
- loadCachedState and recordStateChange helpers (no map to read/write)
- recordPostReloadState (now just logStateIfStateable)
- Two shutdown_test cache-contract subtests (the cache being tested no
  longer exists)

Test updates:
- state_monitoring_test.go and state_deduplication_test.go: dropped
  stateMap.Store seeds; added GetState mock returns to drive the live
  reads from GetStateMap during snapshot/broadcast.
- discardInitialState test renamed and updated to consumeInitialState's
  (string, bool) signature.

Behavior change: GetStateMap now reflects each runnable's state at the
moment of call rather than the last recorded broadcast snapshot. For
healthy runnables these match; the live read is more accurate when the
FSM has transitioned without yet emitting on its state channel.

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9