### PR TITLE
docs: compile-check README Quick Start + Reloadable Service

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,7 +50,7 @@ jobs:
           github.com/robbyt/go-supervisor/supervisor/...
 
       - name: Build examples
-        run: cd examples/http && go build .
+        run: go build ./examples/...
 
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v8

--- a/examples/quickstart/main.go
+++ b/examples/quickstart/main.go
@@ -1,0 +1,77 @@
+// Quickstart example mirrors the "Quick Start" code block in the
+// top-level README.md. Kept in sync so `go build ./examples/...`
+// catches signature drift between the docs and the supervisor API.
+// See PRs #128, #129 for the same pattern applied to other README
+// snippets via readme_test.go.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/robbyt/go-supervisor/supervisor"
+)
+
+// Example service that implements Runnable interface
+type MyService struct {
+	name string
+}
+
+// Interface guard, ensuring that MyService implements Runnable
+var _ supervisor.Runnable = (*MyService)(nil)
+
+func (s *MyService) Run(ctx context.Context) error {
+	fmt.Printf("%s: Starting\n", s.name)
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Printf("%s: Context canceled\n", s.name)
+			return nil
+		case <-ticker.C:
+			fmt.Printf("%s: Tick\n", s.name)
+		}
+	}
+}
+
+func (s *MyService) Stop() {
+	fmt.Printf("%s: Stopping\n", s.name)
+	// Perform cleanup if needed
+}
+
+func (s *MyService) String() string {
+	return s.name
+}
+
+func main() {
+	// Create some services
+	service1 := &MyService{name: "Service1"}
+	service2 := &MyService{name: "Service2"}
+
+	// Create a custom logger
+	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+
+	// Create a supervisor with our services and custom logger
+	super, err := supervisor.New(
+		supervisor.WithRunnables(service1, service2),
+		supervisor.WithLogHandler(handler),
+	)
+	if err != nil {
+		fmt.Printf("Error creating supervisor: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Blocking call to Run(), starts listening to signals and starts all Runnables
+	if err := super.Run(); err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/supervisor/readme_test.go
+++ b/supervisor/readme_test.go
@@ -1,17 +1,21 @@
 // Package supervisor_test contains compile-checked mirrors of the code
-// snippets in the top-level README.md. If you edit a snippet under
-// "Testing" (or add a new one), update or add the matching Example
+// snippets in the top-level README.md. If you edit one of the mirrored
+// snippets (or add a new one), update or add the matching Example
 // function below so `go test` will catch typos and signature drift.
 //
 // Examples follow Go's godoc convention `Example_<suffix>`, where the
 // suffix maps to the README subsection: `testingFakeRunnable` for the
-// fake Runnable shown under "Testing". No Output comment is needed
-// because we only care that the snippets compile against the current
-// supervisor API.
+// fake Runnable shown under "Testing", `reloadableConfigurable` for the
+// `ConfigurableService` snippet under "Implementing a Reloadable
+// Service". No Output comment is needed because we only care that the
+// snippets compile against the current supervisor API.
 package supervisor_test
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"time"
 
 	"github.com/robbyt/go-supervisor/supervisor"
 )
@@ -46,6 +50,76 @@ func Example_testingFakeRunnable() {
 		stopped: make(chan struct{}),
 	}
 	if _, err := supervisor.New(supervisor.WithRunnables(r)); err != nil {
+		panic(err)
+	}
+}
+
+// readmeMyService mirrors the MyService struct defined in README.md's
+// "Quick Start" — the Reloadable Service snippet extends this type so
+// we need a local stand-in to compile-check the snippet here. The
+// Quick Start itself lives in examples/quickstart/main.go.
+type readmeMyService struct {
+	name string
+}
+
+func (s *readmeMyService) String() string { return s.name }
+
+func (s *readmeMyService) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (s *readmeMyService) Stop() {}
+
+// readmeConfig mirrors the Config struct defined inline in the
+// Reloadable Service snippet.
+type readmeConfig struct {
+	Interval time.Duration
+}
+
+// readmeLoadConfig stands in for the snippet's loadConfig() helper.
+// The README leaves it undefined (a user-supplied loader); the stub
+// just returns a non-nil config so Reload's success path compiles.
+func readmeLoadConfig() (*readmeConfig, error) {
+	return &readmeConfig{Interval: time.Second}, nil
+}
+
+// Mirrors the ConfigurableService struct from README.md's
+// "Implementing a Reloadable Service" section. Kept unexported so it
+// doesn't leak into godoc.
+type readmeConfigurableService struct {
+	readmeMyService
+	config *readmeConfig
+	mu     sync.Mutex
+}
+
+// Interface guards, ensuring that the snippet's compose still
+// satisfies both Runnable and Reloadable.
+var (
+	_ supervisor.Runnable   = (*readmeConfigurableService)(nil)
+	_ supervisor.Reloadable = (*readmeConfigurableService)(nil)
+)
+
+func (s *readmeConfigurableService) Reload(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Load new config from file or environment
+	newConfig, err := readmeLoadConfig()
+	if err != nil {
+		return err
+	}
+	s.config = newConfig
+
+	fmt.Printf("%s: Configuration reloaded\n", s.name)
+	return nil
+}
+
+func Example_reloadableConfigurable() {
+	s := &readmeConfigurableService{
+		readmeMyService: readmeMyService{name: "service"},
+	}
+	if _, err := supervisor.New(supervisor.WithRunnables(s)); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
## Summary

Closes F-A from the open audit queue. Extends the `readme_test.go` compile-check pattern established by PRs #128 and #129 to two remaining README sections.

**1. Quick Start (`README.md:30-103`)** — Added `examples/quickstart/main.go` byte-identical to the snippet. CI's "Build examples" step was previously scoped to `examples/http` only; broadened to `go build ./examples/...` in `.github/workflows/go.yml` so every example (including the new one and any future additions) is compile-checked on every push.

**2. Implementing a Reloadable Service (`README.md:178-207`)** — Extended `supervisor/readme_test.go` with:
- `readmeMyService` — stub for the embedded type (Quick Start's `MyService` isn't in this package).
- `readmeConfig` + `readmeLoadConfig` — fill in the snippet's undefined references.
- `readmeConfigurableService` — embeds `readmeMyService`, implements `Reload()` per the snippet. Interface guards for both `Runnable` and `Reloadable`.
- `Example_reloadableConfigurable` — instantiates and hands the service to `supervisor.New` so the constructor signature is also covered.
- Header comment broadened from "Testing section only" to "any mirrored README snippet".

### Test plan

- [x] `go build ./examples/...` succeeds locally (catches Quick Start drift).
- [x] `go vet ./...` clean.
- [x] `go test -race ./supervisor/...` green; the new `Example_reloadableConfigurable` compiles.
- [x] `go test -race ./...` (full repo) green.

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_