### PR TITLE
ci: add parallel race-detector job with shared build/module cache

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -68,3 +68,24 @@ jobs:
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.language=go
             -Dsonar.sourceEncoding=UTF-8
+
+  race:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          # Shares the module (~/go/pkg/mod) and build (~/.cache/go-build)
+          # caches with the `build` job: setup-go keys the cache on the OS, Go
+          # version, and go.sum hash, so both jobs restore from the same entry.
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Display Go version
+        run: go version
+
+      - name: Go test (race detector)
+        run: go test -race -timeout 5m ./...


### PR DESCRIPTION
## Why

CI runs the test suite **without** the race detector — `.github/workflows/go.yml` runs `go test -cover …` with no `-race`. Only the local `make test` target enables `-race`, so data races never fail a PR. This is the first PR in a small race-condition hardening series; it lands the guardrail first so the follow-up repro tests actually gate merges.

## What

- Adds a second job `race` that runs `go test -race -timeout 5m ./...`, in parallel with the existing `build` job (coverage / lint / Sonar / examples).
- Both jobs use `actions/setup-go@v6` caching keyed on `go.sum`, so they **share** the module cache (`~/go/pkg/mod`) and build cache (`~/.cache/go-build`) rather than each rebuilding from scratch.
- The `build` job is intentionally left without `-race` so coverage/Sonar timing and output are unchanged.

## Notes

Part of a progressive audit. Follow-up PRs (each TDD, failing repro first) will fix:
1. an httpcluster data race in `shutdown()` (writes shared state under `RLock`),
2. an httpserver reload bug where a stale instance's error can kill a healthy runner,
3. an httpcluster stability issue where one crashed backend permanently wedges the whole cluster.

Landing this job first means those repro tests will fail CI until their fix lands.

https://claude.ai/code/session_01M2nd9n1KAjj41j2VzrZ7WE

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2nd9n1KAjj41j2VzrZ7WE)_