### PR TITLE
httpcluster: one_for_one crash supervision with CrashLoopBackOff

### DIFF
--- a/runnables/httpcluster/options.go
+++ b/runnables/httpcluster/options.go
@@ -84,6 +84,48 @@ func WithRestartDelay(delay time.Duration) Option {
 	}
 }
 
+// WithRestartBackoff configures the CrashLoopBackOff used when a backend
+// crashes at runtime: the first restart waits initial, each subsequent restart
+// doubles the wait, capped at max. Defaults are 100ms and 30s.
+func WithRestartBackoff(initial, max time.Duration) Option {
+	return func(r *Runner) error {
+		if initial <= 0 {
+			return fmt.Errorf("restart backoff initial must be positive: %v", initial)
+		}
+		if max < initial {
+			return fmt.Errorf("restart backoff max (%v) must be >= initial (%v)", max, initial)
+		}
+		r.restartBackoffInitial = initial
+		r.restartBackoffMax = max
+		return nil
+	}
+}
+
+// WithMaxRestarts sets the crash-loop threshold: a server that crashes more
+// than max times within the restart window escalates the whole cluster to
+// Error instead of being restarted again. Default is 5.
+func WithMaxRestarts(max int) Option {
+	return func(r *Runner) error {
+		if max < 0 {
+			return fmt.Errorf("max restarts cannot be negative: %d", max)
+		}
+		r.maxRestarts = max
+		return nil
+	}
+}
+
+// WithRestartWindow sets the sliding window over which crashes are counted
+// against the max-restarts threshold. Default is 1 minute.
+func WithRestartWindow(window time.Duration) Option {
+	return func(r *Runner) error {
+		if window <= 0 {
+			return fmt.Errorf("restart window must be positive: %v", window)
+		}
+		r.restartWindow = window
+		return nil
+	}
+}
+
 // WithShutdownTimeout sets the deadline on the context that the cluster
 // runner builds when it begins shutting down. Both the synchronous shutdown
 // path and the background siphon drain observe that context, so the deadline

--- a/runnables/httpcluster/options_test.go
+++ b/runnables/httpcluster/options_test.go
@@ -127,3 +127,27 @@ func TestOptionError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to apply option")
 }
+
+// TestRestartSupervisionDefaults verifies NewRunner installs the documented
+// crash-supervision defaults, and that the options override them.
+func TestRestartSupervisionDefaults(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRunner()
+	require.NoError(t, err)
+	assert.Equal(t, defaultRestartBackoffInitial, r.restartBackoffInitial)
+	assert.Equal(t, defaultRestartBackoffMax, r.restartBackoffMax)
+	assert.Equal(t, defaultMaxRestarts, r.maxRestarts)
+	assert.Equal(t, defaultRestartWindow, r.restartWindow)
+
+	r, err = NewRunner(
+		WithRestartBackoff(250*time.Millisecond, 10*time.Second),
+		WithMaxRestarts(7),
+		WithRestartWindow(2*time.Minute),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 250*time.Millisecond, r.restartBackoffInitial)
+	assert.Equal(t, 10*time.Second, r.restartBackoffMax)
+	assert.Equal(t, 7, r.maxRestarts)
+	assert.Equal(t, 2*time.Minute, r.restartWindow)
+}

