### PR TITLE
httpserver: per-method godoc on HttpServer interface

### DIFF
--- a/runnables/httpserver/runner.go
+++ b/runnables/httpserver/runner.go
@@ -27,9 +27,25 @@ var (
 // ConfigCallback is the function type signature for the callback used to load initial config, and new config during Reload()
 type ConfigCallback func() (*Config, error)
 
-// HttpServer is the interface for the HTTP server
+// HttpServer is the runner's abstraction over the underlying HTTP server.
+// It exposes the subset of net/http.Server's methods the runner needs, so
+// alternative implementations (test doubles, custom server types) can be
+// plugged in via ServerCreator. *net/http.Server satisfies this interface
+// directly; see DefaultServerCreator for the default factory.
 type HttpServer interface {
+	// ListenAndServe binds the configured listen address and serves
+	// HTTP requests until Shutdown is called or a fatal error occurs.
+	// Returns http.ErrServerClosed after a successful Shutdown; any
+	// other non-nil return is treated as a fatal startup or runtime
+	// error and trips the cluster FSM into Error.
 	ListenAndServe() error
+
+	// Shutdown gracefully terminates the server. Stops accepting new
+	// connections immediately, then waits for in-flight requests to
+	// complete or for ctx to be canceled — whichever comes first.
+	// Returns ctx.Err() if the deadline elapses with active requests
+	// still running (those requests continue on connections that
+	// outlive Shutdown); returns nil on clean drain.
 	Shutdown(ctx context.Context) error
 }
 

--- a/runnables/httpserver/runner.go
+++ b/runnables/httpserver/runner.go
@@ -30,22 +30,25 @@ type ConfigCallback func() (*Config, error)
 // HttpServer is the runner's abstraction over the underlying HTTP server.
 // It exposes the subset of net/http.Server's methods the runner needs, so
 // alternative implementations (test doubles, custom server types) can be
-// plugged in via ServerCreator. *net/http.Server satisfies this interface
-// directly; see DefaultServerCreator for the default factory.
+// plugged in via ServerCreator. *http.Server (from net/http) satisfies
+// this interface directly; see DefaultServerCreator for the default
+// factory.
 type HttpServer interface {
 	// ListenAndServe binds the configured listen address and serves
 	// HTTP requests until Shutdown is called or a fatal error occurs.
 	// Returns http.ErrServerClosed after a successful Shutdown; any
 	// other non-nil return is treated as a fatal startup or runtime
-	// error and trips the cluster FSM into Error.
+	// error and trips this runner's FSM into Error (the per-server
+	// state machine — not the surrounding httpcluster runner, if any).
 	ListenAndServe() error
 
 	// Shutdown gracefully terminates the server. Stops accepting new
 	// connections immediately, then waits for in-flight requests to
-	// complete or for ctx to be canceled — whichever comes first.
-	// Returns ctx.Err() if the deadline elapses with active requests
-	// still running (those requests continue on connections that
-	// outlive Shutdown); returns nil on clean drain.
+	// complete or for ctx to be Done — whichever comes first. Returns
+	// ctx.Err() whenever ctx is Done with active requests still
+	// running (deadline exceeded or cancellation); those requests
+	// continue on connections that outlive Shutdown. Returns nil on
+	// clean drain.
 	Shutdown(ctx context.Context) error
 }
 


### PR DESCRIPTION
## Summary

Closes F-B from the open audit queue. The `HttpServer` interface in `runnables/httpserver/runner.go:30-34` had a single one-line comment and no per-method documentation — the last gap from audit item #17.

Added per-method godoc covering:

- **Type**: explains the interface is a pluggable abstraction over `net/http.Server`, satisfied directly by `*http.Server`, with the `ServerCreator` option as the customization seam.
- **`ListenAndServe`**: documents the success-vs-fatal contract used by the runner (`http.ErrServerClosed` = clean stop; anything else trips the FSM into Error).
- **`Shutdown`**: documents the graceful-drain semantics and the `ctx.Err()` return path, mirroring `net/http.Server`'s behavior.

Docs-only change. No behavior change, no tests touched.

### Test plan

- [x] `go vet ./...` clean.
- [x] `go test -race ./runnables/httpserver/...` green.

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_