### PR TITLE
Drain httpcluster configSiphon during shutdown

### DIFF
--- a/runnables/httpcluster/options.go
+++ b/runnables/httpcluster/options.go
@@ -83,3 +83,20 @@ func WithRestartDelay(delay time.Duration) Option {
 		return nil
 	}
 }
+
+// WithShutdownTimeout sets the upper bound on the cluster runner's shutdown
+// phase. It currently bounds the background drain that unparks senders blocked
+// on the publicly-exposed configSiphon when the supervisor cancels the
+// runner's context. A timeout of 0 disables the bound; the drain then exits
+// only on quiescence (the channel has been quiet for an internal inactivity
+// window) or when the channel is closed. The default is 5 seconds, matching
+// the supervisor's stateMonitorShutdownTimeout default.
+func WithShutdownTimeout(d time.Duration) Option {
+	return func(r *Runner) error {
+		if d < 0 {
+			return fmt.Errorf("shutdown timeout cannot be negative: %v", d)
+		}
+		r.shutdownTimeout = d
+		return nil
+	}
+}

--- a/runnables/httpcluster/options_test.go
+++ b/runnables/httpcluster/options_test.go
@@ -3,6 +3,7 @@ package httpcluster
 import (
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/robbyt/go-supervisor/runnables/httpserver"
 	"github.com/stretchr/testify/assert"
@@ -65,6 +66,34 @@ func TestWithStateChanBufferSize(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "state channel buffer size cannot be negative")
 		assert.Contains(t, err.Error(), "-1")
+	})
+}
+
+func TestWithShutdownTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default is 5 seconds", func(t *testing.T) {
+		runner, err := NewRunner()
+		require.NoError(t, err)
+		assert.Equal(t, defaultShutdownTimeout, runner.shutdownTimeout)
+	})
+
+	t.Run("positive value is honored", func(t *testing.T) {
+		runner, err := NewRunner(WithShutdownTimeout(2 * time.Second))
+		require.NoError(t, err)
+		assert.Equal(t, 2*time.Second, runner.shutdownTimeout)
+	})
+
+	t.Run("zero disables the bound", func(t *testing.T) {
+		runner, err := NewRunner(WithShutdownTimeout(0))
+		require.NoError(t, err)
+		assert.Equal(t, time.Duration(0), runner.shutdownTimeout)
+	})
+
+	t.Run("negative value returns error", func(t *testing.T) {
+		_, err := NewRunner(WithShutdownTimeout(-1 * time.Second))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "shutdown timeout cannot be negative")
 	})
 }
 

