### PR TITLE
httpcluster: fix data race in shutdown() writing currentEntries under RLock

### DIFF
--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -327,8 +327,13 @@ func (r *Runner) Stop() {
 func (r *Runner) shutdown(ctx context.Context) error {
 	logger := r.logger.WithGroup("shutdown")
 	logger.Debug("Shutting down...")
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	// Write lock: shutdown reassigns r.currentEntries (the commit below), so
+	// it must exclude the RLock readers GetServerCount()/String(). Holding
+	// only RLock here was a data race. The call chain (executeActions →
+	// stopServers/startServers) never re-acquires r.mu, so this can't
+	// self-deadlock; a concurrent removeEntryIfMatches (Lock) simply waits.
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/runnables/httpcluster/shutdown_race_test.go
+++ b/runnables/httpcluster/shutdown_race_test.go
@@ -1,0 +1,59 @@
+package httpcluster
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+
+	"github.com/robbyt/go-supervisor/internal/finitestate"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShutdown_NoRaceWithConcurrentReaders is a regression test for a data
+// race in shutdown(): it held only r.mu.RLock() while reassigning
+// r.currentEntries, so it raced concurrent RLock readers such as
+// GetServerCount() and String().
+//
+// Written with testing/synctest so the bubble bounds all spawned goroutines;
+// the race detector still observes true concurrency inside the bubble. Run
+// under `go test -race` — before the fix this fails with a write/read data
+// race on r.currentEntries; after switching shutdown() to a write lock it
+// passes clean.
+func TestShutdown_NoRaceWithConcurrentReaders(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		r, err := NewRunner()
+		require.NoError(t, err)
+
+		// Drive the FSM to Running so shutdown()'s Stopping/Stopped
+		// transitions are valid without standing up the full Run loop.
+		require.NoError(t, r.fsm.Transition(finitestate.StatusBooting))
+		require.NoError(t, r.fsm.Transition(finitestate.StatusRunning))
+
+		var stop atomic.Bool
+		var wg sync.WaitGroup
+
+		// Hammer the RLock readers concurrently with shutdown(). GetServerCount
+		// is a pure r.mu.RLock + read of currentEntries, giving an unmasked
+		// race signal against shutdown()'s reassignment of the same field.
+		const readers = 16
+		for i := 0; i < readers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for !stop.Load() {
+					_ = r.GetServerCount()
+					_ = r.String()
+				}
+			}()
+		}
+
+		// Empty cluster: shutdown still reassigns r.currentEntries (the
+		// commit at the end of the function), which is the racy write.
+		require.NoError(t, r.shutdown(context.Background()))
+
+		stop.Store(true)
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
## Bug

`httpcluster.Runner.shutdown()` held only `r.mu.RLock()` (runner.go:330) but reassigned `r.currentEntries` at its final commit (runner.go:349) — a **write under a read lock**. The `RLock` readers `GetServerCount()` (runner.go:122) and `String()` (runner.go:166) read the same field concurrently, so this is a write/read data race. Every other writer (`processConfigUpdate`, `removeEntryIfMatches`) correctly takes the write lock; `shutdown` was the lone offender.

It was latent because no test exercised a reader concurrently with shutdown, and (until #138) CI didn't run `-race`.

## Fix

Switch `shutdown()` to `r.mu.Lock()`. Verified safe against deadlock: the call chain (`executeActions` → `stopServers`/`startServers`) never re-acquires `r.mu`; a concurrent `removeEntryIfMatches` (which takes `Lock`) simply waits.

## Test (TDD, failing-first)

Adds `shutdown_race_test.go` using `testing/synctest` (Go 1.26). It drives the FSM to `Running`, then hammers `GetServerCount()`/`String()` from 16 goroutines while calling `shutdown()`. `GetServerCount` is a pure `RLock` + read of `currentEntries`, giving an unmasked race signal.

Before the fix (`go test -race`):
```
WARNING: DATA RACE
Write at ... by goroutine 11:
  (*Runner).shutdown()  runner.go:349
Previous read at ... by goroutine 12:
  (*Runner).GetServerCount()  runner.go:122
```
After the fix: package green under `-race`.

https://claude.ai/code/session_01M2nd9n1KAjj41j2VzrZ7WE

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2nd9n1KAjj41j2VzrZ7WE)_