### PR TITLE
composite: reject nil Runnable entries at construction

### DIFF
--- a/runnables/composite/config.go
+++ b/runnables/composite/config.go
@@ -32,13 +32,41 @@ type Config[T runnable] struct {
 	Entries []RunnableEntry[T]
 }
 
-// NewConfig creates a new Config instance for a CompositeRunner
+// isNil reports whether v is nil. Handles three cases that all satisfy
+// the runnable interface constraint:
+//   - true nil interface (no concrete type): reflect.ValueOf returns an
+//     invalid Value.
+//   - typed-nil pointer/interface/etc held in an interface T: the Value
+//     is valid with a nillable Kind and IsNil() == true.
+//   - non-nil pointer or struct-valued T: caught by the default branch.
+func isNil[T runnable](v T) bool {
+	rv := reflect.ValueOf(v)
+	if !rv.IsValid() {
+		return true
+	}
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func,
+		reflect.Map, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
+
+// NewConfig creates a new Config instance for a CompositeRunner. Returns
+// ErrNilRunnable if any entry's Runnable is nil — see ErrNilRunnable's
+// godoc for context.
 func NewConfig[T runnable](
 	name string,
 	entries []RunnableEntry[T],
 ) (*Config[T], error) {
 	if name == "" {
 		return nil, errors.New("name cannot be empty")
+	}
+	for i, entry := range entries {
+		if isNil(entry.Runnable) {
+			return nil, fmt.Errorf("%w: index %d", ErrNilRunnable, i)
+		}
 	}
 
 	return &Config[T]{
@@ -47,28 +75,22 @@ func NewConfig[T runnable](
 	}, nil
 }
 
-// NewConfigFromRunnables creates a Config from a list of runnables, all using the same config
+// NewConfigFromRunnables creates a Config from a list of runnables, all
+// using the same config. Delegates to NewConfig so nil-runnable validation
+// runs in one place.
 func NewConfigFromRunnables[T runnable](
 	name string,
 	runnables []T,
 	sharedConfig any,
 ) (*Config[T], error) {
-	if name == "" {
-		return nil, errors.New("name cannot be empty")
-	}
-
 	entries := make([]RunnableEntry[T], len(runnables))
-	for i, runnable := range runnables {
+	for i, r := range runnables {
 		entries[i] = RunnableEntry[T]{
-			Runnable: runnable,
+			Runnable: r,
 			Config:   sharedConfig,
 		}
 	}
-
-	return &Config[T]{
-		Name:    name,
-		Entries: entries,
-	}, nil
+	return NewConfig(name, entries)
 }
 
 // Equal compares two configs for equality

--- a/runnables/composite/config.go
+++ b/runnables/composite/config.go
@@ -45,7 +45,7 @@ func isNil[T runnable](v T) bool {
 		return true
 	}
 	switch rv.Kind() {
-	case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Func,
+	case reflect.Pointer, reflect.Interface, reflect.Chan, reflect.Func,
 		reflect.Map, reflect.Slice:
 		return rv.IsNil()
 	default:

--- a/runnables/composite/config_test.go
+++ b/runnables/composite/config_test.go
@@ -118,7 +118,7 @@ func TestNewConfigFromRunnables_RejectsNilRunnable(t *testing.T) {
 
 	cfg, err := NewConfigFromRunnables(
 		"test",
-		[]*mocks.Runnable{&mocks.Runnable{}, nil},
+		[]*mocks.Runnable{{}, nil},
 		nil,
 	)
 	assert.Nil(t, cfg)

--- a/runnables/composite/config_test.go
+++ b/runnables/composite/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/robbyt/go-supervisor/internal/mocks"
+	"github.com/robbyt/go-supervisor/supervisor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,6 +77,53 @@ func TestNewConfigFromRunnables(t *testing.T) {
 	assert.Equal(t, mockRunnable2, cfg.Entries[1].Runnable)
 	assert.Equal(t, sharedConfig, cfg.Entries[0].Config)
 	assert.Equal(t, sharedConfig, cfg.Entries[1].Config)
+}
+
+// TestNewConfig_RejectsNilEntry verifies that a typed-nil pointer in a
+// RunnableEntry is caught at construction time rather than panicking
+// later inside the lifecycle (Equal, boot, stopAll, GetChildStates all
+// call methods on the runnable).
+func TestNewConfig_RejectsNilEntry(t *testing.T) {
+	t.Parallel()
+
+	entries := []RunnableEntry[*mocks.Runnable]{
+		{Runnable: nil, Config: nil},
+	}
+	cfg, err := NewConfig("name", entries)
+	assert.Nil(t, cfg)
+	require.ErrorIs(t, err, ErrNilRunnable)
+	assert.Contains(t, err.Error(), "index 0")
+}
+
+// TestNewConfig_RejectsNilInterfaceEntry verifies the same protection
+// when T is the supervisor.Runnable interface type. An interface holding
+// a nil concrete pointer is itself non-nil (the classic Go gotcha), so
+// the validation must use reflect-based nil-checking to catch both.
+func TestNewConfig_RejectsNilInterfaceEntry(t *testing.T) {
+	t.Parallel()
+
+	entries := []RunnableEntry[supervisor.Runnable]{
+		{Runnable: nil, Config: nil},
+	}
+	cfg, err := NewConfig("name", entries)
+	assert.Nil(t, cfg)
+	require.ErrorIs(t, err, ErrNilRunnable)
+	assert.Contains(t, err.Error(), "index 0")
+}
+
+// TestNewConfigFromRunnables_RejectsNilRunnable verifies the validation
+// runs via the delegated NewConfig call. Reports the offending index.
+func TestNewConfigFromRunnables_RejectsNilRunnable(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := NewConfigFromRunnables(
+		"test",
+		[]*mocks.Runnable{&mocks.Runnable{}, nil},
+		nil,
+	)
+	assert.Nil(t, cfg)
+	require.ErrorIs(t, err, ErrNilRunnable)
+	assert.Contains(t, err.Error(), "index 1")
 }
 
 func TestConfig_Equal(t *testing.T) {

--- a/runnables/composite/config_test.go
+++ b/runnables/composite/config_test.go
@@ -111,6 +111,31 @@ func TestNewConfig_RejectsNilInterfaceEntry(t *testing.T) {
 	assert.Contains(t, err.Error(), "index 0")
 }
 
+// TestNewConfig_RejectsTypedNilInInterface verifies the classic Go nil
+// gotcha: an interface value with a non-nil dynamic type but a nil
+// dynamic value. The interface itself satisfies `!= nil`, but every
+// method call on it panics. isNil's reflect.Pointer branch must catch
+// this — guarding against the case the docs explicitly call out.
+func TestNewConfig_RejectsTypedNilInInterface(t *testing.T) {
+	t.Parallel()
+
+	var nilPtr *mocks.Runnable                   // typed nil pointer
+	var asInterface supervisor.Runnable = nilPtr // non-nil interface holding the nil pointer
+	// Go-level `asInterface != nil` is true here (interface has a
+	// type even though the value is nil) — that's the gotcha. Calling
+	// any method on it would panic. testify's NotNil is smart enough
+	// to look through this so we don't bother asserting it.
+
+	entries := []RunnableEntry[supervisor.Runnable]{
+		{Runnable: &mocks.Runnable{}, Config: nil},
+		{Runnable: asInterface, Config: nil},
+	}
+	cfg, err := NewConfig("name", entries)
+	assert.Nil(t, cfg)
+	require.ErrorIs(t, err, ErrNilRunnable)
+	assert.Contains(t, err.Error(), "index 1")
+}
+
 // TestNewConfigFromRunnables_RejectsNilRunnable verifies the validation
 // runs via the delegated NewConfig call. Reports the offending index.
 func TestNewConfigFromRunnables_RejectsNilRunnable(t *testing.T) {

--- a/runnables/composite/errors.go
+++ b/runnables/composite/errors.go
@@ -28,4 +28,12 @@ var (
 	// reload request was accepted into Run's event loop, or while a
 	// caller was waiting for the accepted request to finish.
 	ErrReloadAbandoned = errors.New("reload abandoned because runner stopped")
+
+	// ErrNilRunnable is returned by NewConfig / NewConfigFromRunnables
+	// when a RunnableEntry's Runnable field is nil. Typically surfaces
+	// from accidentally passing a typed-nil pointer (e.g.,
+	// `var x *MyRunnable` left uninitialized) which satisfies the
+	// interface constraint at compile time but blows up later inside
+	// the lifecycle when any method is called on it.
+	ErrNilRunnable = errors.New("entry has nil runnable")
 )


### PR DESCRIPTION
## Summary

Closes FS-3 from the open audit queue.

`composite.NewConfig` and `NewConfigFromRunnables` previously accepted entries whose `Runnable` field was nil. Because `T` is constrained to `supervisor.Runnable` (an interface), a typed-nil pointer satisfies the constraint at compile time — the nil-deref then panics deep inside the runner lifecycle (`Config.Equal` calls `.String()`, `boot`/`stopAll`/`GetChildStates` all call methods on the runnable) long after the caller has handed the config to a runner.

Validate at construction time:

- New `ErrNilRunnable` sentinel in `runnables/composite/errors.go`.
- New `isNil[T runnable]` helper in `config.go` that uses `reflect` to handle all three cases the interface constraint admits:
  - true nil interface (no concrete type): `reflect.ValueOf` returns an invalid `Value`.
  - typed-nil pointer/interface/etc: `Kind()` is nillable and `IsNil() == true`.
  - non-nil pointer or struct-valued T: caught by the default branch.
- `NewConfig` validates every entry. `NewConfigFromRunnables` delegates to `NewConfig` so the check runs in exactly one place (also drops the duplicated `name == ""` check).

### Behavior change

A nil `RunnableEntry.Runnable` now returns `ErrNilRunnable` from `NewConfig` / `NewConfigFromRunnables` instead of silently constructing a `*Config` that later panics. Callers using `errors.Is(err, composite.ErrNilRunnable)` can distinguish this from other construction errors.

### Test plan

- [x] `TestNewConfig_RejectsNilEntry` — concrete-pointer T with nil entry.
- [x] `TestNewConfig_RejectsNilInterfaceEntry` — interface-typed T (`supervisor.Runnable`) with literal nil, exercises the `reflect.Invalid` path.
- [x] `TestNewConfigFromRunnables_RejectsNilRunnable` — nil slice element, reports the offending index.
- [x] `go vet ./...` clean.
- [x] `go test -race ./runnables/composite/...` green; existing tests untouched.
- [x] `go test -race ./...` (full repo) green.

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_