### PR TITLE
httpserver: bundle server + sync.Once into serverInstance (FS-4)

### DIFF
--- a/runnables/httpserver/options_test.go
+++ b/runnables/httpserver/options_test.go
@@ -109,12 +109,12 @@ func TestWithServerCreator(t *testing.T) {
 	// Call the ServerCreator directly to test it properly
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {})
-	server.server = cfg.ServerCreator(testAddr, mux, cfg)
+	server.instance.Store(&serverInstance{server: cfg.ServerCreator(testAddr, mux, cfg)})
 	// Verify the custom creator was called with correct parameters
 	assert.Equal(t, testAddr, capturedAddr, "Server creator should receive correct address")
 	assert.NotNil(t, capturedHandler, "Server creator should receive a handler")
 	// Verify the created server is our mock
-	assert.Same(t, mockServer, server.server, "Server should be our mock instance")
+	assert.Same(t, mockServer, server.instance.Load().server, "Server should be our mock instance")
 	// The server is created but not started, so we don't need to stop it
 	// The FSM would be in the 'New' state, not 'Running', so stopServer would fail
 }

--- a/runnables/httpserver/reload_test.go
+++ b/runnables/httpserver/reload_test.go
@@ -589,7 +589,7 @@ func TestExecuteReloadStopsExistingServerWithMock(t *testing.T) {
 
 	oldServer := &MockHttpServer{}
 	oldServer.On("Shutdown", mock.Anything).Return(nil).Once()
-	runner.server = oldServer
+	runner.instance.Store(&serverInstance{server: oldServer})
 
 	updatedCfg := createReloadTestConfig(t, "invalid-port", "/", 2*time.Second)
 	err = runner.executeReload(t.Context(), updatedCfg)
@@ -617,7 +617,7 @@ func TestExecuteReloadLogsFailureInsteadOfCompletion(t *testing.T) {
 
 	oldServer := &MockHttpServer{}
 	oldServer.On("Shutdown", mock.Anything).Return(nil).Once()
-	runner.server = oldServer
+	runner.instance.Store(&serverInstance{server: oldServer})
 
 	updatedCfg := createReloadTestConfig(t, "invalid-port", "/", 2*time.Second)
 	err = runner.executeReload(t.Context(), updatedCfg)

--- a/runnables/httpserver/runner.go
+++ b/runnables/httpserver/runner.go
@@ -375,8 +375,14 @@ func (r *Runner) boot(ctx context.Context) error {
 
 	// Initialize server instance. The fresh *serverInstance carries
 	// its own sync.Once for shutdown, so we don't need to reset
-	// anything from a prior boot.
-	inst := &serverInstance{server: serverCfg.createServer()}
+	// anything from a prior boot. A misbehaving ServerCreator that
+	// returns nil is caught here rather than panicking later in
+	// ListenAndServe or Shutdown.
+	serverImpl := serverCfg.createServer()
+	if serverImpl == nil {
+		return fmt.Errorf("%w: server creator returned nil", ErrServerBoot)
+	}
+	inst := &serverInstance{server: serverImpl}
 	r.instance.Store(inst)
 
 	r.logger.Debug("Starting HTTP server",
@@ -486,7 +492,11 @@ func (r *Runner) getConfig() (*Config, error) {
 // fresh instance brings a fresh gate.
 func (r *Runner) stopServer(ctx context.Context) error {
 	inst := r.instance.Load()
-	if inst == nil {
+	// Treat a nil-server instance the same as a missing instance — the
+	// boot path validates the ServerCreator's return value, but this
+	// guard keeps the shutdown path safe against any future caller
+	// that stores a partially-constructed *serverInstance.
+	if inst == nil || inst.server == nil {
 		return ErrServerNotRunning
 	}
 

--- a/runnables/httpserver/runner.go
+++ b/runnables/httpserver/runner.go
@@ -75,12 +75,26 @@ type Runner struct {
 
 	reloadCh chan *reloadReq
 
-	server          HttpServer
-	serverCloseOnce sync.Once
-	serverMutex     sync.RWMutex
-	serverErrors    chan error
+	// instance holds the live HttpServer alongside its one-shot
+	// shutdown gate. Each boot creates a fresh *serverInstance and
+	// installs it via atomic Store; stopServer reads it via atomic
+	// Load and clears it via CompareAndSwap on completion. The
+	// sync.Once is bound to the specific server it shipped with, so
+	// there is no "reset between boots" pattern — see serverInstance.
+	instance     atomic.Pointer[serverInstance]
+	serverErrors chan error
 
 	logger *slog.Logger
+}
+
+// serverInstance bundles an HttpServer with its one-shot shutdown gate.
+// Each boot constructs a fresh instance; the closeOnce is bound to this
+// specific server, so a subsequent boot's instance carries a fresh
+// sync.Once instead of reassigning one — eliminating the "reset
+// sync.Once between operations" pattern flagged in the audit.
+type serverInstance struct {
+	server    HttpServer
+	closeOnce sync.Once
 }
 
 // reloadReq carries an accepted reload from Reload(ctx) into Run's event loop
@@ -102,13 +116,12 @@ func NewRunner(opts ...Option) (*Runner, error) {
 	logger := slog.Default().WithGroup("httpserver.Runner")
 
 	r := &Runner{
-		lc:              lifecycle.New(),
-		name:            "",
-		config:          atomic.Pointer[Config]{},
-		serverCloseOnce: sync.Once{},
-		serverErrors:    make(chan error, 1),
-		reloadCh:        make(chan *reloadReq, 1),
-		logger:          logger,
+		lc:           lifecycle.New(),
+		name:         "",
+		config:       atomic.Pointer[Config]{},
+		serverErrors: make(chan error, 1),
+		reloadCh:     make(chan *reloadReq, 1),
+		logger:       logger,
 	}
 
 	// Apply options
@@ -360,11 +373,11 @@ func (r *Runner) boot(ctx context.Context) error {
 
 	listenAddr := serverCfg.ListenAddr
 
-	// Initialize server instance and reset shutdown guard
-	r.serverMutex.Lock()
-	r.server = serverCfg.createServer()
-	r.serverCloseOnce = sync.Once{}
-	r.serverMutex.Unlock()
+	// Initialize server instance. The fresh *serverInstance carries
+	// its own sync.Once for shutdown, so we don't need to reset
+	// anything from a prior boot.
+	inst := &serverInstance{server: serverCfg.createServer()}
+	r.instance.Store(inst)
 
 	r.logger.Debug("Starting HTTP server",
 		"listenOn", listenAddr,
@@ -373,18 +386,11 @@ func (r *Runner) boot(ctx context.Context) error {
 		"idleTimeout", serverCfg.IdleTimeout,
 		"drainTimeout", serverCfg.DrainTimeout)
 
-	// Start HTTP server in background goroutine
+	// Start HTTP server in background goroutine. The local `inst`
+	// captured here is the same pointer we just stored — a later boot
+	// can install a new instance without disturbing this goroutine.
 	go func() {
-		r.serverMutex.RLock()
-		server := r.server
-		r.serverMutex.RUnlock()
-
-		if server == nil {
-			r.logger.Debug("Server was nil, not starting")
-			return
-		}
-
-		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := inst.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			r.serverErrors <- err
 		}
 		r.logger.Debug("HTTP server stopped", "listenOn", listenAddr)
@@ -398,13 +404,13 @@ func (r *Runner) boot(ctx context.Context) error {
 		return fmt.Errorf("%w: %w", ErrServerBoot, err)
 	}
 
-	// Retrieve actual listening address for port 0 assignments
+	// Retrieve actual listening address for port 0 assignments.
+	// Reuse the local `inst` captured at boot — it's still the live
+	// instance because boot serializes with stopServer via r.mutex.
 	actualAddr := listenAddr
-	r.serverMutex.RLock()
-	if tcpAddr, ok := r.server.(interface{ Addr() net.Addr }); ok && tcpAddr.Addr() != nil {
+	if tcpAddr, ok := inst.server.(interface{ Addr() net.Addr }); ok && tcpAddr.Addr() != nil {
 		actualAddr = tcpAddr.Addr().String()
 	}
-	r.serverMutex.RUnlock()
 
 	r.logger.Debug("HTTP server is ready",
 		"addr", actualAddr)
@@ -475,17 +481,18 @@ func (r *Runner) getConfig() (*Config, error) {
 // its ctx fires; it just stops waiting and returns. Active requests
 // continue running on connections that outlive Shutdown.
 //
-// sync.Once ensures shutdown runs at most once per server instance.
+// Each *serverInstance carries its own sync.Once, so shutdown runs at
+// most once per server instance — even across the boot/reload cycle a
+// fresh instance brings a fresh gate.
 func (r *Runner) stopServer(ctx context.Context) error {
+	inst := r.instance.Load()
+	if inst == nil {
+		return ErrServerNotRunning
+	}
+
 	var shutdownErr error
 	//nolint:contextcheck // intentional: Run cancels runCtx before shutdown(); a ctx-derived timeout would fire immediately and skip the drain
-	r.serverCloseOnce.Do(func() {
-		r.serverMutex.RLock()
-		defer r.serverMutex.RUnlock()
-		if r.server == nil {
-			shutdownErr = ErrServerNotRunning
-			return
-		}
+	inst.closeOnce.Do(func() {
 		r.logger.Debug("Stopping HTTP server")
 
 		// Read the cached config directly: this is a shutdown path and
@@ -503,7 +510,7 @@ func (r *Runner) stopServer(ctx context.Context) error {
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), drainTimeout)
 		defer shutdownCancel()
 
-		localErr := r.server.Shutdown(shutdownCtx)
+		localErr := inst.server.Shutdown(shutdownCtx)
 
 		// Detect timeout regardless of Shutdown() return value
 		select {
@@ -524,10 +531,11 @@ func (r *Runner) stopServer(ctx context.Context) error {
 		}
 	})
 
-	// Reset server reference after shutdown attempt
-	r.serverMutex.Lock()
-	r.server = nil
-	r.serverMutex.Unlock()
+	// Clear the instance only if it's still the one we shut down. If a
+	// concurrent boot installed a fresh instance, leave it in place
+	// rather than stomping it. (In practice r.mutex serializes
+	// stopServer and boot; the CAS is belt-and-suspenders.)
+	r.instance.CompareAndSwap(inst, nil)
 
 	return shutdownErr
 }

--- a/runnables/httpserver/runner_shutdown_test.go
+++ b/runnables/httpserver/runner_shutdown_test.go
@@ -38,7 +38,7 @@ func TestStopServerFailures(t *testing.T) {
 		runner, err := NewRunner(WithConfigCallback(callback))
 		require.NoError(t, err)
 
-		runner.server = mockServer
+		runner.instance.Store(&serverInstance{server: mockServer})
 
 		err = runner.stopServer(context.Background())
 		require.Error(t, err)
@@ -59,7 +59,7 @@ func TestStopServerFailures(t *testing.T) {
 		runner, err := NewRunner(WithConfigCallback(callback))
 		require.NoError(t, err)
 
-		runner.server = mockServer
+		runner.instance.Store(&serverInstance{server: mockServer})
 
 		err = runner.stopServer(context.Background())
 		require.Error(t, err)
@@ -78,7 +78,7 @@ func TestStopServerFailures(t *testing.T) {
 		runner, err := NewRunner(WithConfigCallback(callback))
 		require.NoError(t, err)
 
-		runner.server = mockServer
+		runner.instance.Store(&serverInstance{server: mockServer})
 
 		// Clear config to test default drain timeout path
 		runner.config.Store(nil)
@@ -133,7 +133,7 @@ func TestShutdownFSMTransitions(t *testing.T) {
 		err = runner.fsm.Transition("Running")
 		require.NoError(t, err)
 
-		runner.server = mockServer
+		runner.instance.Store(&serverInstance{server: mockServer})
 
 		// Call shutdown and verify state transitions
 		err = runner.shutdown(context.Background())
@@ -163,7 +163,7 @@ func TestShutdownFSMTransitions(t *testing.T) {
 		err = runner.fsm.Transition("Running")
 		require.NoError(t, err)
 
-		runner.server = mockServer
+		runner.instance.Store(&serverInstance{server: mockServer})
 
 		// Call shutdown and expect error
 		err = runner.shutdown(context.Background())
@@ -191,7 +191,7 @@ func TestShutdownFSMTransitions(t *testing.T) {
 		err = runner.fsm.Transition("Running")
 		require.NoError(t, err)
 
-		runner.server = mockServer
+		runner.instance.Store(&serverInstance{server: mockServer})
 
 		// Force FSM into Stopping state, then call shutdown which will try to transition to Stopping again
 		// This should cause the first transition to fail, but continue
@@ -221,7 +221,7 @@ func TestShutdownFSMTransitions(t *testing.T) {
 		err = runner.fsm.Transition("Error")
 		require.NoError(t, err)
 
-		runner.server = mockServer
+		runner.instance.Store(&serverInstance{server: mockServer})
 
 		// Call shutdown - initial FSM transition will fail but shutdown should continue
 		err = runner.shutdown(context.Background())
@@ -294,7 +294,7 @@ func TestServerCleanupOnlyOnce(t *testing.T) {
 	require.NoError(t, err)
 
 	// Replace the server with our mock server
-	runner.server = mockServer
+	runner.instance.Store(&serverInstance{server: mockServer})
 
 	// Run stopServer twice concurrently to verify that sync.Once prevents
 	// the actual shutdown from running more than once
@@ -359,27 +359,28 @@ func TestStopServerResetsOnRestart(t *testing.T) {
 	runner, err := NewRunner(WithConfigCallback(cfgCallback))
 	require.NoError(t, err)
 
-	// Replace the server with our mock server
-	runner.server = mockServer
+	// Install the mock as the live server instance
+	runner.instance.Store(&serverInstance{server: mockServer})
 
 	// Stop the server once
 	err = runner.stopServer(context.Background())
 	require.NoError(t, err)
 
-	// Server should be nil after stopServer completes
-	assert.Nil(t, runner.server)
+	// instance should be nil after stopServer completes
+	assert.Nil(t, runner.instance.Load())
 
-	// Simulate a boot sequence that sets a new server and resets serverCloseOnce
+	// Simulate a boot sequence that installs a fresh instance. The
+	// new *serverInstance carries its own sync.Once gate, so no
+	// reset step is needed (which is the whole point of FS-4).
 	mockServer2 := &mockCountingServer{}
-	runner.server = mockServer2
-	runner.serverCloseOnce = sync.Once{} // This would normally be done by boot()
+	runner.instance.Store(&serverInstance{server: mockServer2})
 
 	// Attempt to stop the new server
 	err = runner.stopServer(context.Background())
 	require.NoError(t, err)
 
-	// The server should be nil again after the second shutdown
-	assert.Nil(t, runner.server)
+	// instance should be nil again after the second shutdown
+	assert.Nil(t, runner.instance.Load())
 
 	// Verify second server was also shut down
 	mockServer2.mutex.Lock()

--- a/runnables/httpserver/runner_shutdown_test.go
+++ b/runnables/httpserver/runner_shutdown_test.go
@@ -389,6 +389,61 @@ func TestStopServerResetsOnRestart(t *testing.T) {
 	assert.Equal(t, 1, calls, "Second server should be shut down once")
 }
 
+// TestStopServer_NilServerInstance verifies the defensive nil-server
+// guard in stopServer: if a partially-constructed *serverInstance ever
+// reaches r.instance (the boot path validates ServerCreator's return,
+// but this branch protects future callers and tests), stopServer
+// returns ErrServerNotRunning instead of panicking on inst.server.Shutdown.
+func TestStopServer_NilServerInstance(t *testing.T) {
+	t.Parallel()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	route, err := NewRouteFromHandlerFunc("test", "/test", handler)
+	require.NoError(t, err)
+	port := fmt.Sprintf(":%d", networking.GetRandomPort(t))
+	cfgCallback := func() (*Config, error) {
+		return NewConfig(port, Routes{*route})
+	}
+	runner, err := NewRunner(WithConfigCallback(cfgCallback))
+	require.NoError(t, err)
+
+	// Install a serverInstance whose server is nil (the scenario the
+	// guard protects against).
+	runner.instance.Store(&serverInstance{server: nil})
+
+	err = runner.stopServer(context.Background())
+	require.ErrorIs(t, err, ErrServerNotRunning,
+		"nil-server instance must surface as ErrServerNotRunning, not panic")
+}
+
+// TestBoot_NilFromServerCreator verifies that a custom ServerCreator
+// that returns a nil HttpServer causes boot to fail fast with
+// ErrServerBoot rather than installing a broken instance and
+// panicking later inside ListenAndServe.
+func TestBoot_NilFromServerCreator(t *testing.T) {
+	t.Parallel()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {}
+	route, err := NewRouteFromHandlerFunc("test", "/test", handler)
+	require.NoError(t, err)
+	port := fmt.Sprintf(":%d", networking.GetRandomPort(t))
+	nilCreator := func(addr string, h http.Handler, cfg *Config) HttpServer {
+		return nil
+	}
+	cfgCallback := func() (*Config, error) {
+		return NewConfig(port, Routes{*route}, WithServerCreator(nilCreator))
+	}
+	runner, err := NewRunner(WithConfigCallback(cfgCallback))
+	require.NoError(t, err)
+
+	bootErr := runner.boot(context.Background())
+	require.Error(t, bootErr)
+	require.ErrorIs(t, bootErr, ErrServerBoot)
+	assert.Contains(t, bootErr.Error(), "server creator returned nil")
+	assert.Nil(t, runner.instance.Load(),
+		"boot must not install a broken instance when ServerCreator returns nil")
+}
+
 // TestRun_ShutdownDeadlineExceeded tests shutdown behavior when a handler exceeds the drain timeout
 func TestRun_ShutdownDeadlineExceeded(t *testing.T) {
 	if testing.Short() {

--- a/runnables/httpserver/runner_test.go
+++ b/runnables/httpserver/runner_test.go
@@ -64,10 +64,10 @@ func TestCustomServerCreator(t *testing.T) {
 	require.NotNil(t, cfg.ServerCreator, "ServerCreator should not be nil")
 
 	// Create and set the server using the custom creator
-	runner.server = cfg.ServerCreator(cfg.ListenAddr, http.HandlerFunc(handler), cfg)
+	runner.instance.Store(&serverInstance{server: cfg.ServerCreator(cfg.ListenAddr, http.HandlerFunc(handler), cfg)})
 
 	// Verify the server was created with our custom creator
-	assert.Same(t, mockServer, runner.server, "Server should be our mock instance")
+	assert.Same(t, mockServer, runner.instance.Load().server, "Server should be our mock instance")
 
 	// Directly test the mock's methods without going through the runner's FSM
 	// This avoids FSM state transition issues in the test
@@ -477,7 +477,7 @@ func TestHandleReloadSetsErrorWhenRunningTransitionFails(t *testing.T) {
 
 	oldServer := &MockHttpServer{}
 	oldServer.On("Shutdown", mock.Anything).Return(nil).Once()
-	server.server = oldServer
+	server.instance.Store(&serverInstance{server: oldServer})
 
 	stateMachine := NewMockStateMachine()
 	stateMachine.On("Transition", finitestate.StatusRunning).Return(assert.AnError).Once()


### PR DESCRIPTION
The httpserver runner was reassigning `r.serverCloseOnce = sync.Once{}` in `boot()` to "reset" its shutdown gate between server instances. Reassigning `sync.Once` is unidiomatic — the type is designed for "do this thing exactly once per object" — and was only safe because all accesses sat behind `serverMutex`. A future refactor that read `serverCloseOnce` outside that mutex would have silently become racy.

Restructure: bundle the live `HttpServer` with its own one-shot gate.

```go
type serverInstance struct {
    server    HttpServer
    closeOnce sync.Once
}

type Runner struct {
    // ...
    instance atomic.Pointer[serverInstance]
    // serverMutex deleted
}
```

- `boot()` constructs a fresh `*serverInstance` and `r.instance.Store(inst)`. The new instance's `closeOnce` is fresh by construction — no reassignment.
- `stopServer()` does `inst := r.instance.Load(); inst.closeOnce.Do(...)`, then `r.instance.CompareAndSwap(inst, nil)` to clear (only if it's still the one we shut down — defensive against a hypothetical concurrent boot, though `r.mutex` already serializes them).
- The "reset `sync.Once` between operations" pattern is structurally impossible now.
- `serverMutex` is gone entirely — the atomic pointer provides all the synchronization between `boot`, `stopServer`, and the in-flight `ListenAndServe` goroutine.

### Behavior change

None observable to callers. All public methods behave identically; this is a structural cleanup of the internal lifecycle.

### Test plan

- [x] Existing `TestStopServerResetsOnRestart` updated: now exercises the production reset path (install a new instance instead of reaching into `r.serverCloseOnce = sync.Once{}`).
- [x] All other tests that reached into `r.server` directly now use `r.instance.Store(&serverInstance{...})` and `r.instance.Load()`.
- [x] `go vet ./...` clean.
- [x] `go test -race ./runnables/httpserver/...` green.
- [x] `go test -race -count=10 ./runnables/httpserver/...` green (33s) — locking change exercised under high repeat.
- [x] `go test -race ./...` (full repo) green.

https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA2UbdU3HWyhHvYVSt93g9)_