### PR TITLE
Add Testing section to README with compile-checked examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,11 @@ Each runnable has its own documentation in its directory (e.g., `runnables/https
 
 ## Testing
 
-Code that uses go-supervisor is most easily tested by implementing the
-relevant interfaces against a fake. The interfaces are small (`Runnable`
-is 3 methods, `Reloadable` is 1, `Stateable` is 2), so a hand-rolled fake
-is usually clearer than a mocking framework. A minimal `Runnable` fake
-that lets a test observe lifecycle transitions:
+To test code that uses go-supervisor, write a fake that implements the
+relevant interfaces. The interfaces are small (`Runnable` is 3 methods,
+`Reloadable` is 1, `Stateable` is 2), so hand-roll the fake rather than
+reach for a mocking framework. The minimal `Runnable` fake below lets
+your test observe lifecycle transitions:
 
 ```go
 type fakeRunnable struct {
@@ -242,17 +242,18 @@ func (f *fakeRunnable) Run(ctx context.Context) error {
 func (f *fakeRunnable) Stop() { close(f.stopped) }
 ```
 
-Register it with `supervisor.New(supervisor.WithRunnables(r))`, run the
-supervisor in a goroutine, and assert on `started`/`stopped` with a
-`select` + timeout. The same pattern extends to `Reloadable` (add a
-`Reload` method) and `Stateable` (return a state string and a state
-channel).
+To drive it: register the fake with `supervisor.New(supervisor.WithRunnables(r))`,
+call `super.Run()` in a goroutine, and assert on `r.started` and
+`r.stopped` with a `select` + timeout. To exercise reload paths, add a
+`Reload(ctx context.Context) error` method. To exercise state
+observability, add `GetState() string` and
+`GetStateChan(context.Context) <-chan string`.
 
-Contributors working on go-supervisor itself can find ready-made
-testify/mock implementations under `internal/mocks/`. These are *not*
-importable by downstream code (Go's `internal/` rule), which is
-intentional — external code should depend only on the public
-interfaces, not on the project's internal test doubles.
+If you are contributing to go-supervisor itself, use the testify/mock
+implementations under `internal/mocks/`. They are deliberately not
+importable from downstream code (Go's `internal/` rule) — your
+application code should depend on the public interfaces, not on this
+project's internal test doubles.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,44 @@ The package includes the following runnable implementations:
 
 Each runnable has its own documentation in its directory (e.g., `runnables/httpserver/README.md`).
 
+## Testing
+
+Code that uses go-supervisor is most easily tested by implementing the
+relevant interfaces against a fake. The interfaces are small (`Runnable`
+is 3 methods, `Reloadable` is 1, `Stateable` is 2), so a hand-rolled fake
+is usually clearer than a mocking framework. A minimal `Runnable` fake
+that lets a test observe lifecycle transitions:
+
+```go
+type fakeRunnable struct {
+    name    string
+    started chan struct{}
+    stopped chan struct{}
+}
+
+func (f *fakeRunnable) String() string { return f.name }
+
+func (f *fakeRunnable) Run(ctx context.Context) error {
+    close(f.started)
+    <-ctx.Done()
+    return nil
+}
+
+func (f *fakeRunnable) Stop() { close(f.stopped) }
+```
+
+Register it with `supervisor.New(supervisor.WithRunnables(r))`, run the
+supervisor in a goroutine, and assert on `started`/`stopped` with a
+`select` + timeout. The same pattern extends to `Reloadable` (add a
+`Reload` method) and `Stateable` (return a state string and a state
+channel).
+
+Contributors working on go-supervisor itself can find ready-made
+testify/mock implementations under `internal/mocks/`. These are *not*
+importable by downstream code (Go's `internal/` rule), which is
+intentional — external code should depend only on the public
+interfaces, not on the project's internal test doubles.
+
 ## License
 
 Apache License 2.0 - See [LICENSE](LICENSE) for details.

--- a/supervisor/readme_test.go
+++ b/supervisor/readme_test.go
@@ -1,0 +1,49 @@
+// Package supervisor_test contains compile-checked mirrors of the code
+// snippets in the top-level README.md. If you edit a snippet under
+// "Testing" (or add a new one), update or add the matching Example
+// function below so `go test` will catch typos and signature drift.
+//
+// Examples follow Go's godoc convention `Example_<suffix>`, where the
+// suffix maps to the README subsection: `testingFakeRunnable` for the
+// fake Runnable shown under "Testing". No Output comment is needed
+// because we only care that the snippets compile against the current
+// supervisor API.
+package supervisor_test
+
+import (
+	"context"
+
+	"github.com/robbyt/go-supervisor/supervisor"
+)
+
+// Mirrors the fakeRunnable definition shown in README.md's "Testing"
+// section. Kept as an unexported type so it doesn't leak into godoc as
+// a public API.
+type readmeFakeRunnable struct {
+	name    string
+	started chan struct{}
+	stopped chan struct{}
+}
+
+func (f *readmeFakeRunnable) String() string { return f.name }
+
+func (f *readmeFakeRunnable) Run(ctx context.Context) error {
+	close(f.started)
+	<-ctx.Done()
+	return nil
+}
+
+func (f *readmeFakeRunnable) Stop() { close(f.stopped) }
+
+// Interface guard mirroring the README's promise that the fake
+// satisfies supervisor.Runnable.
+var _ supervisor.Runnable = (*readmeFakeRunnable)(nil)
+
+func Example_testingFakeRunnable() {
+	r := &readmeFakeRunnable{
+		name:    "fake",
+		started: make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+	_, _ = supervisor.New(supervisor.WithRunnables(r))
+}

--- a/supervisor/readme_test.go
+++ b/supervisor/readme_test.go
@@ -45,5 +45,7 @@ func Example_testingFakeRunnable() {
 		started: make(chan struct{}),
 		stopped: make(chan struct{}),
 	}
-	_, _ = supervisor.New(supervisor.WithRunnables(r))
+	if _, err := supervisor.New(supervisor.WithRunnables(r)); err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
## Summary
This PR adds a new "Testing" section to the README that documents best practices for testing code that uses go-supervisor, along with a compile-checked example implementation.

## Key Changes
- **README.md**: Added comprehensive "Testing" section that:
  - Explains the philosophy of using hand-rolled fakes over mocking frameworks
  - Provides a minimal `fakeRunnable` implementation as a concrete example
  - Documents how to register and test with the fake
  - Mentions the pattern extends to `Reloadable` and `Stateable` interfaces
  - Notes that internal test doubles exist but are not for external use

- **supervisor/readme_test.go**: Added new test file that:
  - Mirrors the `fakeRunnable` code snippet from the README
  - Ensures the example code compiles against the current supervisor API
  - Follows Go's godoc convention with `Example_testingFakeRunnable()`
  - Includes an interface guard to verify the fake satisfies `supervisor.Runnable`
  - Serves as a compile-time check to catch API drift or typos in documentation

## Implementation Details
The test file uses Go's example testing convention to automatically verify that code snippets in the README remain valid and compile-safe. This prevents documentation from becoming stale as the API evolves.

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9