--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -192,11 +192,13 @@ func (r *Runner) Run(ctx context.Context) error {
 		select {
 		case <-runCtx.Done():
 			logger.Debug("Run context cancelled, initiating shutdown")
+			r.drainConfigSiphon()
 			return r.shutdown(runCtx)
 
 		case <-r.lc.StopCh():
 			logger.Debug("Stop() called, initiating shutdown")
 			runCancel()
+			r.drainConfigSiphon()
 			return r.shutdown(runCtx)
 
 		case newConfigs, ok := <-r.configSiphon:
@@ -212,6 +214,44 @@ func (r *Runner) Run(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+// drainConfigSiphon spawns a background goroutine that consumes and discards
+// values from r.configSiphon. It is invoked when shutdown begins to unpark
+// any external goroutines parked in a send on the publicly-exposed siphon
+// channel while the main event loop tears down. The drain runs in the
+// background — it does not block Run() from returning — and exits once the
+// channel has been quiet for the inactivity window or once a hard deadline
+// has elapsed. Callers should still stop publishing on the siphon after the
+// supervisor reports shutdown; the drain only covers the race window where a
+// send was already in flight when shutdown began.
+func (r *Runner) drainConfigSiphon() {
+	const (
+		quiescence = 100 * time.Millisecond
+		maxDrain   = 5 * time.Second
+	)
+	go func() {
+		inactivity := time.NewTimer(quiescence)
+		defer inactivity.Stop()
+		hardDeadline := time.NewTimer(maxDrain)
+		defer hardDeadline.Stop()
+		for {
+			select {
+			case <-r.configSiphon:
+				if !inactivity.Stop() {
+					select {
+					case <-inactivity.C:
+					default:
+					}
+				}
+				inactivity.Reset(quiescence)
+			case <-inactivity.C:
+				return
+			case <-hardDeadline.C:
+				return
+			}
+		}
+	}()
 }
 
 // Stop signals the cluster to stop all servers and shut down.

--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -16,6 +16,7 @@ import (
 const (
 	defaultDeadlineServerStart = 10 * time.Second
 	defaultRestartDelay        = 10 * time.Millisecond
+	defaultShutdownTimeout     = 5 * time.Second
 )
 
 type fsm interface {
@@ -38,6 +39,7 @@ type Runner struct {
 	runnerFactory       runnerFactory
 	restartDelay        time.Duration
 	deadlineServerStart time.Duration
+	shutdownTimeout     time.Duration
 
 	// Configuration siphon channel
 	configSiphon chan map[string]*httpserver.Config
@@ -80,6 +82,7 @@ func NewRunner(opts ...Option) (*Runner, error) {
 		logger:              slog.Default().WithGroup("httpcluster.Runner"),
 		restartDelay:        defaultRestartDelay,
 		deadlineServerStart: defaultDeadlineServerStart,
+		shutdownTimeout:     defaultShutdownTimeout,
 		configSiphon: make(
 			chan map[string]*httpserver.Config,
 		), // unbuffered by default
@@ -221,20 +224,23 @@ func (r *Runner) Run(ctx context.Context) error {
 // any external goroutines parked in a send on the publicly-exposed siphon
 // channel while the main event loop tears down. The drain runs in the
 // background — it does not block Run() from returning — and exits once the
-// channel has been quiet for the inactivity window or once a hard deadline
-// has elapsed. Callers should still stop publishing on the siphon after the
+// channel has been quiet for the inactivity window, the channel is closed,
+// or r.shutdownTimeout has elapsed (whichever comes first). A shutdownTimeout
+// of zero disables the hard deadline; the drain then exits only on quiescence
+// or close. Callers should still stop publishing on the siphon after the
 // supervisor reports shutdown; the drain only covers the race window where a
 // send was already in flight when shutdown began.
 func (r *Runner) drainConfigSiphon() {
-	const (
-		quiescence = 100 * time.Millisecond
-		maxDrain   = 5 * time.Second
-	)
+	const quiescence = 100 * time.Millisecond
 	go func() {
 		inactivity := time.NewTimer(quiescence)
 		defer inactivity.Stop()
-		hardDeadline := time.NewTimer(maxDrain)
-		defer hardDeadline.Stop()
+		var hardDeadline <-chan time.Time
+		if r.shutdownTimeout > 0 {
+			t := time.NewTimer(r.shutdownTimeout)
+			defer t.Stop()
+			hardDeadline = t.C
+		}
 		for {
 			select {
 			case _, ok := <-r.configSiphon:
@@ -242,7 +248,7 @@ func (r *Runner) drainConfigSiphon() {
 					// Siphon closed by its owner (WithCustomSiphonChannel
 					// callers can do this). Receives would otherwise return
 					// immediately forever, resetting the inactivity timer on
-					// every iteration and spinning until the hard deadline.
+					// every iteration and spinning until shutdownTimeout.
 					return
 				}
 				if !inactivity.Stop() {
@@ -254,7 +260,7 @@ func (r *Runner) drainConfigSiphon() {
 				inactivity.Reset(quiescence)
 			case <-inactivity.C:
 				return
-			case <-hardDeadline.C:
+			case <-hardDeadline:
 				return
 			}
 		}

--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -237,7 +237,14 @@ func (r *Runner) drainConfigSiphon() {
 		defer hardDeadline.Stop()
 		for {
 			select {
-			case <-r.configSiphon:
+			case _, ok := <-r.configSiphon:
+				if !ok {
+					// Siphon closed by its owner (WithCustomSiphonChannel
+					// callers can do this). Receives would otherwise return
+					// immediately forever, resetting the inactivity timer on
+					// every iteration and spinning until the hard deadline.
+					return
+				}
 				if !inactivity.Stop() {
 					select {
 					case <-inactivity.C:

--- a/runnables/httpcluster/runner_drain_test.go
+++ b/runnables/httpcluster/runner_drain_test.go
@@ -231,7 +231,7 @@ func TestDrainExitsOnShutdownTimeout(t *testing.T) {
 		time.Sleep(2 * time.Second)
 		synctest.Wait()
 		frozen := sent.Load()
-		require.Greater(t, frozen, int64(0),
+		require.Positive(t, frozen,
 			"publisher must have delivered values to the drain before the deadline")
 
 		// More synthetic time: with the drain gone, the count cannot

--- a/runnables/httpcluster/runner_drain_test.go
+++ b/runnables/httpcluster/runner_drain_test.go
@@ -1,0 +1,119 @@
+package httpcluster
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/robbyt/go-supervisor/internal/finitestate"
+	"github.com/robbyt/go-supervisor/runnables/httpserver"
+	"github.com/robbyt/go-supervisor/runnables/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShutdownDrainsConfigSiphon verifies that external goroutines parked in a
+// send on the public siphon channel are unblocked when the runner shuts down.
+// Without the drain, a parked sender would block forever because the main
+// event loop has exited and nothing is reading the channel.
+//
+// The test forces senders to park by using a slow runner factory: while the
+// event loop is in createAndStartServer the unbuffered siphon has no reader,
+// so any concurrent send blocks until either the reader returns to the select
+// or the drain consumes the value.
+func TestShutdownDrainsConfigSiphon(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		shutdown func(runner *Runner, cancel context.CancelFunc)
+	}{
+		{
+			name: "ctx cancel",
+			shutdown: func(_ *Runner, cancel context.CancelFunc) {
+				cancel()
+			},
+		},
+		{
+			name: "Stop()",
+			shutdown: func(r *Runner, _ context.CancelFunc) {
+				r.Stop()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Slow factory keeps the reader busy in createAndStartServer
+			// long enough for subsequent senders to be parked on the
+			// unbuffered siphon when shutdown is triggered.
+			factory := func(ctx context.Context, _ string, _ *httpserver.Config, _ slog.Handler) (httpServerRunner, error) {
+				time.Sleep(50 * time.Millisecond)
+				m := mocks.NewMockRunnableWithStateable()
+				m.On("Run", mock.Anything).Run(func(mock.Arguments) {
+					<-ctx.Done()
+				}).Return(nil)
+				m.On("Stop").Return().Maybe()
+				m.On("GetState").Return(finitestate.StatusRunning)
+				m.On("IsReady").Return(true)
+				stateChan := make(chan string, 1)
+				stateChan <- finitestate.StatusRunning
+				m.On("GetStateChan", mock.Anything).Return(stateChan)
+				return m, nil
+			}
+
+			runner, err := NewRunner(WithRunnerFactory(factory))
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			runErr := make(chan error, 1)
+			go func() { runErr <- runner.Run(ctx) }()
+			require.Eventually(t, runner.IsReady, time.Second, 10*time.Millisecond)
+
+			// Many senders each pushing a unique server config, so the reader
+			// has real work (factory call) per receive and the senders pile up.
+			const numSenders = 20
+			var senderWg sync.WaitGroup
+			senderWg.Add(numSenders)
+			siphon := runner.GetConfigSiphon()
+			for i := range numSenders {
+				go func() {
+					defer senderWg.Done()
+					addr := fmt.Sprintf(":%d", 18000+i)
+					siphon <- map[string]*httpserver.Config{
+						fmt.Sprintf("server%d", i): createTestHTTPConfig(t, addr),
+					}
+				}()
+			}
+
+			// Give the reader time to consume one or two configs and start
+			// the slow factory, parking the remaining senders.
+			time.Sleep(30 * time.Millisecond)
+
+			tt.shutdown(runner, cancel)
+
+			select {
+			case <-runErr:
+			case <-time.After(5 * time.Second):
+				t.Fatal("Run() did not return after shutdown")
+			}
+
+			done := make(chan struct{})
+			go func() {
+				senderWg.Wait()
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("Siphon senders blocked after shutdown; drain did not unblock them")
+			}
+		})
+	}
+}

--- a/runnables/httpcluster/runner_drain_test.go
+++ b/runnables/httpcluster/runner_drain_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -164,5 +165,85 @@ func TestDrainExitsWhenSiphonClosed(t *testing.T) {
 		// stays runnable and synctest will surface a deadlock when the
 		// bubble cleanup runs.
 		<-runErr
+	})
+}
+
+// TestDrainExitsOnShutdownTimeout verifies the hard-deadline exit path: when
+// a caller keeps publishing to the siphon faster than the drain's internal
+// inactivity window, quiescence can never fire and the drain must rely on
+// WithShutdownTimeout as its safety bound. Without that bound, a misbehaving
+// publisher could keep the drain goroutine alive indefinitely.
+//
+// The test publishes every 50ms (well below the 100ms quiescence window) so
+// the drain's inactivity timer is reset on every receive. The only exit path
+// left is the shutdownTimeout. After it elapses, the drain returns and the
+// publisher's next send parks forever — which the test asserts by observing
+// that the publisher's success counter stops growing across additional
+// synthetic time.
+func TestDrainExitsOnShutdownTimeout(t *testing.T) {
+	t.Parallel()
+
+	synctest.Test(t, func(t *testing.T) {
+		customSiphon := make(chan map[string]*httpserver.Config)
+		runner, err := NewRunner(
+			WithCustomSiphonChannel(customSiphon),
+			WithShutdownTimeout(500*time.Millisecond),
+		)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		runErr := make(chan error, 1)
+		go func() { runErr <- runner.Run(ctx) }()
+		synctest.Wait()
+		require.True(t, runner.IsReady())
+
+		// Trigger shutdown: cancel and let Run return. The drain is now
+		// the only consumer on the siphon and is running on its own
+		// 500ms deadline.
+		cancel()
+		<-runErr
+
+		// Continuous publisher: 50ms interval < 100ms quiescence, so
+		// the drain's inactivity timer is reset on every receive and
+		// can never fire. Only shutdownTimeout can release the drain.
+		stop := make(chan struct{})
+		var sent atomic.Int64
+		go func() {
+			cfg := map[string]*httpserver.Config{
+				"keepalive": createTestHTTPConfig(t, ":18999"),
+			}
+			for {
+				select {
+				case <-stop:
+					return
+				case customSiphon <- cfg:
+					sent.Add(1)
+					time.Sleep(50 * time.Millisecond)
+				}
+			}
+		}()
+
+		// Advance well past the deadline. If the drain were missing or
+		// unbounded, it would still be receiving and sent would keep
+		// climbing. If the deadline fires, the drain exits and the
+		// publisher's next send parks; sent freezes.
+		time.Sleep(2 * time.Second)
+		synctest.Wait()
+		frozen := sent.Load()
+		require.Greater(t, frozen, int64(0),
+			"publisher must have delivered values to the drain before the deadline")
+
+		// More synthetic time: with the drain gone, the count cannot
+		// change. If it does, the drain is still consuming and the
+		// deadline did not bound it.
+		time.Sleep(2 * time.Second)
+		synctest.Wait()
+		require.Equal(t, frozen, sent.Load(),
+			"drain must exit on shutdownTimeout; publisher should be parked on send")
+
+		// Release the publisher so the synctest bubble has no lingering
+		// goroutines when it exits.
+		close(stop)
 	})
 }

--- a/runnables/httpcluster/runner_drain_test.go
+++ b/runnables/httpcluster/runner_drain_test.go
@@ -1,13 +1,12 @@
 package httpcluster
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
-	"runtime"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
@@ -25,7 +24,8 @@ import (
 // The test forces senders to park by using a slow runner factory: while the
 // event loop is in createAndStartServer the unbuffered siphon has no reader,
 // so any concurrent send blocks until either the reader returns to the select
-// or the drain consumes the value.
+// or the drain consumes the value. Under synctest the slow factory's sleep
+// is synthetic and the test runs in zero real time.
 func TestShutdownDrainsConfigSiphon(t *testing.T) {
 	t.Parallel()
 
@@ -49,73 +49,75 @@ func TestShutdownDrainsConfigSiphon(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				// Slow factory keeps the reader busy in createAndStartServer
+				// long enough for subsequent senders to be parked on the
+				// unbuffered siphon when shutdown is triggered. The sleep
+				// is synthetic under synctest and advances automatically.
+				factory := func(ctx context.Context, _ string, _ *httpserver.Config, _ slog.Handler) (httpServerRunner, error) {
+					time.Sleep(50 * time.Millisecond)
+					m := mocks.NewMockRunnableWithStateable()
+					m.On("Run", mock.Anything).Run(func(mock.Arguments) {
+						<-ctx.Done()
+					}).Return(nil)
+					m.On("Stop").Return().Maybe()
+					m.On("GetState").Return(finitestate.StatusRunning)
+					m.On("IsReady").Return(true)
+					stateChan := make(chan string, 1)
+					stateChan <- finitestate.StatusRunning
+					m.On("GetStateChan", mock.Anything).Return(stateChan)
+					return m, nil
+				}
 
-			// Slow factory keeps the reader busy in createAndStartServer
-			// long enough for subsequent senders to be parked on the
-			// unbuffered siphon when shutdown is triggered.
-			factory := func(ctx context.Context, _ string, _ *httpserver.Config, _ slog.Handler) (httpServerRunner, error) {
-				time.Sleep(50 * time.Millisecond)
-				m := mocks.NewMockRunnableWithStateable()
-				m.On("Run", mock.Anything).Run(func(mock.Arguments) {
-					<-ctx.Done()
-				}).Return(nil)
-				m.On("Stop").Return().Maybe()
-				m.On("GetState").Return(finitestate.StatusRunning)
-				m.On("IsReady").Return(true)
-				stateChan := make(chan string, 1)
-				stateChan <- finitestate.StatusRunning
-				m.On("GetStateChan", mock.Anything).Return(stateChan)
-				return m, nil
-			}
+				runner, err := NewRunner(WithRunnerFactory(factory))
+				require.NoError(t, err)
 
-			runner, err := NewRunner(WithRunnerFactory(factory))
-			require.NoError(t, err)
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+				runErr := make(chan error, 1)
+				go func() { runErr <- runner.Run(ctx) }()
 
-			ctx, cancel := context.WithCancel(t.Context())
-			defer cancel()
-			runErr := make(chan error, 1)
-			go func() { runErr <- runner.Run(ctx) }()
-			require.Eventually(t, runner.IsReady, time.Second, 10*time.Millisecond)
+				// Settle initialization so IsReady is observable.
+				synctest.Wait()
+				require.True(t, runner.IsReady())
 
-			// Many senders each pushing a unique server config, so the reader
-			// has real work (factory call) per receive and the senders pile up.
-			const numSenders = 20
-			var senderWg sync.WaitGroup
-			senderWg.Add(numSenders)
-			siphon := runner.GetConfigSiphon()
-			for i := range numSenders {
-				go func() {
-					defer senderWg.Done()
-					addr := fmt.Sprintf(":%d", 18000+i)
-					siphon <- map[string]*httpserver.Config{
-						fmt.Sprintf("server%d", i): createTestHTTPConfig(t, addr),
-					}
-				}()
-			}
+				// Many senders each pushing a unique server config. The
+				// reader is in the slow factory; all but one are parked
+				// on the unbuffered siphon when shutdown begins.
+				const numSenders = 20
+				var senderWg sync.WaitGroup
+				senderWg.Add(numSenders)
+				siphon := runner.GetConfigSiphon()
+				for i := range numSenders {
+					go func() {
+						defer senderWg.Done()
+						addr := fmt.Sprintf(":%d", 18000+i)
+						siphon <- map[string]*httpserver.Config{
+							fmt.Sprintf("server%d", i): createTestHTTPConfig(t, addr),
+						}
+					}()
+				}
 
-			// Give the reader time to consume one or two configs and start
-			// the slow factory, parking the remaining senders.
-			time.Sleep(30 * time.Millisecond)
+				tt.shutdown(runner, cancel)
 
-			tt.shutdown(runner, cancel)
+				// Block on Run's return. While the test goroutine is
+				// durably blocked here, synctest advances time so the
+				// reader's factory sleep completes, the shutdown path
+				// runs, and the drain consumes the parked senders.
+				<-runErr
 
-			select {
-			case <-runErr:
-			case <-time.After(5 * time.Second):
-				t.Fatal("Run() did not return after shutdown")
-			}
-
-			done := make(chan struct{})
-			go func() {
+				// All senders must have completed. Without the drain
+				// (bug), these stay parked and synctest reports a
+				// deadlock when the bubble exits.
 				senderWg.Wait()
-				close(done)
-			}()
-			select {
-			case <-done:
-			case <-time.After(5 * time.Second):
-				t.Fatal("Siphon senders blocked after shutdown; drain did not unblock them")
-			}
+
+				// The drain does not observe ctx — it exits when its
+				// inactivity timer (100ms synthetic) fires. Synthetic
+				// sleep past it so the drain returns cleanly before the
+				// bubble checks for lingering goroutines. (Real elapsed
+				// time inside the bubble is zero.)
+				time.Sleep(150 * time.Millisecond)
+			})
 		})
 	}
 }
@@ -128,39 +130,39 @@ func TestShutdownDrainsConfigSiphon(t *testing.T) {
 // resetting the inactivity timer on every iteration until the hard deadline.
 // The fix is to inspect the receive's ok value and return when the channel
 // is closed.
+//
+// Under synctest, a spinning drain is detectable: it is never durably blocked
+// (the receive returns immediately every iteration), so time cannot advance
+// and the bubble cannot drain. synctest.Test reports the lingering goroutine
+// when the test function returns.
 func TestDrainExitsWhenSiphonClosed(t *testing.T) {
 	t.Parallel()
 
-	customSiphon := make(chan map[string]*httpserver.Config)
-	runner, err := NewRunner(WithCustomSiphonChannel(customSiphon))
-	require.NoError(t, err)
+	synctest.Test(t, func(t *testing.T) {
+		customSiphon := make(chan map[string]*httpserver.Config)
+		runner, err := NewRunner(WithCustomSiphonChannel(customSiphon))
+		require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
-	runErr := make(chan error, 1)
-	go func() { runErr <- runner.Run(ctx) }()
-	require.Eventually(t, runner.IsReady, time.Second, 10*time.Millisecond)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		runErr := make(chan error, 1)
+		go func() { runErr <- runner.Run(ctx) }()
+		synctest.Wait()
+		require.True(t, runner.IsReady())
 
-	// Trigger ctx-cancel shutdown (which spawns the drain) and then close
-	// the siphon from outside. Order matters: the drain must already be
-	// running when the close arrives, otherwise the main loop's !ok branch
-	// handles shutdown and the drain never spawns.
-	cancel()
-	close(customSiphon)
+		// Cancel first so the reader picks runCtx.Done and spawns the
+		// drain; settle so the drain is alive before the close arrives.
+		cancel()
+		synctest.Wait()
 
-	select {
-	case <-runErr:
-	case <-time.After(2 * time.Second):
-		t.Fatal("Run() did not return")
-	}
+		// Now close the siphon. A drain that ignored ok would spin on
+		// the closed receive forever.
+		close(customSiphon)
 
-	// After shutdown the drain goroutine must have exited. We grep all
-	// goroutine stacks for the drain's function name; a spinning drain
-	// would still be alive here until the 5s hard deadline.
-	require.Eventually(t, func() bool {
-		buf := make([]byte, 64*1024)
-		n := runtime.Stack(buf, true)
-		return !bytes.Contains(buf[:n], []byte("drainConfigSiphon"))
-	}, 500*time.Millisecond, 10*time.Millisecond,
-		"drainConfigSiphon goroutine still alive after siphon close — drain is spinning")
+		// Block on Run's return so synctest can advance time. With the
+		// fix the drain observes !ok and exits; with the bug the drain
+		// stays runnable and synctest will surface a deadlock when the
+		// bubble cleanup runs.
+		<-runErr
+	})
 }

--- a/runnables/httpcluster/runner_drain_test.go
+++ b/runnables/httpcluster/runner_drain_test.go
@@ -1,9 +1,11 @@
 package httpcluster
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -116,4 +118,49 @@ func TestShutdownDrainsConfigSiphon(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDrainExitsWhenSiphonClosed verifies that the shutdown drain exits when
+// the siphon channel is closed by its owner. WithCustomSiphonChannel lets
+// callers own the channel; if a caller cancels the supervisor's context and
+// also closes the siphon, the drain (spawned by the ctx-cancel case) would
+// hot-loop on a receive that always returns immediately — pegging CPU and
+// resetting the inactivity timer on every iteration until the hard deadline.
+// The fix is to inspect the receive's ok value and return when the channel
+// is closed.
+func TestDrainExitsWhenSiphonClosed(t *testing.T) {
+	t.Parallel()
+
+	customSiphon := make(chan map[string]*httpserver.Config)
+	runner, err := NewRunner(WithCustomSiphonChannel(customSiphon))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- runner.Run(ctx) }()
+	require.Eventually(t, runner.IsReady, time.Second, 10*time.Millisecond)
+
+	// Trigger ctx-cancel shutdown (which spawns the drain) and then close
+	// the siphon from outside. Order matters: the drain must already be
+	// running when the close arrives, otherwise the main loop's !ok branch
+	// handles shutdown and the drain never spawns.
+	cancel()
+	close(customSiphon)
+
+	select {
+	case <-runErr:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run() did not return")
+	}
+
+	// After shutdown the drain goroutine must have exited. We grep all
+	// goroutine stacks for the drain's function name; a spinning drain
+	// would still be alive here until the 5s hard deadline.
+	require.Eventually(t, func() bool {
+		buf := make([]byte, 64*1024)
+		n := runtime.Stack(buf, true)
+		return !bytes.Contains(buf[:n], []byte("drainConfigSiphon"))
+	}, 500*time.Millisecond, 10*time.Millisecond,
+		"drainConfigSiphon goroutine still alive after siphon close — drain is spinning")
 }

--- a/runnables/httpcluster/runner_drain_test.go
+++ b/runnables/httpcluster/runner_drain_test.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/robbyt/go-supervisor/runnables/httpserver"
-	"github.com/robbyt/go-supervisor/runnables/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
## Summary
- `httpcluster.Runner` exposes `GetConfigSiphon()` as the public way to push new configs into the cluster. Until now the only reader was `Run()`'s main event loop, so any goroutine parked in a send on that channel when shutdown began would block forever — `Run()` returned via `r.shutdown(...)` without ever draining the channel.
- This is the same hazard shape as the old `ShutdownSender` / `reloadListener` race fixed in #101 (where a send on a runner-internal channel could deadlock after `Run()` had exited). The previous full-project audit did not visit `httpcluster`; this fix closes the equivalent gap there.
- Spawns a background drain goroutine when either shutdown trigger fires (`runCtx.Done()` or `lc.StopCh()`). The drain consumes-and-discards from `configSiphon` until either the channel has been quiet for 100ms or a 5s hard deadline elapses. It is intentionally non-blocking so `Run()` returns promptly; the drain only covers the race window where a send was already in flight when shutdown began. Callers should still stop publishing after the supervisor reports shutdown.

## Implementation notes
- An earlier draft used a blocking drain that stopped the moment `shutdown()` returned. That was insufficient when shutdown completes quickly (mocked servers, fast cleanup): the drain only got a few microseconds before its `stopDrain()` fired, and the parked senders that hadn't been consumed yet stayed parked. The current non-blocking design with a quiescence window lets `Run()` return without waiting on the drain while still unparking stragglers.
- The drain uses two timers (`inactivity` + `hardDeadline`). On each receive the inactivity timer is reset; once it fires (no traffic for `quiescence`) the drain exits. The `hardDeadline` is a safety bound so a buggy caller that keeps sending forever can't pin a drain goroutine indefinitely.

## Test plan
- [x] New `TestShutdownDrainsConfigSiphon` covers both shutdown paths (ctx cancel, `Stop()`). Uses a slow runner factory (50ms sleep inside `createAndStartServer`) to deterministically park ~19/20 senders before triggering shutdown, then asserts all 20 unblock within a bounded timeout. Verified failing before the fix and passing after.
- [x] `go test -race ./runnables/httpcluster/ ./supervisor/ ./runnables/httpserver/ ./runnables/composite/` — green.
- [x] `go vet ./...` — clean.

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_