--- a/runnables/httpcluster/restart_test.go
+++ b/runnables/httpcluster/restart_test.go
@@ -1,0 +1,200 @@
+package httpcluster
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/robbyt/go-supervisor/internal/finitestate"
+	"github.com/robbyt/go-supervisor/runnables/httpserver"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunner_ServerCrash_AutoRestarts verifies one_for_one supervision: when a
+// single backend crashes at runtime, the cluster restarts it and stays Running
+// rather than wedging the whole cluster into Error.
+func TestRunner_ServerCrash_AutoRestarts(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	crashErr := errors.New("simulated crash")
+	crashCh := make(chan struct{})
+
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	// First call returns a server that becomes ready then crashes; subsequent
+	// calls (the restart) return a healthy server.
+	mockFactory := func(serverCtx context.Context, _ string, _ *httpserver.Config, _ slog.Handler) (httpServerRunner, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		if calls == 1 {
+			return createCrashingMockServer(serverCtx, crashCh, crashErr), nil
+		}
+		return createMockServer(serverCtx), nil
+	}
+
+	cluster, err := NewRunner(
+		WithRunnerFactory(mockFactory),
+		WithRestartBackoff(time.Millisecond, 5*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- cluster.Run(ctx) }()
+	require.Eventually(t, cluster.IsReady, time.Second, 5*time.Millisecond)
+
+	cluster.configSiphon <- map[string]*httpserver.Config{
+		"web": createTestHTTPConfig(t, ":18401"),
+	}
+	require.Eventually(t, func() bool { return cluster.GetServerCount() == 1 },
+		2*time.Second, 10*time.Millisecond)
+
+	// Crash the server.
+	close(crashCh)
+
+	// The cluster must recreate the server (factory called again), remain
+	// Running, and keep one server.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		recreated := calls >= 2
+		mu.Unlock()
+		return recreated &&
+			cluster.GetState() == finitestate.StatusRunning &&
+			cluster.GetServerCount() == 1
+	}, 2*time.Second, 10*time.Millisecond,
+		"cluster should auto-restart the crashed server and stay Running")
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("cluster did not shut down after ctx cancel")
+	}
+}
+
+// TestRunner_ServerCrashLoop_EscalatesToError verifies the CrashLoopBackOff
+// escalation: a server that keeps crashing past maxRestarts within the window
+// stops being restarted and trips the whole cluster to Error.
+func TestRunner_ServerCrashLoop_EscalatesToError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	crashErr := errors.New("always crashes")
+	// Pre-closed: every instance becomes ready then immediately crashes.
+	crashCh := make(chan struct{})
+	close(crashCh)
+
+	mockFactory := func(serverCtx context.Context, _ string, _ *httpserver.Config, _ slog.Handler) (httpServerRunner, error) {
+		return createCrashingMockServer(serverCtx, crashCh, crashErr), nil
+	}
+
+	cluster, err := NewRunner(
+		WithRunnerFactory(mockFactory),
+		WithMaxRestarts(2),
+		WithRestartBackoff(time.Millisecond, 2*time.Millisecond),
+		WithRestartWindow(time.Minute),
+	)
+	require.NoError(t, err)
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- cluster.Run(ctx) }()
+	require.Eventually(t, cluster.IsReady, time.Second, 5*time.Millisecond)
+
+	cluster.configSiphon <- map[string]*httpserver.Config{
+		"flaky": createTestHTTPConfig(t, ":18411"),
+	}
+
+	// After more than maxRestarts crashes, the cluster escalates to Error and
+	// gives up on the server.
+	require.Eventually(t, func() bool {
+		return cluster.GetState() == finitestate.StatusError &&
+			cluster.GetServerCount() == 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"crash loop should escalate the cluster to Error")
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("cluster did not shut down after ctx cancel")
+	}
+}
+
+// TestRunner_ServerCrash_SiblingsSurvive verifies one_for_one isolation: when
+// one server crashes (and is restarted), an unrelated sibling keeps running and
+// the cluster stays Running with both servers accounted for.
+func TestRunner_ServerCrash_SiblingsSurvive(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	crashErr := errors.New("crasher down")
+	crashCh := make(chan struct{})
+
+	var (
+		mu           sync.Mutex
+		crasherCalls int
+	)
+	mockFactory := func(serverCtx context.Context, id string, _ *httpserver.Config, _ slog.Handler) (httpServerRunner, error) {
+		if id == "crasher" {
+			mu.Lock()
+			defer mu.Unlock()
+			crasherCalls++
+			if crasherCalls == 1 {
+				return createCrashingMockServer(serverCtx, crashCh, crashErr), nil
+			}
+		}
+		return createMockServer(serverCtx), nil
+	}
+
+	cluster, err := NewRunner(
+		WithRunnerFactory(mockFactory),
+		WithRestartBackoff(time.Millisecond, 5*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- cluster.Run(ctx) }()
+	require.Eventually(t, cluster.IsReady, time.Second, 5*time.Millisecond)
+
+	cluster.configSiphon <- map[string]*httpserver.Config{
+		"crasher": createTestHTTPConfig(t, ":18421"),
+		"stable":  createTestHTTPConfig(t, ":18422"),
+	}
+	require.Eventually(t, func() bool { return cluster.GetServerCount() == 2 },
+		2*time.Second, 10*time.Millisecond)
+
+	close(crashCh)
+
+	// Crasher is restarted; cluster stays Running with both servers.
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		restarted := crasherCalls >= 2
+		mu.Unlock()
+		return restarted &&
+			cluster.GetState() == finitestate.StatusRunning &&
+			cluster.GetServerCount() == 2
+	}, 2*time.Second, 10*time.Millisecond,
+		"sibling should survive and crasher should be restarted")
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("cluster did not shut down after ctx cancel")
+	}
+}

--- a/runnables/httpcluster/restart_test.go
+++ b/runnables/httpcluster/restart_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/robbyt/go-supervisor/internal/finitestate"
+	"github.com/robbyt/go-supervisor/internal/mocks"
 	"github.com/robbyt/go-supervisor/runnables/httpserver"
 	"github.com/stretchr/testify/require"
 )
@@ -189,6 +190,160 @@ func TestRunner_ServerCrash_SiblingsSurvive(t *testing.T) {
 			cluster.GetServerCount() == 2
 	}, 2*time.Second, 10*time.Millisecond,
 		"sibling should survive and crasher should be restarted")
