### PR TITLE
httpcluster: recover from Error state via a new config update

### DIFF
--- a/runnables/httpcluster/recovery_test.go
+++ b/runnables/httpcluster/recovery_test.go
@@ -61,22 +61,31 @@ func TestRunner_RecoversFromErrorViaConfigUpdate(t *testing.T) {
 		"cluster should recover to Running with the new server")
 
 	cancel()
-	select {
-	case err := <-runErr:
-		require.NoError(t, err)
-	case <-time.After(2 * time.Second):
-		t.Fatal("cluster did not shut down after ctx cancel")
-	}
+	var stopErr error
+	require.Eventually(t, func() bool {
+		select {
+		case stopErr = <-runErr:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond, "cluster did not shut down after ctx cancel")
+	require.NoError(t, stopErr)
 }
 
 // sendConfig pushes a config on the cluster's siphon, failing fast instead of
 // hanging until the test timeout if the event loop is not receiving (e.g. Run
-// exited early).
+// exited early). The non-blocking send is retried via require.Eventually until
+// the event loop accepts it.
 func sendConfig(t *testing.T, c *Runner, cfg map[string]*httpserver.Config) {
 	t.Helper()
-	select {
-	case c.configSiphon <- cfg:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out sending config on siphon - event loop not receiving")
-	}
+	require.Eventually(t, func() bool {
+		select {
+		case c.configSiphon <- cfg:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 10*time.Millisecond,
+		"timed out sending config on siphon - event loop not receiving")
 }

--- a/runnables/httpcluster/recovery_test.go
+++ b/runnables/httpcluster/recovery_test.go
@@ -43,17 +43,17 @@ func TestRunner_RecoversFromErrorViaConfigUpdate(t *testing.T) {
 	require.Eventually(t, cluster.IsReady, time.Second, 5*time.Millisecond)
 
 	// 1. Wedge the cluster: a failing server trips it into Error.
-	cluster.configSiphon <- map[string]*httpserver.Config{
+	sendConfig(t, cluster, map[string]*httpserver.Config{
 		brokenID: createTestHTTPConfig(t, ":18301"),
-	}
+	})
 	require.Eventually(t, func() bool {
 		return cluster.GetState() == finitestate.StatusError
 	}, 2*time.Second, 10*time.Millisecond, "cluster should enter Error")
 
 	// 2. Recover: a new valid config must be applied, not silently dropped.
-	cluster.configSiphon <- map[string]*httpserver.Config{
+	sendConfig(t, cluster, map[string]*httpserver.Config{
 		"good": createTestHTTPConfig(t, ":18302"),
-	}
+	})
 	require.Eventually(t, func() bool {
 		return cluster.GetState() == finitestate.StatusRunning &&
 			cluster.GetServerCount() == 1
@@ -66,5 +66,17 @@ func TestRunner_RecoversFromErrorViaConfigUpdate(t *testing.T) {
 		require.NoError(t, err)
 	case <-time.After(2 * time.Second):
 		t.Fatal("cluster did not shut down after ctx cancel")
+	}
+}
+
+// sendConfig pushes a config on the cluster's siphon, failing fast instead of
+// hanging until the test timeout if the event loop is not receiving (e.g. Run
+// exited early).
+func sendConfig(t *testing.T, c *Runner, cfg map[string]*httpserver.Config) {
+	t.Helper()
+	select {
+	case c.configSiphon <- cfg:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out sending config on siphon - event loop not receiving")
 	}
 }

--- a/runnables/httpcluster/recovery_test.go
+++ b/runnables/httpcluster/recovery_test.go
@@ -1,0 +1,70 @@
+package httpcluster
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/robbyt/go-supervisor/internal/finitestate"
+	"github.com/robbyt/go-supervisor/runnables/httpserver"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunner_RecoversFromErrorViaConfigUpdate verifies that a cluster wedged in
+// the Error state (e.g. after a backend crash or a failed config update) can be
+// recovered by pushing a new, valid config on the siphon.
+//
+// Before the recovery path existed, processConfigUpdate admitted updates only
+// from Running, and the FSM has no Error->Running edge — so once in Error every
+// subsequent update was silently dropped and the operator could never push a
+// fix. This test fails against that behavior (cluster stays in Error, new
+// server never starts) and passes once Error is an accepted entry state.
+func TestRunner_RecoversFromErrorViaConfigUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	const brokenID = "broken"
+
+	mockFactory := func(serverCtx context.Context, id string, _ *httpserver.Config, _ slog.Handler) (httpServerRunner, error) {
+		if id == brokenID {
+			return createErroredMockServer(serverCtx), nil
+		}
+		return createMockServer(serverCtx), nil
+	}
+
+	cluster, err := NewRunner(WithRunnerFactory(mockFactory))
+	require.NoError(t, err)
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- cluster.Run(ctx) }()
+	require.Eventually(t, cluster.IsReady, time.Second, 5*time.Millisecond)
+
+	// 1. Wedge the cluster: a failing server trips it into Error.
+	cluster.configSiphon <- map[string]*httpserver.Config{
+		brokenID: createTestHTTPConfig(t, ":18301"),
+	}
+	require.Eventually(t, func() bool {
+		return cluster.GetState() == finitestate.StatusError
+	}, 2*time.Second, 10*time.Millisecond, "cluster should enter Error")
+
+	// 2. Recover: a new valid config must be applied, not silently dropped.
+	cluster.configSiphon <- map[string]*httpserver.Config{
+		"good": createTestHTTPConfig(t, ":18302"),
+	}
+	require.Eventually(t, func() bool {
+		return cluster.GetState() == finitestate.StatusRunning &&
+			cluster.GetServerCount() == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"cluster should recover to Running with the new server")
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("cluster did not shut down after ctx cancel")
+	}
+}

--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -367,11 +367,18 @@ func (r *Runner) processConfigUpdate(
 	defer r.mu.Unlock()
 
 	// Admit the update and move to Reloading while holding the update lock.
-	// Two entry states are accepted:
+	// Drive the decision off the transition *result* rather than a pre-read
+	// state: a crashed backend calls setStateError() without taking r.mu, so it
+	// can flip Running->Error in the window between a GetState() check and the
+	// transition. Attempting the guarded transition first, and only inspecting
+	// the state when it fails, closes that TOCTOU — otherwise a recovery config
+	// arriving exactly as a backend crashes could still be silently dropped.
 	//
-	//   - Running: the normal path. A guarded TransitionIfCurrentState avoids a
-	//     TOCTOU race where the cluster is Running before the lock but Stop()
-	//     moves it to Stopped before this update enters Reloading.
+	// Two entry states are admissible:
+	//
+	//   - Running: the normal path. The guarded TransitionIfCurrentState also
+	//     covers the race where Stop() moved the cluster to Stopped before this
+	//     update could enter Reloading.
 	//
 	//   - Error: recovery. A crashed backend (or a failed prior update) leaves
 	//     the cluster in Error, and the FSM has no Error->Running edge — so
@@ -379,24 +386,21 @@ func (r *Runner) processConfigUpdate(
 	//     and the operator could never push a corrected config. Force the FSM
 	//     to Reloading via SetState (Error has no valid Transition to
 	//     Reloading) and let this update rebuild the cluster.
-	switch state := r.fsm.GetState(); state {
-	case finitestate.StatusRunning:
-		if err := r.fsm.TransitionIfCurrentState(
-			finitestate.StatusRunning,
-			finitestate.StatusReloading,
-		); err != nil {
-			logger.Warn("Ignoring config update - cluster left Running", "state", r.fsm.GetState())
+	if err := r.fsm.TransitionIfCurrentState(
+		finitestate.StatusRunning,
+		finitestate.StatusReloading,
+	); err != nil {
+		switch state := r.fsm.GetState(); state {
+		case finitestate.StatusError:
+			logger.Info("Recovering cluster from Error state via config update")
+			if err := r.fsm.SetState(finitestate.StatusReloading); err != nil {
+				r.setStateError()
+				return fmt.Errorf("failed to enter reloading state for recovery: %w", err)
+			}
+		default:
+			logger.Warn("Ignoring config update - cluster not admissible", "state", state)
 			return nil
 		}
-	case finitestate.StatusError:
-		logger.Info("Recovering cluster from Error state via config update")
-		if err := r.fsm.SetState(finitestate.StatusReloading); err != nil {
-			r.setStateError()
-			return fmt.Errorf("failed to enter reloading state for recovery: %w", err)
-		}
-	default:
-		logger.Warn("Ignoring config update - cluster not running", "state", state)
-		return nil
 	}
 
 	// Phase 1: Create new entries with pending actions

--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -366,14 +366,36 @@ func (r *Runner) processConfigUpdate(
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// Check and transition while holding the update lock. This prevents a
-	// TOCTOU race where the cluster is Running before the lock, but Stop()
-	// moves it to Stopped before this update enters Reloading.
-	if err := r.fsm.TransitionIfCurrentState(
-		finitestate.StatusRunning,
-		finitestate.StatusReloading,
-	); err != nil {
-		logger.Warn("Ignoring config update - cluster not running", "state", r.fsm.GetState())
+	// Admit the update and move to Reloading while holding the update lock.
+	// Two entry states are accepted:
+	//
+	//   - Running: the normal path. A guarded TransitionIfCurrentState avoids a
+	//     TOCTOU race where the cluster is Running before the lock but Stop()
+	//     moves it to Stopped before this update enters Reloading.
+	//
+	//   - Error: recovery. A crashed backend (or a failed prior update) leaves
+	//     the cluster in Error, and the FSM has no Error->Running edge — so
+	//     without this path every subsequent update would be silently dropped
+	//     and the operator could never push a corrected config. Force the FSM
+	//     to Reloading via SetState (Error has no valid Transition to
+	//     Reloading) and let this update rebuild the cluster.
+	switch state := r.fsm.GetState(); state {
+	case finitestate.StatusRunning:
+		if err := r.fsm.TransitionIfCurrentState(
+			finitestate.StatusRunning,
+			finitestate.StatusReloading,
+		); err != nil {
+			logger.Warn("Ignoring config update - cluster left Running", "state", r.fsm.GetState())
+			return nil
+		}
+	case finitestate.StatusError:
+		logger.Info("Recovering cluster from Error state via config update")
+		if err := r.fsm.SetState(finitestate.StatusReloading); err != nil {
+			r.setStateError()
+			return fmt.Errorf("failed to enter reloading state for recovery: %w", err)
+		}
+	default:
+		logger.Warn("Ignoring config update - cluster not running", "state", state)
 		return nil
 	}
 


### PR DESCRIPTION
## Problem

A crashed backend (or a failed config update) transitions the whole cluster to `StatusError` — this is **deliberate and tested** (Bug A/B coverage), and this PR keeps that behavior. The latent bug is what happens *next*: `processConfigUpdate` admitted updates only from `Running`, and the FSM transition table has no `Error→Running`/`Error→Reloading` edge. So once in `Error`, every subsequent config pushed to the siphon was **silently dropped** (logged `Ignoring config update - cluster not running`). An operator could never push a corrected config to recover a degraded cluster — it was wedged until `Stop()`.

## Fix

Accept `Error` as an entry state for `processConfigUpdate`:
- **Running** → unchanged guarded `TransitionIfCurrentState(Running, Reloading)` (preserves the existing TOCTOU protection vs `Stop()`).
- **Error** → recovery: force the FSM to `Reloading` via `SetState` (Error has no valid *transition* to Reloading), then rebuild the cluster from the new config — back to `Running` on success, or back to `Error` if the new config also fails.
- Any other state (Stopping/Stopped/Booting) → still ignored.

The deliberate Error-on-crash design and its `TestRunner_ChildRuntimeError`/`ConfigUpdateFailure`/`PartialFailure` tests are unchanged and still pass.

## Test (TDD, failing-first)

`recovery_test.go`: wedge the cluster into `Error` with a failing server, then push a valid config and assert it recovers to `Running` with the new server. Verified it fails before the fix (`cluster should recover... Condition never satisfied`) and passes after. Full package green under `-race`.

## Context

Final PR in a 4-part stability/race audit (follows #138 CI `-race` job, #139 shutdown data race, #140 httpserver per-instance error channel). The recovery semantics here were chosen in consultation rather than reverting the intentional Error-on-crash design.

https://claude.ai/code/session_01M2nd9n1KAjj41j2VzrZ7WE

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2nd9n1KAjj41j2VzrZ7WE)_