+
+	cancel()
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("cluster did not shut down after ctx cancel")
+	}
+}
+
+// TestRestartOptionValidation covers the validation branches of the
+// crash-supervision options.
+func TestRestartOptionValidation(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewRunner(WithRestartBackoff(0, time.Second))
+	require.Error(t, err, "non-positive initial backoff must be rejected")
+
+	_, err = NewRunner(WithRestartBackoff(time.Second, time.Millisecond))
+	require.Error(t, err, "max < initial must be rejected")
+
+	_, err = NewRunner(WithMaxRestarts(-1))
+	require.Error(t, err, "negative max restarts must be rejected")
+
+	_, err = NewRunner(WithRestartWindow(0))
+	require.Error(t, err, "non-positive restart window must be rejected")
+
+	// Valid values are accepted.
+	_, err = NewRunner(
+		WithRestartBackoff(time.Millisecond, time.Second),
+		WithMaxRestarts(3),
+		WithRestartWindow(time.Minute),
+	)
+	require.NoError(t, err)
+}
+
+// TestBackoffForLocked covers the exponential ramp, the cap, and the
+// attempt<1 clamp.
+func TestBackoffForLocked(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRunner(WithRestartBackoff(10*time.Millisecond, 80*time.Millisecond))
+	require.NoError(t, err)
+
+	require.Equal(t, 10*time.Millisecond, r.backoffForLocked(0), "attempt<1 clamps to first")
+	require.Equal(t, 10*time.Millisecond, r.backoffForLocked(1))
+	require.Equal(t, 20*time.Millisecond, r.backoffForLocked(2))
+	require.Equal(t, 40*time.Millisecond, r.backoffForLocked(3))
+	require.Equal(t, 80*time.Millisecond, r.backoffForLocked(4), "capped at max")
+	require.Equal(t, 80*time.Millisecond, r.backoffForLocked(10), "stays capped")
+}
+
+// TestSuperviseRestart_IgnoresSupersededRunner covers the identity guard: a
+// late crash from a runner that has already been replaced under the same id
+// must not record a failure or touch the live entry.
+func TestSuperviseRestart_IgnoresSupersededRunner(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRunner()
+	require.NoError(t, err)
+	require.NoError(t, r.fsm.Transition(finitestate.StatusBooting))
+	require.NoError(t, r.fsm.Transition(finitestate.StatusRunning))
+
+	current := mocks.NewMockRunnableWithStateable()
+	r.currentEntries = &entries{servers: map[string]*serverEntry{
+		"x": {id: "x", config: createTestHTTPConfig(t, ":18511"), runner: current},
+	}}
+
+	stale := mocks.NewMockRunnableWithStateable()
+	r.superviseRestart(context.Background(), "x", stale, errors.New("late crash"))
+
+	require.Equal(t, finitestate.StatusRunning, r.GetState())
+	require.Equal(t, 1, r.GetServerCount())
+	require.Empty(t, r.restartTracker, "no failure should be recorded for a superseded runner")
+	require.Same(t, current, r.currentEntries.get("x").runner, "live entry must be untouched")
+}
+
+// TestSuperviseRestart_AbortsBackoffOnShutdown covers the failure-record +
+// runtime-clear + backoff-abort path when the cluster context is already done.
+func TestSuperviseRestart_AbortsBackoffOnShutdown(t *testing.T) {
+	t.Parallel()
+
+	// Long backoff so the only way out of the wait is ctx cancellation.
+	r, err := NewRunner(WithRestartBackoff(time.Hour, time.Hour))
+	require.NoError(t, err)
+	require.NoError(t, r.fsm.Transition(finitestate.StatusBooting))
+	require.NoError(t, r.fsm.Transition(finitestate.StatusRunning))
+
+	crashed := mocks.NewMockRunnableWithStateable()
+	r.currentEntries = &entries{servers: map[string]*serverEntry{
+		"x": {id: "x", config: createTestHTTPConfig(t, ":18512"), runner: crashed},
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // backoff select must take the ctx.Done branch immediately
+
+	r.superviseRestart(ctx, "x", crashed, errors.New("boom"))
+
+	require.Equal(t, finitestate.StatusRunning, r.GetState(), "no escalation on shutdown abort")
+	require.Nil(t, r.currentEntries.get("x").runner, "dead runtime should be cleared before backoff")
+	require.Len(t, r.restartTracker["x"].failures, 1, "the crash should be recorded")
+}
+
+// TestRunner_RestartFailure_EscalatesToError covers the branch where the
+// restart attempt itself cannot bring the server back to ready: rather than
+// spinning, the cluster escalates to Error.
+func TestRunner_RestartFailure_EscalatesToError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	crashErr := errors.New("crash then refuse to start")
+	crashCh := make(chan struct{})
+
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	mockFactory := func(serverCtx context.Context, _ string, _ *httpserver.Config, _ slog.Handler) (httpServerRunner, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		if calls == 1 {
+			return createCrashingMockServer(serverCtx, crashCh, crashErr), nil
+		}
+		// The restart never becomes ready.
+		return createErroredMockServer(serverCtx), nil
+	}
+
+	cluster, err := NewRunner(
+		WithRunnerFactory(mockFactory),
+		WithRestartBackoff(time.Millisecond, 5*time.Millisecond),
+		WithMaxRestarts(5), // not a crash loop; the restart-readiness failure escalates
+	)
+	require.NoError(t, err)
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- cluster.Run(ctx) }()
+	require.Eventually(t, cluster.IsReady, time.Second, 5*time.Millisecond)
+
+	cluster.configSiphon <- map[string]*httpserver.Config{
+		"web": createTestHTTPConfig(t, ":18513"),
+	}
+	require.Eventually(t, func() bool { return cluster.GetServerCount() == 1 },
+		2*time.Second, 10*time.Millisecond)
+
+	close(crashCh)
+
+	require.Eventually(t, func() bool {
+		return cluster.GetState() == finitestate.StatusError &&
+			cluster.GetServerCount() == 0
+	}, 2*time.Second, 10*time.Millisecond,
+		"a restart that cannot become ready should escalate to Error")
 
 	cancel()
 	select {

--- a/runnables/httpcluster/restart_test.go
+++ b/runnables/httpcluster/restart_test.go
@@ -268,7 +268,8 @@ func TestSuperviseRestart_IgnoresSupersededRunner(t *testing.T) {
 }
 
 // TestSuperviseRestart_AbortsBackoffOnShutdown covers the failure-record +
-// runtime-clear + backoff-abort path when the cluster context is already done.
+// attempt-bookkeeping + runtime-clear + backoff-abort path when the cluster
+// context is already done.
 func TestSuperviseRestart_AbortsBackoffOnShutdown(t *testing.T) {
 	t.Parallel()
 
@@ -291,6 +292,7 @@ func TestSuperviseRestart_AbortsBackoffOnShutdown(t *testing.T) {
 	require.Equal(t, finitestate.StatusRunning, r.GetState(), "no escalation on shutdown abort")
 	require.Nil(t, r.currentEntries.get("x").runner, "dead runtime should be cleared before backoff")
 	require.Len(t, r.restartTracker["x"].failures, 1, "the crash should be recorded")
+	require.Equal(t, 1, r.restartTracker["x"].attempts, "the restart attempt should be recorded")
 }
 
 // TestRunner_RestartFailure_EscalatesToError covers the branch where the

--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -17,6 +17,15 @@ const (
 	defaultDeadlineServerStart = 10 * time.Second
 	defaultRestartDelay        = 10 * time.Millisecond
 	defaultShutdownTimeout     = 5 * time.Second
+
+	// Crash-supervision defaults (one_for_one with CrashLoopBackOff). A
+	// backend that crashes at runtime is restarted with exponential backoff;
+	// only a crash loop — more than maxRestarts failures within restartWindow —
+	// escalates the whole cluster to Error.
+	defaultRestartBackoffInitial = 100 * time.Millisecond
+	defaultRestartBackoffMax     = 30 * time.Second
+	defaultMaxRestarts           = 5
+	defaultRestartWindow         = 1 * time.Minute
 )
 
 type fsm interface {
@@ -41,6 +50,16 @@ type Runner struct {
 	deadlineServerStart time.Duration
 	shutdownTimeout     time.Duration
 
+	// Crash supervision (one_for_one + CrashLoopBackOff).
+	restartBackoffInitial time.Duration
+	restartBackoffMax     time.Duration
+	maxRestarts           int
+	restartWindow         time.Duration
+	// restartTracker records recent crash timestamps per server id. Guarded by
+	// mu; mutated only from superviseRestart, which always holds the write lock
+	// while touching it.
+	restartTracker map[string]*restartState
+
 	// Configuration siphon channel
 	configSiphon chan map[string]*httpserver.Config
 
@@ -57,6 +76,15 @@ var (
 	_ supervisor.Runnable  = (*Runner)(nil)
 	_ supervisor.Stateable = (*Runner)(nil)
 )
+
+// restartState tracks a single server's crash history for CrashLoopBackOff.
+type restartState struct {
+	// failures holds crash timestamps inside the current restartWindow.
+	failures []time.Time
+	// attempts counts consecutive restart attempts and drives the exponential
+	// backoff; it resets once a restart succeeds.
+	attempts int
+}
 
 type runnerFactory func(ctx context.Context, id string, cfg *httpserver.Config, handler slog.Handler) (httpServerRunner, error)
 
@@ -77,12 +105,17 @@ func defaultRunnerFactory(
 // NewRunner creates a new HTTP cluster runner with the provided options.
 func NewRunner(opts ...Option) (*Runner, error) {
 	r := &Runner{
-		lc:                  lifecycle.New(),
-		runnerFactory:       defaultRunnerFactory,
-		logger:              slog.Default().WithGroup("httpcluster.Runner"),
-		restartDelay:        defaultRestartDelay,
-		deadlineServerStart: defaultDeadlineServerStart,
-		shutdownTimeout:     defaultShutdownTimeout,
+		lc:                    lifecycle.New(),
+		runnerFactory:         defaultRunnerFactory,
+		logger:                slog.Default().WithGroup("httpcluster.Runner"),
+		restartDelay:          defaultRestartDelay,
+		deadlineServerStart:   defaultDeadlineServerStart,
+		shutdownTimeout:       defaultShutdownTimeout,
+		restartBackoffInitial: defaultRestartBackoffInitial,
+		restartBackoffMax:     defaultRestartBackoffMax,
+		maxRestarts:           defaultMaxRestarts,
+		restartWindow:         defaultRestartWindow,
+		restartTracker:        make(map[string]*restartState),
 		configSiphon: make(
 			chan map[string]*httpserver.Config,
 		), // unbuffered by default
@@ -606,8 +639,11 @@ func (r *Runner) createAndStartServer(
 		return nil, nil, err
 	}
 
-	// Start that Runnable implementation in a goroutine
-	go func(id string, runner httpServerRunner, c context.Context, cancel context.CancelFunc) {
+	// Start that Runnable implementation in a goroutine. parentCtx (the
+	// cluster's runCtx, not this server's ctx) is captured so the crash
+	// supervisor outlives the dead server's ctx and is bounded by the cluster
+	// lifetime instead.
+	go func(id string, runner httpServerRunner, parentCtx, c context.Context, cancel context.CancelFunc) {
 		// Always release this server's ctx when the goroutine exits — the
 		// crash path didn't otherwise call cancel(), so per-server ctx
 		// resources would have stayed referenced until the cluster runCtx
@@ -618,28 +654,138 @@ func (r *Runner) createAndStartServer(
 		logger.Debug("Starting server instance")
 		err := runner.Run(c)
 		if err != nil && c.Err() == nil {
-			// Context not cancelled, this is an actual error: mark the
-			// cluster degraded so consumers watching GetStateChan see it,
-			// and drop the dead entry from currentEntries.
+			// Context not cancelled, so this is a real runtime crash (not a
+			// stop/reload). Hand off to the crash supervisor, which restarts
+			// the server with backoff (one_for_one isolation) and only
+			// escalates the cluster to Error on a crash loop.
 			logger.Error("Server instance failed", "error", err)
-			r.setStateError()
-			r.removeEntryIfMatches(id, runner)
+			go r.superviseRestart(parentCtx, id, runner, err)
 		}
 		logger.Debug("Instance stopped")
-	}(entry.id, runner, serverCtx, serverCancel)
+	}(entry.id, runner, ctx, serverCtx, serverCancel)
 
 	return runner, serverCancel, nil
 }
 
-// removeEntryIfMatches drops the entry stored under id only if it still points
-// at the given runner. Called from the per-server crash handler to avoid
-// racing a concurrent restart that has already committed a different runner
-// under the same id — without this guard, an old goroutine's late error path
-// would delete the new healthy server from currentEntries.
-func (r *Runner) removeEntryIfMatches(id string, runner httpServerRunner) {
+// superviseRestart implements one_for_one crash supervision with
+// CrashLoopBackOff. It runs in its own goroutine, one per crash. The dead
+// runner is restarted after an exponential backoff; the whole cluster is only
+// escalated to Error when a server exceeds maxRestarts crashes within
+// restartWindow (a crash loop). All currentEntries / FSM / restartTracker
+// mutations happen under r.mu, so this serializes with processConfigUpdate the
+// same way the old removeEntryIfMatches did — the runner-identity guard below
+// drops the work if a config update already superseded this server.
+func (r *Runner) superviseRestart(
+	ctx context.Context,
+	id string,
+	crashed httpServerRunner,
+	cause error,
+) {
+	logger := r.logger.WithGroup("superviseRestart").With("id", id)
+
+	r.mu.Lock()
+	cur := r.currentEntries.get(id)
+	if cur == nil || cur.runner != crashed {
+		// Superseded by a config update (or already handled). Not our problem.
+		r.mu.Unlock()
+		return
+	}
+
+	st := r.recordFailureLocked(id, time.Now())
+	if len(st.failures) > r.maxRestarts {
+		logger.Error("Server exceeded restart intensity; escalating cluster to Error",
+			"restarts", len(st.failures), "window", r.restartWindow, "cause", cause)
+		r.currentEntries = r.currentEntries.removeEntry(id)
+		delete(r.restartTracker, id)
+		r.setStateError()
+		r.mu.Unlock()
+		return
+	}
+	st.attempts++
+	backoff := r.backoffForLocked(st.attempts)
+	// Clear the dead runtime so the entry reads as "not running"; this also
+	// makes a racing config update or a second crash fail the identity guard.
+	if updated := r.currentEntries.clearRuntime(id); updated != nil {
+		r.currentEntries = updated
+	}
+	addr := cur.config.ListenAddr
+	r.mu.Unlock()
+
+	logger.Warn("Server crashed; scheduling restart",
+		"cause", cause, "backoff", backoff, "attempt", st.attempts, "addr", addr)
+
+	select {
+	case <-ctx.Done():
+		logger.Debug("Restart aborted: cluster shutting down")
+		return
+	case <-time.After(backoff):
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if cur := r.currentEntries.get(id); cur != nil && cur.runner == runner {
-		r.currentEntries = r.currentEntries.removeEntry(id)
+	cur = r.currentEntries.get(id)
+	if cur == nil {
+		logger.Debug("Restart aborted: entry removed during backoff")
+		return
 	}
+	if cur.runner != nil {
+		logger.Debug("Restart aborted: server already running (replaced by config update)")
+		return
+	}
+
+	updated, failed := r.startServers(ctx, r.currentEntries, []string{id})
+	r.currentEntries = updated
+	if failed {
+		if ctx.Err() != nil {
+			// Cluster is shutting down; startServers already cleaned up.
+			return
+		}
+		// The restart itself couldn't bring the server back to ready. Don't
+		// spin: escalate so the failure is visible (a config update can later
+		// recover the cluster).
+		logger.Error("Restart attempt failed to become ready; escalating cluster to Error")
+		delete(r.restartTracker, id)
+		r.setStateError()
+		return
+	}
+
+	// Healthy again: reset the backoff ramp but keep the crash timestamps so a
+	// slow-burn crash loop still trips maxRestarts within the window.
+	st.attempts = 0
+	logger.Info("Server restarted successfully", "addr", addr)
+}
+
+// recordFailureLocked appends a crash timestamp for id, pruning entries older
+// than restartWindow, and returns the live restartState. Caller must hold mu.
+func (r *Runner) recordFailureLocked(id string, now time.Time) *restartState {
+	st := r.restartTracker[id]
+	if st == nil {
+		st = &restartState{}
+		r.restartTracker[id] = st
+	}
+	cutoff := now.Add(-r.restartWindow)
+	kept := st.failures[:0]
+	for _, t := range st.failures {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	st.failures = append(kept, now)
+	return st
+}
+
+// backoffForLocked returns the exponential backoff for the given consecutive
+// attempt number (1-based), capped at restartBackoffMax. Caller must hold mu.
+func (r *Runner) backoffForLocked(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	d := r.restartBackoffInitial
+	for i := 1; i < attempt; i++ {
+		if d >= r.restartBackoffMax/2 {
+			return r.restartBackoffMax
+		}
+		d *= 2
+	}
+	return d
 }

--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -84,6 +84,13 @@ type restartState struct {
 	// attempts counts consecutive restart attempts and drives the exponential
 	// backoff; it resets once a restart succeeds.
 	attempts int
+	// gen is a per-id restart generation, bumped each time a crash begins being
+	// supervised. A supervising goroutine captures it before its backoff and
+	// re-checks it after: if a newer crash for the same id started supervising
+	// in the meantime (e.g. a config-update replacement that itself crashed and
+	// cleared the runtime to nil), the stale goroutine aborts instead of firing
+	// a restart on the wrong generation's schedule.
+	gen int
 }
 
 type runnerFactory func(ctx context.Context, id string, cfg *httpserver.Config, handler slog.Handler) (httpServerRunner, error)
@@ -702,6 +709,8 @@ func (r *Runner) superviseRestart(
 		return
 	}
 	st.attempts++
+	st.gen++
+	gen := st.gen
 	backoff := r.backoffForLocked(st.attempts)
 	// Clear the dead runtime so the entry reads as "not running"; this also
 	// makes a racing config update or a second crash fail the identity guard.
@@ -730,6 +739,15 @@ func (r *Runner) superviseRestart(
 	}
 	if cur.runner != nil {
 		logger.Debug("Restart aborted: server already running (replaced by config update)")
+		return
+	}
+	// A newer crash for this id began supervising during our backoff (it owns
+	// the live "not running" runtime now), so this restart belongs to a stale
+	// generation. Abort and let the newer goroutine drive the restart on its
+	// own backoff schedule.
+	if live := r.restartTracker[id]; live == nil || live.gen != gen {
+		logger.Debug("Restart aborted: superseded by a newer crash generation",
+			"ourGen", gen)
 		return
 	}
 

--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -723,11 +723,14 @@ func (r *Runner) superviseRestart(
 	logger.Warn("Server crashed; scheduling restart",
 		"cause", cause, "backoff", backoff, "attempt", st.attempts, "addr", addr)
 
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+
 	select {
 	case <-ctx.Done():
 		logger.Debug("Restart aborted: cluster shutting down")
 		return
-	case <-time.After(backoff):
+	case <-timer.C:
 	}
 
 	r.mu.Lock()

--- a/runnables/httpcluster/runner.go
+++ b/runnables/httpcluster/runner.go
@@ -710,8 +710,9 @@ func (r *Runner) superviseRestart(
 	}
 	st.attempts++
 	st.gen++
+	attempt := st.attempts
 	gen := st.gen
-	backoff := r.backoffForLocked(st.attempts)
+	backoff := r.backoffForLocked(attempt)
 	// Clear the dead runtime so the entry reads as "not running"; this also
 	// makes a racing config update or a second crash fail the identity guard.
 	if updated := r.currentEntries.clearRuntime(id); updated != nil {
@@ -721,7 +722,7 @@ func (r *Runner) superviseRestart(
 	r.mu.Unlock()
 
 	logger.Warn("Server crashed; scheduling restart",
-		"cause", cause, "backoff", backoff, "attempt", st.attempts, "addr", addr)
+		"cause", cause, "backoff", backoff, "attempt", attempt, "addr", addr)
 
 	timer := time.NewTimer(backoff)
 	defer timer.Stop()

--- a/runnables/httpcluster/runner_failure_test.go
+++ b/runnables/httpcluster/runner_failure_test.go
@@ -58,11 +58,14 @@ func createErroredMockServer(ctx context.Context) *mocks.MockRunnableWithStateab
 	return mockServer
 }
 
-// TestRunner_ChildRuntimeError_TransitionsToError covers Bug A: a child
-// server's Run() returning an error during steady-state must transition the
-// cluster to StatusError and drop the dead entry. Cluster Run() must not exit;
-// healthy siblings must keep running.
-func TestRunner_ChildRuntimeError_TransitionsToError(t *testing.T) {
+// TestRunner_ChildRuntimeError_IsolatedAndRestarted covers the historical
+// "Bug A" scenario under the current one_for_one supervision model: a child
+// server's Run() returning an error during steady-state used to wedge the
+// WHOLE cluster into Error. It must now be isolated — the dead server is
+// restarted (CrashLoopBackOff), the cluster stays Running, Run() does not exit,
+// and healthy siblings are untouched. (Crash-loop escalation to Error is
+// covered by TestRunner_ServerCrashLoop_EscalatesToError.)
+func TestRunner_ChildRuntimeError_IsolatedAndRestarted(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -73,21 +76,31 @@ func TestRunner_ChildRuntimeError_TransitionsToError(t *testing.T) {
 
 	var (
 		mu              sync.Mutex
+		failingCalls    int
 		survivor        *mocks.MockRunnableWithStateable
 		failingServerID = "failing"
 	)
 
-	mockFactory := func(_ context.Context, id string, _ *httpserver.Config, _ slog.Handler) (httpServerRunner, error) {
+	mockFactory := func(serverCtx context.Context, id string, _ *httpserver.Config, _ slog.Handler) (httpServerRunner, error) {
 		if id == failingServerID {
-			return createCrashingMockServer(ctx, crashCh, crashErr), nil
+			mu.Lock()
+			defer mu.Unlock()
+			failingCalls++
+			if failingCalls == 1 {
+				return createCrashingMockServer(serverCtx, crashCh, crashErr), nil
+			}
+			return createMockServer(serverCtx), nil
 		}
 		mu.Lock()
 		defer mu.Unlock()
-		survivor = createMockServer(ctx)
+		survivor = createMockServer(serverCtx)
 		return survivor, nil
 	}
 
-	cluster, err := NewRunner(WithRunnerFactory(mockFactory))
+	cluster, err := NewRunner(
+		WithRunnerFactory(mockFactory),
+		WithRestartBackoff(time.Millisecond, 5*time.Millisecond),
+	)
 	require.NoError(t, err)
 
 	runErr := make(chan error, 1)
@@ -105,11 +118,16 @@ func TestRunner_ChildRuntimeError_TransitionsToError(t *testing.T) {
 
 	close(crashCh)
 
+	// The crashed server is restarted; the cluster stays Running with both.
 	require.Eventually(t, func() bool {
-		return cluster.GetState() == finitestate.StatusError &&
-			cluster.GetServerCount() == 1
+		mu.Lock()
+		restarted := failingCalls >= 2
+		mu.Unlock()
+		return restarted &&
+			cluster.GetState() == finitestate.StatusRunning &&
+			cluster.GetServerCount() == 2
 	}, 2*time.Second, 10*time.Millisecond,
-		"cluster must enter Error and drop the dead entry")
+		"crashed server must be restarted and cluster stay Running")
 
 	select {
 	case err := <-runErr:
@@ -243,60 +261,6 @@ func TestRunner_PartialFailure_GoodSiblingsSurvive(t *testing.T) {
 	}
 }
 
-// TestRemoveEntryIfMatches covers the per-server crash handler's identity
-// guard. The fix keeps an old goroutine's late error path from removing a
-// healthy replacement entry that landed under the same id during a restart.
-func TestRemoveEntryIfMatches(t *testing.T) {
-	t.Parallel()
-
-	makeEntries := func(t *testing.T, id string, runner httpServerRunner) *entries {
-		t.Helper()
-		return &entries{
-			servers: map[string]*serverEntry{
-				id: {id: id, runner: runner},
-			},
-		}
-	}
-
-	t.Run("removes when runner matches", func(t *testing.T) {
-		runner, err := NewRunner()
-		require.NoError(t, err)
-
-		mockServer := mocks.NewMockRunnableWithStateable()
-		runner.currentEntries = makeEntries(t, "x", mockServer)
-
-		runner.removeEntryIfMatches("x", mockServer)
-
-		require.Equal(t, 0, runner.currentEntries.count(),
-			"entry should be removed when runner matches")
-	})
-
-	t.Run("keeps entry when runner differs (replacement race)", func(t *testing.T) {
-		runner, err := NewRunner()
-		require.NoError(t, err)
-
-		oldServer := mocks.NewMockRunnableWithStateable()
-		newServer := mocks.NewMockRunnableWithStateable()
-		runner.currentEntries = makeEntries(t, "x", newServer)
-
-		// Old goroutine fires its crash handler after the entry has been
-		// replaced — the stale id reference must not delete the new entry.
-		runner.removeEntryIfMatches("x", oldServer)
-
-		require.Equal(t, 1, runner.currentEntries.count(),
-			"replacement entry must not be dropped by old runner's crash path")
-		got := runner.currentEntries.get("x")
-		require.NotNil(t, got)
-		require.Same(t, newServer, got.runner)
-	})
-
-	t.Run("no-op when id absent", func(t *testing.T) {
-		runner, err := NewRunner()
-		require.NoError(t, err)
-		mockServer := mocks.NewMockRunnableWithStateable()
-
-		// Does not panic; entries collection unchanged.
-		runner.removeEntryIfMatches("missing", mockServer)
-		require.Equal(t, 0, runner.currentEntries.count())
-	})
-}
+// The per-server crash handler's identity guard (don't drop a healthy
+// replacement that landed under the same id during a restart) now lives inline
+// in superviseRestart and is covered by the restart_test.go suite.


### PR DESCRIPTION
## Why

Today a single backend crashing at runtime trips the **whole** cluster into `Error` (and, without #141, wedges it permanently). That diverges from how supervisors are expected to behave. The established model — **Erlang/OTP `one_for_one`**, **Kubernetes CrashLoopBackOff**, **systemd `Restart=` + `StartLimit*`** — is to *isolate* a single failure, restart it with backoff, and only escalate when a child *crash-loops*. go-supervisor is itself OTP-inspired, so this aligns httpcluster with the project's own philosophy.

(Chosen in discussion with the maintainer after reviewing prior art.)

## What

- A runtime crash now hands off to `superviseRestart` (one goroutine per crash) instead of calling `setStateError`. It restarts the dead server with **exponential backoff** (capped), keeping the cluster `Running` and siblings untouched.
- Only a **crash loop** — more than `maxRestarts` crashes within `restartWindow` — escalates the cluster to `Error`. A restart that can't reach readiness also escalates rather than spinning.
- Backoff happens *outside* `r.mu`; the actual restart runs *under* `r.mu` with the same runner-identity guard the old `removeEntryIfMatches` used, so `superviseRestart` serializes cleanly with `processConfigUpdate` (a config update that supersedes the server wins).

### New options (sensible defaults)
- `WithRestartBackoff(initial, max)` — default `100ms` / `30s`
- `WithMaxRestarts(n)` — default `5`
- `WithRestartWindow(d)` — default `1m`

### Behavior preserved
- The **config-update failure** path (historical "Bug B") still escalates to `Error` immediately — an operator who just pushed a bad config should see it.
- Pairs with **#141**: if a crash loop (or a bad config update) does escalate to `Error`, #141 lets a subsequent valid config update recover the cluster. The two PRs touch different functions and don't conflict.

## Tests (TDD)
New `restart_test.go`: auto-restart keeps the cluster Running; siblings survive a crash; a crash loop escalates to `Error`. The historical "Bug A" test is rewritten to assert isolation+restart instead of whole-cluster `Error`. Verified under `go test -race` and `-count=10`.

## Note on scope
This is a feature (not just a bug fix) and is the largest PR of the audit series. Happy to split the escalation/backoff knobs out if you'd prefer a smaller first cut.

https://claude.ai/code/session_01M2nd9n1KAjj41j2VzrZ7WE

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2nd9n1KAjj41j2VzrZ7WE)_